### PR TITLE
feat(canvas): ReactFlow DFD diagramming canvas

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,0 +1,5 @@
+import { AppLayout } from "./components/layout/app-layout";
+
+export function App() {
+	return <AppLayout />;
+}

--- a/src/components/canvas/canvas.tsx
+++ b/src/components/canvas/canvas.tsx
@@ -1,6 +1,7 @@
 import { Shield } from "lucide-react";
 import { useModelStore } from "@/stores/model-store";
 import type { ThreatModel } from "@/types/threat-model";
+import { DfdCanvas } from "./dfd-canvas";
 
 export function Canvas() {
 	const model = useModelStore((s) => s.model);
@@ -9,13 +10,7 @@ export function Canvas() {
 		return <EmptyCanvas />;
 	}
 
-	return (
-		<div className="flex h-full items-center justify-center bg-background">
-			<p className="text-sm text-muted-foreground">
-				ReactFlow canvas will be integrated in the next sprint.
-			</p>
-		</div>
-	);
+	return <DfdCanvas />;
 }
 
 function createEmptyModel(): ThreatModel {

--- a/src/components/canvas/dfd-canvas.tsx
+++ b/src/components/canvas/dfd-canvas.tsx
@@ -1,0 +1,150 @@
+import {
+	Background,
+	BackgroundVariant,
+	type Connection,
+	Controls,
+	MiniMap,
+	ReactFlow,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import { useCallback, useEffect } from "react";
+import type { DfdEdge, DfdNode } from "@/stores/canvas-store";
+import { useCanvasStore } from "@/stores/canvas-store";
+import { useModelStore } from "@/stores/model-store";
+import type { ElementType } from "@/types/threat-model";
+import { DataFlowEdge } from "./edges/data-flow-edge";
+import { DataStoreNode } from "./nodes/data-store-node";
+import { ExternalEntityNode } from "./nodes/external-entity-node";
+import { ProcessNode } from "./nodes/process-node";
+import { TrustBoundaryNode } from "./nodes/trust-boundary-node";
+
+const nodeTypes = {
+	process: ProcessNode,
+	dataStore: DataStoreNode,
+	externalEntity: ExternalEntityNode,
+	trustBoundary: TrustBoundaryNode,
+};
+
+const edgeTypes = {
+	dataFlow: DataFlowEdge,
+};
+
+const defaultEdgeOptions = {
+	type: "dataFlow",
+	markerEnd: {
+		type: "arrowclosed" as const,
+		width: 16,
+		height: 16,
+	},
+};
+
+export function DfdCanvas() {
+	const nodes = useCanvasStore((s) => s.nodes);
+	const edges = useCanvasStore((s) => s.edges);
+	const onNodesChange = useCanvasStore((s) => s.onNodesChange);
+	const onEdgesChange = useCanvasStore((s) => s.onEdgesChange);
+	const setViewport = useCanvasStore((s) => s.setViewport);
+	const addElement = useCanvasStore((s) => s.addElement);
+	const addDataFlow = useCanvasStore((s) => s.addDataFlow);
+	const addTrustBoundary = useCanvasStore((s) => s.addTrustBoundary);
+	const deleteSelected = useCanvasStore((s) => s.deleteSelected);
+	const syncFromModel = useCanvasStore((s) => s.syncFromModel);
+	const model = useModelStore((s) => s.model);
+
+	// Sync canvas from model when it changes (new model loaded, file opened).
+	// `model` is intentionally in deps — syncFromModel reads from model-store internally,
+	// but we need the effect to re-run when the model reference changes.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: model triggers re-sync
+	useEffect(() => {
+		syncFromModel();
+	}, [syncFromModel, model]);
+
+	const onConnect = useCallback(
+		(connection: Connection) => {
+			if (connection.source && connection.target) {
+				addDataFlow(connection.source, connection.target);
+			}
+		},
+		[addDataFlow],
+	);
+
+	const onDragOver = useCallback((event: React.DragEvent) => {
+		event.preventDefault();
+		event.dataTransfer.dropEffect = "copy";
+	}, []);
+
+	const onDrop = useCallback(
+		(event: React.DragEvent) => {
+			event.preventDefault();
+
+			const rawData = event.dataTransfer.getData("application/threatforge-element");
+			if (!rawData) return;
+
+			try {
+				const parsed = JSON.parse(rawData) as { type: string };
+
+				// Get canvas-relative position
+				const reactFlowBounds = event.currentTarget.getBoundingClientRect();
+				const position = {
+					x: event.clientX - reactFlowBounds.left,
+					y: event.clientY - reactFlowBounds.top,
+				};
+
+				if (parsed.type === "trust_boundary") {
+					addTrustBoundary("New Boundary", position);
+				} else {
+					addElement(parsed.type as ElementType, position);
+				}
+			} catch {
+				// Ignore invalid drag data
+			}
+		},
+		[addElement, addTrustBoundary],
+	);
+
+	const onKeyDown = useCallback(
+		(event: React.KeyboardEvent) => {
+			if (event.key === "Delete" || event.key === "Backspace") {
+				deleteSelected();
+			}
+		},
+		[deleteSelected],
+	);
+
+	const onPaneClick = useCallback(() => {
+		useModelStore.getState().setSelectedElement(null);
+	}, []);
+
+	return (
+		<div className="h-full w-full" onKeyDown={onKeyDown}>
+			<ReactFlow<DfdNode, DfdEdge>
+				nodes={nodes}
+				edges={edges}
+				onNodesChange={onNodesChange}
+				onEdgesChange={onEdgesChange}
+				onConnect={onConnect}
+				onMoveEnd={(_event, viewport) => setViewport(viewport)}
+				onDragOver={onDragOver}
+				onDrop={onDrop}
+				onPaneClick={onPaneClick}
+				nodeTypes={nodeTypes}
+				edgeTypes={edgeTypes}
+				defaultEdgeOptions={defaultEdgeOptions}
+				fitView
+				snapToGrid
+				snapGrid={[16, 16]}
+				deleteKeyCode={null}
+				className="bg-background"
+				proOptions={{ hideAttribution: true }}
+			>
+				<Background variant={BackgroundVariant.Dots} gap={16} size={1} color="oklch(0.35 0 0)" />
+				<Controls className="!bg-card !border-border !shadow-md [&>button]:!bg-card [&>button]:!border-border [&>button]:!text-foreground [&>button:hover]:!bg-accent" />
+				<MiniMap
+					className="!bg-card !border-border"
+					nodeColor="oklch(0.4 0 0)"
+					maskColor="oklch(0.1 0 0 / 0.7)"
+				/>
+			</ReactFlow>
+		</div>
+	);
+}

--- a/src/components/canvas/edges/data-flow-edge.tsx
+++ b/src/components/canvas/edges/data-flow-edge.tsx
@@ -1,0 +1,56 @@
+import { BaseEdge, EdgeLabelRenderer, type EdgeProps, getBezierPath } from "@xyflow/react";
+import { cn } from "@/lib/utils";
+import type { DfdEdgeData } from "@/stores/canvas-store";
+
+export function DataFlowEdge({
+	id,
+	sourceX,
+	sourceY,
+	targetX,
+	targetY,
+	sourcePosition,
+	targetPosition,
+	data,
+	selected,
+	markerEnd,
+}: EdgeProps) {
+	const edgeData = data as DfdEdgeData | undefined;
+	const [edgePath, labelX, labelY] = getBezierPath({
+		sourceX,
+		sourceY,
+		sourcePosition,
+		targetX,
+		targetY,
+		targetPosition,
+	});
+
+	const hasLabel = edgeData?.protocol || (edgeData?.data && edgeData.data.length > 0);
+
+	return (
+		<>
+			<BaseEdge
+				id={id}
+				path={edgePath}
+				markerEnd={markerEnd}
+				className={cn("!stroke-2", selected ? "!stroke-tf-signal" : "!stroke-muted-foreground/50")}
+			/>
+			{hasLabel && (
+				<EdgeLabelRenderer>
+					<div
+						className={cn(
+							"pointer-events-all nodrag nopan absolute rounded border bg-card px-1.5 py-0.5 text-[10px]",
+							selected ? "border-tf-signal text-foreground" : "border-border text-muted-foreground",
+						)}
+						style={{
+							transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+						}}
+					>
+						{edgeData?.protocol && <span>{edgeData.protocol}</span>}
+						{edgeData?.protocol && edgeData?.data && edgeData.data.length > 0 && <span> · </span>}
+						{edgeData?.data && edgeData.data.length > 0 && <span>{edgeData.data.join(", ")}</span>}
+					</div>
+				</EdgeLabelRenderer>
+			)}
+		</>
+	);
+}

--- a/src/components/canvas/nodes/data-store-node.tsx
+++ b/src/components/canvas/nodes/data-store-node.tsx
@@ -1,0 +1,27 @@
+import { Handle, Position } from "@xyflow/react";
+import { cn } from "@/lib/utils";
+import type { DfdNodeData } from "@/stores/canvas-store";
+
+export function DataStoreNode({ data, selected }: { data: DfdNodeData; selected?: boolean }) {
+	return (
+		<div
+			className={cn(
+				"flex min-w-[140px] items-center justify-center border-y-2 bg-card px-4 py-3 shadow-md transition-colors",
+				selected ? "border-tf-signal shadow-tf-signal/20" : "border-border",
+			)}
+		>
+			<Handle type="target" position={Position.Top} className="!bg-muted-foreground !w-2 !h-2" />
+			<Handle type="target" position={Position.Left} className="!bg-muted-foreground !w-2 !h-2" />
+
+			<div className="text-center">
+				<div className="text-sm font-medium text-foreground">{data.label}</div>
+				{data.trustZone && (
+					<div className="mt-0.5 text-[10px] text-muted-foreground">{data.trustZone}</div>
+				)}
+			</div>
+
+			<Handle type="source" position={Position.Bottom} className="!bg-muted-foreground !w-2 !h-2" />
+			<Handle type="source" position={Position.Right} className="!bg-muted-foreground !w-2 !h-2" />
+		</div>
+	);
+}

--- a/src/components/canvas/nodes/external-entity-node.tsx
+++ b/src/components/canvas/nodes/external-entity-node.tsx
@@ -1,0 +1,27 @@
+import { Handle, Position } from "@xyflow/react";
+import { cn } from "@/lib/utils";
+import type { DfdNodeData } from "@/stores/canvas-store";
+
+export function ExternalEntityNode({ data, selected }: { data: DfdNodeData; selected?: boolean }) {
+	return (
+		<div
+			className={cn(
+				"flex min-w-[140px] items-center justify-center border-2 bg-card px-4 py-3 shadow-md transition-colors",
+				selected ? "border-tf-signal shadow-tf-signal/20" : "border-border",
+			)}
+		>
+			<Handle type="target" position={Position.Top} className="!bg-muted-foreground !w-2 !h-2" />
+			<Handle type="target" position={Position.Left} className="!bg-muted-foreground !w-2 !h-2" />
+
+			<div className="text-center">
+				<div className="text-sm font-medium text-foreground">{data.label}</div>
+				{data.trustZone && (
+					<div className="mt-0.5 text-[10px] text-muted-foreground">{data.trustZone}</div>
+				)}
+			</div>
+
+			<Handle type="source" position={Position.Bottom} className="!bg-muted-foreground !w-2 !h-2" />
+			<Handle type="source" position={Position.Right} className="!bg-muted-foreground !w-2 !h-2" />
+		</div>
+	);
+}

--- a/src/components/canvas/nodes/process-node.tsx
+++ b/src/components/canvas/nodes/process-node.tsx
@@ -1,0 +1,27 @@
+import { Handle, Position } from "@xyflow/react";
+import { cn } from "@/lib/utils";
+import type { DfdNodeData } from "@/stores/canvas-store";
+
+export function ProcessNode({ data, selected }: { data: DfdNodeData; selected?: boolean }) {
+	return (
+		<div
+			className={cn(
+				"flex min-w-[140px] items-center justify-center rounded-2xl border-2 bg-card px-4 py-3 shadow-md transition-colors",
+				selected ? "border-tf-signal shadow-tf-signal/20" : "border-border",
+			)}
+		>
+			<Handle type="target" position={Position.Top} className="!bg-muted-foreground !w-2 !h-2" />
+			<Handle type="target" position={Position.Left} className="!bg-muted-foreground !w-2 !h-2" />
+
+			<div className="text-center">
+				<div className="text-sm font-medium text-foreground">{data.label}</div>
+				{data.trustZone && (
+					<div className="mt-0.5 text-[10px] text-muted-foreground">{data.trustZone}</div>
+				)}
+			</div>
+
+			<Handle type="source" position={Position.Bottom} className="!bg-muted-foreground !w-2 !h-2" />
+			<Handle type="source" position={Position.Right} className="!bg-muted-foreground !w-2 !h-2" />
+		</div>
+	);
+}

--- a/src/components/canvas/nodes/trust-boundary-node.tsx
+++ b/src/components/canvas/nodes/trust-boundary-node.tsx
@@ -1,0 +1,17 @@
+import { cn } from "@/lib/utils";
+import type { DfdNodeData } from "@/stores/canvas-store";
+
+export function TrustBoundaryNode({ data, selected }: { data: DfdNodeData; selected?: boolean }) {
+	return (
+		<div
+			className={cn(
+				"h-full w-full rounded-lg border-2 border-dashed p-2 transition-colors",
+				selected ? "border-tf-ember/60 bg-tf-ember/5" : "border-muted-foreground/30 bg-muted/5",
+			)}
+		>
+			<div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+				{data.boundaryName ?? data.label}
+			</div>
+		</div>
+	);
+}

--- a/src/components/layout/app-layout.tsx
+++ b/src/components/layout/app-layout.tsx
@@ -1,3 +1,4 @@
+import { ReactFlowProvider } from "@xyflow/react";
 import { useUiStore } from "@/stores/ui-store";
 import { Canvas } from "../canvas/canvas";
 import { ComponentPalette } from "../palette/component-palette";
@@ -10,31 +11,33 @@ export function AppLayout() {
 	const rightPanelOpen = useUiStore((s) => s.rightPanelOpen);
 
 	return (
-		<div className="flex h-full w-full flex-col bg-background text-foreground">
-			<TopMenuBar />
+		<ReactFlowProvider>
+			<div className="flex h-full w-full flex-col bg-background text-foreground">
+				<TopMenuBar />
 
-			<div className="flex flex-1 overflow-hidden">
-				{/* Left sidebar — Component palette */}
-				{leftPanelOpen && (
-					<aside className="w-56 shrink-0 border-r border-border bg-card">
-						<ComponentPalette />
-					</aside>
-				)}
+				<div className="flex flex-1 overflow-hidden">
+					{/* Left sidebar — Component palette */}
+					{leftPanelOpen && (
+						<aside className="w-56 shrink-0 border-r border-border bg-card">
+							<ComponentPalette />
+						</aside>
+					)}
 
-				{/* Main canvas area */}
-				<main className="flex-1 overflow-hidden">
-					<Canvas />
-				</main>
+					{/* Main canvas area */}
+					<main className="flex-1 overflow-hidden">
+						<Canvas />
+					</main>
 
-				{/* Right panel — Properties / Threats */}
-				{rightPanelOpen && (
-					<aside className="w-80 shrink-0 border-l border-border bg-card">
-						<RightPanel />
-					</aside>
-				)}
+					{/* Right panel — Properties / Threats */}
+					{rightPanelOpen && (
+						<aside className="w-80 shrink-0 border-l border-border bg-card">
+							<RightPanel />
+						</aside>
+					)}
+				</div>
+
+				<StatusBar />
 			</div>
-
-			<StatusBar />
-		</div>
+		</ReactFlowProvider>
 	);
 }

--- a/src/components/palette/component-palette.tsx
+++ b/src/components/palette/component-palette.tsx
@@ -1,23 +1,32 @@
-import { Box, Database, Globe } from "lucide-react";
+import { Box, Database, Globe, ShieldAlert } from "lucide-react";
 
 const DFD_ELEMENTS = [
 	{
-		type: "process" as const,
+		type: "process",
 		label: "Process",
 		icon: Box,
 		description: "A processing step or function",
 	},
 	{
-		type: "data_store" as const,
+		type: "data_store",
 		label: "Data Store",
 		icon: Database,
 		description: "A place where data is stored",
 	},
 	{
-		type: "external_entity" as const,
+		type: "external_entity",
 		label: "External Entity",
 		icon: Globe,
 		description: "An actor outside the system",
+	},
+] as const;
+
+const BOUNDARY_ELEMENTS = [
+	{
+		type: "trust_boundary",
+		label: "Trust Boundary",
+		icon: ShieldAlert,
+		description: "A security trust zone boundary",
 	},
 ] as const;
 
@@ -35,6 +44,7 @@ export function ComponentPalette() {
 					{DFD_ELEMENTS.map((element) => (
 						<PaletteItem
 							key={element.type}
+							type={element.type}
 							icon={element.icon}
 							label={element.label}
 							description={element.description}
@@ -46,9 +56,17 @@ export function ComponentPalette() {
 					<h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
 						Boundaries
 					</h3>
-					<p className="text-xs text-muted-foreground">
-						Trust boundaries will be added in the next sprint.
-					</p>
+					<div className="flex flex-col gap-1">
+						{BOUNDARY_ELEMENTS.map((element) => (
+							<PaletteItem
+								key={element.type}
+								type={element.type}
+								icon={element.icon}
+								label={element.label}
+								description={element.description}
+							/>
+						))}
+					</div>
 				</div>
 			</div>
 		</div>
@@ -58,10 +76,12 @@ export function ComponentPalette() {
 function PaletteItem({
 	icon: Icon,
 	label,
+	type,
 	description,
 }: {
 	icon: React.ComponentType<{ className?: string }>;
 	label: string;
+	type: string;
 	description: string;
 }) {
 	return (
@@ -69,10 +89,7 @@ function PaletteItem({
 			className="flex cursor-grab items-center gap-3 rounded-md border border-transparent px-2 py-2 transition-colors hover:border-border hover:bg-accent"
 			draggable
 			onDragStart={(e) => {
-				e.dataTransfer.setData(
-					"application/threatforge-element",
-					JSON.stringify({ type: label.toLowerCase().replace(" ", "_") }),
-				);
+				e.dataTransfer.setData("application/threatforge-element", JSON.stringify({ type }));
 				e.dataTransfer.effectAllowed = "copy";
 			}}
 		>

--- a/src/stores/canvas-store.test.ts
+++ b/src/stores/canvas-store.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { ThreatModel } from "@/types/threat-model";
+import { useCanvasStore } from "./canvas-store";
+import { useModelStore } from "./model-store";
+
+function createTestModel(): ThreatModel {
+	return {
+		version: "1.0",
+		metadata: {
+			title: "Test Model",
+			author: "Test",
+			created: "2026-01-01",
+			modified: "2026-01-01",
+			description: "",
+		},
+		elements: [
+			{
+				id: "process-1",
+				type: "process",
+				name: "Web App",
+				trust_zone: "internal",
+				description: "",
+				technologies: [],
+			},
+			{
+				id: "data-store-1",
+				type: "data_store",
+				name: "Database",
+				trust_zone: "internal",
+				description: "",
+				technologies: ["PostgreSQL"],
+			},
+		],
+		data_flows: [
+			{
+				id: "flow-1",
+				from: "process-1",
+				to: "data-store-1",
+				protocol: "PostgreSQL/TLS",
+				data: ["user_records"],
+				authenticated: true,
+			},
+		],
+		trust_boundaries: [
+			{
+				id: "boundary-1",
+				name: "Internal Network",
+				contains: ["process-1", "data-store-1"],
+			},
+		],
+		threats: [],
+		diagrams: [],
+	};
+}
+
+describe("canvas-store", () => {
+	beforeEach(() => {
+		useCanvasStore.setState({ nodes: [], edges: [], viewport: { x: 0, y: 0, zoom: 1 } });
+		useModelStore.setState({ model: null, filePath: null, isDirty: false });
+	});
+
+	it("syncs nodes and edges from model store", () => {
+		useModelStore.getState().setModel(createTestModel(), null);
+		useCanvasStore.getState().syncFromModel();
+
+		const { nodes, edges } = useCanvasStore.getState();
+
+		// 1 boundary + 2 elements = 3 nodes
+		expect(nodes).toHaveLength(3);
+		expect(edges).toHaveLength(1);
+
+		// Boundary node is first
+		expect(nodes[0].type).toBe("trustBoundary");
+		expect(nodes[0].data.boundaryName).toBe("Internal Network");
+
+		// Element nodes follow
+		const processNode = nodes.find((n) => n.id === "process-1");
+		expect(processNode).toBeDefined();
+		expect(processNode?.type).toBe("process");
+		expect(processNode?.data.label).toBe("Web App");
+
+		const dataStoreNode = nodes.find((n) => n.id === "data-store-1");
+		expect(dataStoreNode).toBeDefined();
+		expect(dataStoreNode?.type).toBe("dataStore");
+
+		// Edge maps flow correctly
+		expect(edges[0].id).toBe("flow-1");
+		expect(edges[0].source).toBe("process-1");
+		expect(edges[0].target).toBe("data-store-1");
+	});
+
+	it("clears nodes and edges when model is null", () => {
+		// First sync with a model
+		useModelStore.getState().setModel(createTestModel(), null);
+		useCanvasStore.getState().syncFromModel();
+		expect(useCanvasStore.getState().nodes).toHaveLength(3);
+
+		// Clear model
+		useModelStore.getState().clearModel();
+		useCanvasStore.getState().syncFromModel();
+
+		expect(useCanvasStore.getState().nodes).toHaveLength(0);
+		expect(useCanvasStore.getState().edges).toHaveLength(0);
+	});
+
+	it("adds a new element to canvas and model", () => {
+		useModelStore.getState().setModel(createTestModel(), null);
+		useCanvasStore.getState().syncFromModel();
+
+		useCanvasStore.getState().addElement("external_entity", { x: 200, y: 300 });
+
+		const { nodes } = useCanvasStore.getState();
+		const newNode = nodes.find((n) => n.type === "externalEntity");
+		expect(newNode).toBeDefined();
+		expect(newNode?.data.label).toBe("New External Entity");
+		expect(newNode?.position).toEqual({ x: 200, y: 300 });
+
+		// Model store should also have the new element
+		const model = useModelStore.getState().model;
+		expect(model?.elements).toHaveLength(3);
+		expect(model?.elements[2].type).toBe("external_entity");
+	});
+
+	it("adds a data flow between nodes", () => {
+		useModelStore.getState().setModel(createTestModel(), null);
+		useCanvasStore.getState().syncFromModel();
+
+		useCanvasStore.getState().addDataFlow("data-store-1", "process-1");
+
+		const { edges } = useCanvasStore.getState();
+		expect(edges).toHaveLength(2);
+
+		const newEdge = edges.find((e) => e.source === "data-store-1" && e.target === "process-1");
+		expect(newEdge).toBeDefined();
+
+		// Model store should also have the new flow
+		const model = useModelStore.getState().model;
+		expect(model?.data_flows).toHaveLength(2);
+	});
+
+	it("adds a trust boundary", () => {
+		useModelStore.getState().setModel(createTestModel(), null);
+		useCanvasStore.getState().syncFromModel();
+
+		useCanvasStore.getState().addTrustBoundary("DMZ", { x: 50, y: 50 });
+
+		const { nodes } = useCanvasStore.getState();
+		const boundaries = nodes.filter((n) => n.type === "trustBoundary");
+		expect(boundaries).toHaveLength(2);
+
+		const newBoundary = boundaries.find((n) => n.data.boundaryName === "DMZ");
+		expect(newBoundary).toBeDefined();
+
+		// Model store should have the new boundary
+		const model = useModelStore.getState().model;
+		expect(model?.trust_boundaries).toHaveLength(2);
+	});
+
+	it("assigns child elements to boundary parents on sync", () => {
+		useModelStore.getState().setModel(createTestModel(), null);
+		useCanvasStore.getState().syncFromModel();
+
+		const processNode = useCanvasStore.getState().nodes.find((n) => n.id === "process-1");
+		expect(processNode?.parentId).toBe("boundary-1");
+		expect(processNode?.extent).toBe("parent");
+
+		const dataStoreNode = useCanvasStore.getState().nodes.find((n) => n.id === "data-store-1");
+		expect(dataStoreNode?.parentId).toBe("boundary-1");
+	});
+
+	it("marks model dirty when adding elements", () => {
+		useModelStore.getState().setModel(createTestModel(), null);
+		useModelStore.getState().markClean();
+		useCanvasStore.getState().syncFromModel();
+
+		useCanvasStore.getState().addElement("process", { x: 0, y: 0 });
+
+		expect(useModelStore.getState().isDirty).toBe(true);
+	});
+
+	it("resets ID counters from existing model on sync", () => {
+		useModelStore.getState().setModel(createTestModel(), null);
+		useCanvasStore.getState().syncFromModel();
+
+		// Adding a new element should get ID "process-2" (since process-1 exists)
+		useCanvasStore.getState().addElement("process", { x: 0, y: 0 });
+		const model = useModelStore.getState().model;
+		const newElement = model?.elements[model.elements.length - 1];
+		expect(newElement?.id).toBe("process-2");
+	});
+});

--- a/src/stores/canvas-store.ts
+++ b/src/stores/canvas-store.ts
@@ -1,0 +1,405 @@
+import type { Edge, Node, OnEdgesChange, OnNodesChange, Viewport } from "@xyflow/react";
+import { applyEdgeChanges, applyNodeChanges } from "@xyflow/react";
+import { create } from "zustand";
+import type { DataFlow, Element, ElementType, TrustBoundary } from "@/types/threat-model";
+import { useModelStore } from "./model-store";
+
+/** ReactFlow node data payload for DFD elements.
+ *  Uses `type` + index signature to satisfy ReactFlow's `Record<string, unknown>` constraint. */
+export type DfdNodeData = {
+	[key: string]: unknown;
+	label: string;
+	elementType: ElementType;
+	trustZone: string;
+	description: string;
+	technologies: string[];
+	/** For trust boundary group nodes */
+	isBoundary?: boolean;
+	boundaryName?: string;
+};
+
+/** ReactFlow edge data payload for data flows.
+ *  Uses `type` + index signature to satisfy ReactFlow's `Record<string, unknown>` constraint. */
+export type DfdEdgeData = {
+	[key: string]: unknown;
+	protocol: string;
+	data: string[];
+	authenticated: boolean;
+};
+
+export type DfdNode = Node<DfdNodeData>;
+export type DfdEdge = Edge<DfdEdgeData>;
+
+interface CanvasState {
+	nodes: DfdNode[];
+	edges: DfdEdge[];
+	viewport: Viewport;
+
+	// ReactFlow change handlers
+	onNodesChange: OnNodesChange<DfdNode>;
+	onEdgesChange: OnEdgesChange<DfdEdge>;
+	setViewport: (viewport: Viewport) => void;
+
+	// Canvas actions
+	addElement: (type: ElementType, position: { x: number; y: number }) => void;
+	addDataFlow: (sourceId: string, targetId: string) => void;
+	addTrustBoundary: (name: string, position: { x: number; y: number }) => void;
+	deleteSelected: () => void;
+
+	// Sync from model store
+	syncFromModel: () => void;
+}
+
+let elementCounter = 0;
+let flowCounter = 0;
+let boundaryCounter = 0;
+
+function generateElementId(type: ElementType): string {
+	elementCounter++;
+	const prefix =
+		type === "data_store" ? "data-store" : type === "external_entity" ? "external" : "process";
+	return `${prefix}-${elementCounter}`;
+}
+
+function generateFlowId(): string {
+	flowCounter++;
+	return `flow-${flowCounter}`;
+}
+
+function generateBoundaryId(): string {
+	boundaryCounter++;
+	return `boundary-${boundaryCounter}`;
+}
+
+function elementTypeToNodeType(type: ElementType): string {
+	switch (type) {
+		case "process":
+			return "process";
+		case "data_store":
+			return "dataStore";
+		case "external_entity":
+			return "externalEntity";
+	}
+}
+
+function elementToNode(element: Element, position: { x: number; y: number }): DfdNode {
+	return {
+		id: element.id,
+		type: elementTypeToNodeType(element.type),
+		position,
+		data: {
+			label: element.name,
+			elementType: element.type,
+			trustZone: element.trust_zone,
+			description: element.description,
+			technologies: element.technologies,
+		},
+	};
+}
+
+function boundaryToNode(boundary: TrustBoundary, position: { x: number; y: number }): DfdNode {
+	return {
+		id: boundary.id,
+		type: "trustBoundary",
+		position,
+		style: { width: 400, height: 300 },
+		data: {
+			label: boundary.name,
+			elementType: "process", // unused for boundaries
+			trustZone: "",
+			description: "",
+			technologies: [],
+			isBoundary: true,
+			boundaryName: boundary.name,
+		},
+	};
+}
+
+function flowToEdge(flow: DataFlow): DfdEdge {
+	return {
+		id: flow.id,
+		source: flow.from,
+		target: flow.to,
+		type: "dataFlow",
+		animated: flow.authenticated,
+		data: {
+			protocol: flow.protocol,
+			data: flow.data,
+			authenticated: flow.authenticated,
+		},
+	};
+}
+
+function defaultElementName(type: ElementType): string {
+	switch (type) {
+		case "process":
+			return "New Process";
+		case "data_store":
+			return "New Data Store";
+		case "external_entity":
+			return "New External Entity";
+	}
+}
+
+export const useCanvasStore = create<CanvasState>((set, get) => ({
+	nodes: [],
+	edges: [],
+	viewport: { x: 0, y: 0, zoom: 1 },
+
+	onNodesChange: (changes) => {
+		set({ nodes: applyNodeChanges(changes, get().nodes) as DfdNode[] });
+
+		// Propagate position changes to keep model aware of dirty state
+		const hasPositionChange = changes.some((c) => c.type === "position" && c.dragging === false);
+		if (hasPositionChange) {
+			useModelStore.getState().markDirty();
+		}
+
+		// Handle selection changes
+		const selectionChange = changes.find((c) => c.type === "select" && c.selected);
+		if (selectionChange && selectionChange.type === "select") {
+			const node = get().nodes.find((n) => n.id === selectionChange.id);
+			if (node && !node.data.isBoundary) {
+				useModelStore.getState().setSelectedElement(selectionChange.id);
+			}
+		}
+
+		// Handle deselection
+		const deselection = changes.find((c) => c.type === "select" && !c.selected);
+		if (deselection && !changes.some((c) => c.type === "select" && c.selected)) {
+			useModelStore.getState().setSelectedElement(null);
+		}
+	},
+
+	onEdgesChange: (changes) => {
+		const prevEdges = get().edges;
+		const nextEdges = applyEdgeChanges(changes, prevEdges) as DfdEdge[];
+		set({ edges: nextEdges });
+
+		// Handle edge removal — remove from model store
+		const removals = changes.filter(
+			(c): c is Extract<typeof c, { type: "remove" }> => c.type === "remove",
+		);
+		if (removals.length > 0) {
+			const model = useModelStore.getState().model;
+			if (model) {
+				const removedIds = new Set(removals.map((r) => r.id));
+				const updatedFlows = model.data_flows.filter((f) => !removedIds.has(f.id));
+				useModelStore
+					.getState()
+					.setModel({ ...model, data_flows: updatedFlows }, useModelStore.getState().filePath);
+				useModelStore.getState().markDirty();
+			}
+		}
+	},
+
+	setViewport: (viewport) => set({ viewport }),
+
+	addElement: (type, position) => {
+		const id = generateElementId(type);
+		const name = defaultElementName(type);
+
+		const newElement: Element = {
+			id,
+			type,
+			name,
+			trust_zone: "",
+			description: "",
+			technologies: [],
+		};
+
+		const newNode = elementToNode(newElement, position);
+
+		// Update canvas
+		set({ nodes: [...get().nodes, newNode] });
+
+		// Update model store
+		const model = useModelStore.getState().model;
+		if (model) {
+			useModelStore
+				.getState()
+				.setModel(
+					{ ...model, elements: [...model.elements, newElement] },
+					useModelStore.getState().filePath,
+				);
+			useModelStore.getState().markDirty();
+		}
+
+		// Select the new element
+		useModelStore.getState().setSelectedElement(id);
+	},
+
+	addDataFlow: (sourceId, targetId) => {
+		const id = generateFlowId();
+		const newFlow: DataFlow = {
+			id,
+			from: sourceId,
+			to: targetId,
+			protocol: "",
+			data: [],
+			authenticated: false,
+		};
+
+		const newEdge = flowToEdge(newFlow);
+		set({ edges: [...get().edges, newEdge] });
+
+		// Update model store
+		const model = useModelStore.getState().model;
+		if (model) {
+			useModelStore
+				.getState()
+				.setModel(
+					{ ...model, data_flows: [...model.data_flows, newFlow] },
+					useModelStore.getState().filePath,
+				);
+			useModelStore.getState().markDirty();
+		}
+	},
+
+	addTrustBoundary: (name, position) => {
+		const id = generateBoundaryId();
+		const newBoundary: TrustBoundary = {
+			id,
+			name,
+			contains: [],
+		};
+
+		const newNode = boundaryToNode(newBoundary, position);
+		// Insert boundaries at the beginning so they render behind other nodes
+		set({ nodes: [newNode, ...get().nodes] });
+
+		// Update model store
+		const model = useModelStore.getState().model;
+		if (model) {
+			useModelStore.getState().setModel(
+				{
+					...model,
+					trust_boundaries: [...model.trust_boundaries, newBoundary],
+				},
+				useModelStore.getState().filePath,
+			);
+			useModelStore.getState().markDirty();
+		}
+	},
+
+	deleteSelected: () => {
+		const selectedNodes = get().nodes.filter((n) => n.selected);
+		const selectedEdges = get().edges.filter((e) => e.selected);
+
+		if (selectedNodes.length === 0 && selectedEdges.length === 0) return;
+
+		const selectedNodeIds = new Set(selectedNodes.map((n) => n.id));
+		const selectedEdgeIds = new Set(selectedEdges.map((e) => e.id));
+
+		// Remove nodes and any edges connected to removed nodes
+		const nextNodes = get().nodes.filter((n) => !selectedNodeIds.has(n.id));
+		const nextEdges = get().edges.filter(
+			(e) =>
+				!selectedEdgeIds.has(e.id) &&
+				!selectedNodeIds.has(e.source) &&
+				!selectedNodeIds.has(e.target),
+		);
+
+		set({ nodes: nextNodes, edges: nextEdges });
+
+		// Update model store
+		const model = useModelStore.getState().model;
+		if (model) {
+			const removedEdgeIds = new Set([
+				...selectedEdgeIds,
+				...get()
+					.edges.filter((e) => selectedNodeIds.has(e.source) || selectedNodeIds.has(e.target))
+					.map((e) => e.id),
+			]);
+
+			useModelStore.getState().setModel(
+				{
+					...model,
+					elements: model.elements.filter((e) => !selectedNodeIds.has(e.id)),
+					data_flows: model.data_flows.filter((f) => !removedEdgeIds.has(f.id)),
+					trust_boundaries: model.trust_boundaries.filter((b) => !selectedNodeIds.has(b.id)),
+					// Remove references to deleted elements from remaining boundaries
+					...(selectedNodeIds.size > 0
+						? {
+								trust_boundaries: model.trust_boundaries
+									.filter((b) => !selectedNodeIds.has(b.id))
+									.map((b) => ({
+										...b,
+										contains: b.contains.filter((c) => !selectedNodeIds.has(c)),
+									})),
+							}
+						: {}),
+				},
+				useModelStore.getState().filePath,
+			);
+			useModelStore.getState().markDirty();
+			useModelStore.getState().setSelectedElement(null);
+		}
+	},
+
+	syncFromModel: () => {
+		const model = useModelStore.getState().model;
+		if (!model) {
+			set({ nodes: [], edges: [] });
+			return;
+		}
+
+		// Reset counters based on existing IDs
+		const maxElementNum = model.elements.reduce((max, e) => {
+			const match = e.id.match(/-(\d+)$/);
+			return match ? Math.max(max, Number.parseInt(match[1], 10)) : max;
+		}, 0);
+		const maxFlowNum = model.data_flows.reduce((max, f) => {
+			const match = f.id.match(/-(\d+)$/);
+			return match ? Math.max(max, Number.parseInt(match[1], 10)) : max;
+		}, 0);
+		const maxBoundaryNum = model.trust_boundaries.reduce((max, b) => {
+			const match = b.id.match(/-(\d+)$/);
+			return match ? Math.max(max, Number.parseInt(match[1], 10)) : max;
+		}, 0);
+		elementCounter = maxElementNum;
+		flowCounter = maxFlowNum;
+		boundaryCounter = maxBoundaryNum;
+
+		// Keep existing positions for nodes that still exist
+		const existingPositions = new Map(get().nodes.map((n) => [n.id, n.position]));
+
+		// Convert trust boundaries to group nodes
+		const boundaryNodes: DfdNode[] = model.trust_boundaries.map((b, i) => {
+			const pos = existingPositions.get(b.id) ?? { x: 50 + i * 450, y: 50 };
+			return boundaryToNode(b, pos);
+		});
+
+		// Build a set of elements that belong to boundaries
+		const elementToBoundary = new Map<string, string>();
+		for (const b of model.trust_boundaries) {
+			for (const elementId of b.contains) {
+				elementToBoundary.set(elementId, b.id);
+			}
+		}
+
+		// Convert elements to nodes
+		const elementNodes: DfdNode[] = model.elements.map((e, i) => {
+			const pos = existingPositions.get(e.id) ?? {
+				x: 100 + (i % 4) * 250,
+				y: 100 + Math.floor(i / 4) * 200,
+			};
+			const node = elementToNode(e, pos);
+
+			// Parent to boundary if contained
+			const parentBoundary = elementToBoundary.get(e.id);
+			if (parentBoundary) {
+				node.parentId = parentBoundary;
+				node.extent = "parent";
+			}
+
+			return node;
+		});
+
+		// Convert flows to edges
+		const edges: DfdEdge[] = model.data_flows.map(flowToEdge);
+
+		// Boundaries first (rendered behind), then elements
+		set({ nodes: [...boundaryNodes, ...elementNodes], edges });
+	},
+}));


### PR DESCRIPTION
## Summary

- Integrate ReactFlow as the DFD diagramming engine with custom node types (Process, Data Store, External Entity, Trust Boundary) and a custom labeled edge type (DataFlow)
- Add `canvas-store` with bidirectional sync between ReactFlow state and the model store — drag-drop from palette, keyboard delete, selection syncs to right panel
- Update component palette with trust boundary drag item and fix drag data to use type field directly

## Details

**New files (9):**
- `src/stores/canvas-store.ts` — ReactFlow state management, element/flow/boundary CRUD, model sync
- `src/components/canvas/dfd-canvas.tsx` — Full ReactFlow canvas with background, minimap, controls
- `src/components/canvas/nodes/` — 4 custom DFD node components
- `src/components/canvas/edges/data-flow-edge.tsx` — Labeled bezier edge with protocol/data display
- `src/stores/canvas-store.test.ts` — 8 tests for canvas store
- `src/app.tsx` — App root (was missing from prior merge)

**Modified files (4):**
- `canvas.tsx` — Renders `DfdCanvas` instead of placeholder
- `app-layout.tsx` — Wrapped with `ReactFlowProvider`
- `component-palette.tsx` — Trust boundary item, fixed drag data
- `docs/todo.md` — Session 2 plan completed

**Validation:**
- `npx biome check .` — 31 files, 0 errors
- `npx tsc --noEmit` — clean
- `npx vitest --run` — 19 tests passing (11 existing + 8 new)
- `cargo test` — 13 tests passing

## Test plan

- [ ] `npm run dev` launches app with ReactFlow canvas visible after clicking "New Model"
- [ ] Drag Process, Data Store, External Entity from palette onto canvas
- [ ] Drag Trust Boundary from palette onto canvas (renders as dashed border group)
- [ ] Connect two nodes by dragging from handle to handle (creates data flow edge)
- [ ] Select a node — right panel shows element properties
- [ ] Click canvas background — deselects element
- [ ] Press Delete/Backspace — removes selected nodes and connected edges
- [ ] Minimap and zoom controls visible and functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)