### PR TITLE
feat(stride): STRIDE threat engine + threat management UI

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,3 +1,5 @@
 mod file_commands;
+mod stride_commands;
 
 pub use file_commands::*;
+pub use stride_commands::*;

--- a/src-tauri/src/commands/stride_commands.rs
+++ b/src-tauri/src/commands/stride_commands.rs
@@ -1,0 +1,7 @@
+use crate::models::{Threat, ThreatModel};
+use crate::stride;
+
+#[tauri::command]
+pub fn analyze_stride(model: ThreatModel) -> Result<Vec<Threat>, String> {
+    Ok(stride::analyze(&model))
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,7 +5,8 @@ mod models;
 mod stride;
 
 use commands::{
-    create_new_model, open_layout, open_threat_model, save_layout, save_threat_model,
+    analyze_stride, create_new_model, open_layout, open_threat_model, save_layout,
+    save_threat_model,
 };
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -18,6 +19,7 @@ pub fn run() {
             save_threat_model,
             open_layout,
             save_layout,
+            analyze_stride,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/stride/mod.rs
+++ b/src-tauri/src/stride/mod.rs
@@ -1,2 +1,499 @@
-// STRIDE threat engine — will be implemented in Sprint 3
-// Placeholder module for the Rust module structure
+use std::collections::HashSet;
+
+use crate::models::{
+    ElementType, Severity, StrideCategory, Threat, ThreatModel, TrustBoundary, generate_threat_id,
+};
+
+/// A rule template for generating STRIDE threats.
+struct ThreatRule {
+    category: StrideCategory,
+    /// Which element types this rule applies to. Empty = applies to data flows.
+    applicable_elements: Vec<ElementType>,
+    /// Whether this rule targets data flows instead of elements.
+    targets_flows: bool,
+    title_template: &'static str,
+    description_template: &'static str,
+    severity: Severity,
+}
+
+/// Build the hardcoded set of STRIDE threat rules.
+///
+/// Rules are derived from Microsoft's STRIDE-per-element methodology:
+/// - Process: Spoofing, Tampering, Repudiation, Information Disclosure, DoS, EoP
+/// - Data Store: Tampering, Information Disclosure, Denial of Service
+/// - External Entity: Spoofing, Repudiation
+/// - Data Flow: Tampering, Information Disclosure, Denial of Service
+fn build_rules() -> Vec<ThreatRule> {
+    vec![
+        // ── Process threats ──────────────────────────────────────────
+        ThreatRule {
+            category: StrideCategory::Spoofing,
+            applicable_elements: vec![ElementType::Process],
+            targets_flows: false,
+            title_template: "Spoofing of {name}",
+            description_template: "An attacker may impersonate {name} to gain unauthorized access. Ensure authentication mechanisms verify the identity of callers.",
+            severity: Severity::High,
+        },
+        ThreatRule {
+            category: StrideCategory::Tampering,
+            applicable_elements: vec![ElementType::Process],
+            targets_flows: false,
+            title_template: "Tampering with {name}",
+            description_template: "An attacker may modify the behavior or inputs of {name}. Validate all inputs and ensure integrity checks are in place.",
+            severity: Severity::High,
+        },
+        ThreatRule {
+            category: StrideCategory::Repudiation,
+            applicable_elements: vec![ElementType::Process],
+            targets_flows: false,
+            title_template: "Repudiation threat for {name}",
+            description_template: "{name} may perform actions without adequate logging. Implement audit logging to ensure all operations are traceable.",
+            severity: Severity::Medium,
+        },
+        ThreatRule {
+            category: StrideCategory::InformationDisclosure,
+            applicable_elements: vec![ElementType::Process],
+            targets_flows: false,
+            title_template: "Information disclosure from {name}",
+            description_template: "{name} may leak sensitive information through error messages, logs, or side channels. Review outputs for data exposure.",
+            severity: Severity::Medium,
+        },
+        ThreatRule {
+            category: StrideCategory::DenialOfService,
+            applicable_elements: vec![ElementType::Process],
+            targets_flows: false,
+            title_template: "Denial of service on {name}",
+            description_template: "An attacker may overwhelm {name} with excessive requests or malformed inputs. Implement rate limiting and input validation.",
+            severity: Severity::Medium,
+        },
+        ThreatRule {
+            category: StrideCategory::ElevationOfPrivilege,
+            applicable_elements: vec![ElementType::Process],
+            targets_flows: false,
+            title_template: "Elevation of privilege via {name}",
+            description_template: "An attacker may exploit {name} to gain unauthorized privileges. Apply least-privilege principles and validate authorization.",
+            severity: Severity::High,
+        },
+
+        // ── Data Store threats ───────────────────────────────────────
+        ThreatRule {
+            category: StrideCategory::Tampering,
+            applicable_elements: vec![ElementType::DataStore],
+            targets_flows: false,
+            title_template: "Tampering with data in {name}",
+            description_template: "An attacker may modify data in {name}. Use access controls, integrity constraints, and audit trails to detect unauthorized changes.",
+            severity: Severity::High,
+        },
+        ThreatRule {
+            category: StrideCategory::InformationDisclosure,
+            applicable_elements: vec![ElementType::DataStore],
+            targets_flows: false,
+            title_template: "Information disclosure from {name}",
+            description_template: "Sensitive data stored in {name} may be exposed to unauthorized users. Apply encryption at rest and strict access controls.",
+            severity: Severity::High,
+        },
+        ThreatRule {
+            category: StrideCategory::DenialOfService,
+            applicable_elements: vec![ElementType::DataStore],
+            targets_flows: false,
+            title_template: "Denial of service on {name}",
+            description_template: "An attacker may corrupt or exhaust {name} to disrupt service. Implement backups, storage quotas, and connection limits.",
+            severity: Severity::Medium,
+        },
+
+        // ── External Entity threats ──────────────────────────────────
+        ThreatRule {
+            category: StrideCategory::Spoofing,
+            applicable_elements: vec![ElementType::ExternalEntity],
+            targets_flows: false,
+            title_template: "Spoofing of {name}",
+            description_template: "An attacker may impersonate {name}. Verify the identity of external actors through authentication and certificate validation.",
+            severity: Severity::High,
+        },
+        ThreatRule {
+            category: StrideCategory::Repudiation,
+            applicable_elements: vec![ElementType::ExternalEntity],
+            targets_flows: false,
+            title_template: "Repudiation by {name}",
+            description_template: "{name} may deny having performed an action. Implement non-repudiation mechanisms such as digital signatures or audit logs.",
+            severity: Severity::Medium,
+        },
+
+        // ── Data Flow threats ────────────────────────────────────────
+        ThreatRule {
+            category: StrideCategory::Tampering,
+            applicable_elements: vec![],
+            targets_flows: true,
+            title_template: "Tampering with data flow between {source} and {target}",
+            description_template: "Data in transit between {source} and {target} may be modified by an attacker. Use TLS/encryption and message integrity verification.",
+            severity: Severity::High,
+        },
+        ThreatRule {
+            category: StrideCategory::InformationDisclosure,
+            applicable_elements: vec![],
+            targets_flows: true,
+            title_template: "Information disclosure on flow between {source} and {target}",
+            description_template: "Sensitive data flowing between {source} and {target} may be intercepted. Ensure encryption in transit and minimize data exposure.",
+            severity: Severity::High,
+        },
+        ThreatRule {
+            category: StrideCategory::DenialOfService,
+            applicable_elements: vec![],
+            targets_flows: true,
+            title_template: "Denial of service on flow between {source} and {target}",
+            description_template: "The communication channel between {source} and {target} may be disrupted. Implement redundancy, timeouts, and retry logic.",
+            severity: Severity::Medium,
+        },
+    ]
+}
+
+/// Look up element name by ID, falling back to the raw ID.
+fn element_name<'a>(model: &'a ThreatModel, element_id: &'a str) -> &'a str {
+    model
+        .elements
+        .iter()
+        .find(|e| e.id == element_id)
+        .map(|e| e.name.as_str())
+        .unwrap_or(element_id)
+}
+
+/// Build a set of (element_id, category) pairs from existing threats for dedup.
+fn existing_threat_keys(model: &ThreatModel) -> HashSet<(String, String)> {
+    model
+        .threats
+        .iter()
+        .filter_map(|t| {
+            let ref_id = t.element.as_deref().or(t.flow.as_deref())?;
+            Some((ref_id.to_string(), format!("{:?}", t.category)))
+        })
+        .collect()
+}
+
+/// Which trust boundary (if any) does an element belong to?
+fn element_boundary<'a>(
+    boundaries: &'a [TrustBoundary],
+    element_id: &str,
+) -> Option<&'a TrustBoundary> {
+    boundaries
+        .iter()
+        .find(|b| b.contains.iter().any(|c| c == element_id))
+}
+
+/// Returns true if source and target are in different trust boundaries (or one is unbound).
+fn crosses_boundary(boundaries: &[TrustBoundary], source: &str, target: &str) -> bool {
+    let src_boundary = element_boundary(boundaries, source).map(|b| &b.id);
+    let tgt_boundary = element_boundary(boundaries, target).map(|b| &b.id);
+    src_boundary != tgt_boundary
+}
+
+/// Analyze a threat model using STRIDE-per-element methodology.
+/// Returns a list of suggested threats that don't already exist in the model.
+pub fn analyze(model: &ThreatModel) -> Vec<Threat> {
+    let rules = build_rules();
+    let existing = existing_threat_keys(model);
+    let mut suggestions: Vec<Threat> = Vec::new();
+
+    // Element-based rules
+    for element in &model.elements {
+        for rule in &rules {
+            if rule.targets_flows {
+                continue;
+            }
+            if !rule.applicable_elements.contains(&element.element_type) {
+                continue;
+            }
+            let key = (element.id.clone(), format!("{:?}", rule.category));
+            if existing.contains(&key) {
+                continue;
+            }
+
+            let title = rule.title_template.replace("{name}", &element.name);
+            let description = rule.description_template.replace("{name}", &element.name);
+
+            suggestions.push(Threat {
+                id: generate_threat_id(),
+                title,
+                category: rule.category.clone(),
+                element: Some(element.id.clone()),
+                flow: None,
+                severity: rule.severity.clone(),
+                description,
+                mitigation: None,
+            });
+        }
+    }
+
+    // Data flow rules
+    for flow in &model.data_flows {
+        let source_name = element_name(model, &flow.from);
+        let target_name = element_name(model, &flow.to);
+
+        for rule in &rules {
+            if !rule.targets_flows {
+                continue;
+            }
+            let key = (flow.id.clone(), format!("{:?}", rule.category));
+            if existing.contains(&key) {
+                continue;
+            }
+
+            // For data flows, boost severity if the flow crosses a trust boundary
+            let severity = if crosses_boundary(&model.trust_boundaries, &flow.from, &flow.to) {
+                // Bump severity one level for cross-boundary flows
+                match &rule.severity {
+                    Severity::Medium => Severity::High,
+                    Severity::Low => Severity::Medium,
+                    other => other.clone(),
+                }
+            } else {
+                rule.severity.clone()
+            };
+
+            let title = rule
+                .title_template
+                .replace("{source}", source_name)
+                .replace("{target}", target_name);
+            let description = rule
+                .description_template
+                .replace("{source}", source_name)
+                .replace("{target}", target_name);
+
+            suggestions.push(Threat {
+                id: generate_threat_id(),
+                title,
+                category: rule.category.clone(),
+                element: None,
+                flow: Some(flow.id.clone()),
+                severity,
+                description,
+                mitigation: None,
+            });
+        }
+    }
+
+    suggestions
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{DataFlow, Element, ElementType, Metadata, ThreatModel, TrustBoundary};
+    use chrono::NaiveDate;
+
+    fn sample_model() -> ThreatModel {
+        ThreatModel {
+            version: "1.0".to_string(),
+            metadata: Metadata {
+                title: "Test".to_string(),
+                author: "Test".to_string(),
+                created: NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+                modified: NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+                description: String::new(),
+            },
+            elements: vec![
+                Element {
+                    id: "web-app".to_string(),
+                    element_type: ElementType::Process,
+                    name: "Web Application".to_string(),
+                    trust_zone: "internal".to_string(),
+                    icon: None,
+                    description: String::new(),
+                    technologies: vec![],
+                    stores: None,
+                    encryption: None,
+                },
+                Element {
+                    id: "db".to_string(),
+                    element_type: ElementType::DataStore,
+                    name: "Database".to_string(),
+                    trust_zone: "internal".to_string(),
+                    icon: None,
+                    description: String::new(),
+                    technologies: vec!["PostgreSQL".to_string()],
+                    stores: None,
+                    encryption: None,
+                },
+                Element {
+                    id: "user".to_string(),
+                    element_type: ElementType::ExternalEntity,
+                    name: "End User".to_string(),
+                    trust_zone: "external".to_string(),
+                    icon: None,
+                    description: String::new(),
+                    technologies: vec![],
+                    stores: None,
+                    encryption: None,
+                },
+            ],
+            data_flows: vec![DataFlow {
+                id: "flow-1".to_string(),
+                from: "web-app".to_string(),
+                to: "db".to_string(),
+                protocol: "PostgreSQL/TLS".to_string(),
+                data: vec!["user_records".to_string()],
+                authenticated: true,
+            }],
+            trust_boundaries: vec![
+                TrustBoundary {
+                    id: "boundary-1".to_string(),
+                    name: "Internal Network".to_string(),
+                    contains: vec!["web-app".to_string(), "db".to_string()],
+                },
+            ],
+            threats: vec![],
+            diagrams: vec![],
+        }
+    }
+
+    #[test]
+    fn test_generates_threats_for_process() {
+        let model = sample_model();
+        let threats = analyze(&model);
+        let process_threats: Vec<_> = threats
+            .iter()
+            .filter(|t| t.element.as_deref() == Some("web-app"))
+            .collect();
+        // Process should get: Spoofing, Tampering, Repudiation, InfoDisclosure, DoS, EoP
+        assert_eq!(process_threats.len(), 6, "Process should have 6 STRIDE threats");
+    }
+
+    #[test]
+    fn test_generates_threats_for_data_store() {
+        let model = sample_model();
+        let threats = analyze(&model);
+        let ds_threats: Vec<_> = threats
+            .iter()
+            .filter(|t| t.element.as_deref() == Some("db"))
+            .collect();
+        // DataStore should get: Tampering, InfoDisclosure, DoS
+        assert_eq!(ds_threats.len(), 3, "DataStore should have 3 threats");
+    }
+
+    #[test]
+    fn test_generates_threats_for_external_entity() {
+        let model = sample_model();
+        let threats = analyze(&model);
+        let ee_threats: Vec<_> = threats
+            .iter()
+            .filter(|t| t.element.as_deref() == Some("user"))
+            .collect();
+        // ExternalEntity should get: Spoofing, Repudiation
+        assert_eq!(ee_threats.len(), 2, "ExternalEntity should have 2 threats");
+    }
+
+    #[test]
+    fn test_generates_threats_for_data_flows() {
+        let model = sample_model();
+        let threats = analyze(&model);
+        let flow_threats: Vec<_> = threats
+            .iter()
+            .filter(|t| t.flow.as_deref() == Some("flow-1"))
+            .collect();
+        // DataFlow should get: Tampering, InfoDisclosure, DoS
+        assert_eq!(flow_threats.len(), 3, "DataFlow should have 3 threats");
+    }
+
+    #[test]
+    fn test_total_threat_count() {
+        let model = sample_model();
+        let threats = analyze(&model);
+        // 6 (process) + 3 (data_store) + 2 (external_entity) + 3 (flow) = 14
+        assert_eq!(threats.len(), 14, "Total should be 14 threats for the sample model");
+    }
+
+    #[test]
+    fn test_deduplication_skips_existing() {
+        let mut model = sample_model();
+        model.threats.push(Threat {
+            id: "existing-1".to_string(),
+            title: "Existing spoofing".to_string(),
+            category: StrideCategory::Spoofing,
+            element: Some("web-app".to_string()),
+            flow: None,
+            severity: Severity::High,
+            description: String::new(),
+            mitigation: None,
+        });
+
+        let threats = analyze(&model);
+        let spoofing_web: Vec<_> = threats
+            .iter()
+            .filter(|t| {
+                t.element.as_deref() == Some("web-app")
+                    && t.category == StrideCategory::Spoofing
+            })
+            .collect();
+        assert_eq!(
+            spoofing_web.len(),
+            0,
+            "Should not suggest spoofing for web-app since it already exists"
+        );
+    }
+
+    #[test]
+    fn test_threat_titles_contain_element_names() {
+        let model = sample_model();
+        let threats = analyze(&model);
+        let web_threats: Vec<_> = threats
+            .iter()
+            .filter(|t| t.element.as_deref() == Some("web-app"))
+            .collect();
+        for t in &web_threats {
+            assert!(
+                t.title.contains("Web Application"),
+                "Threat title '{}' should contain element name 'Web Application'",
+                t.title
+            );
+        }
+    }
+
+    #[test]
+    fn test_cross_boundary_flow_boosts_severity() {
+        let mut model = sample_model();
+        // Add a flow from internal to external (crosses boundary)
+        model.data_flows.push(DataFlow {
+            id: "flow-2".to_string(),
+            from: "web-app".to_string(),
+            to: "user".to_string(),
+            protocol: "HTTPS".to_string(),
+            data: vec!["response".to_string()],
+            authenticated: false,
+        });
+
+        let threats = analyze(&model);
+        let cross_flow_threats: Vec<_> = threats
+            .iter()
+            .filter(|t| t.flow.as_deref() == Some("flow-2"))
+            .collect();
+
+        // DoS rule has base severity Medium but should be boosted to High for cross-boundary
+        let dos_threat = cross_flow_threats
+            .iter()
+            .find(|t| t.category == StrideCategory::DenialOfService);
+        assert!(dos_threat.is_some(), "Should have DoS threat for cross-boundary flow");
+        assert_eq!(
+            dos_threat.unwrap().severity,
+            Severity::High,
+            "Cross-boundary DoS should be boosted from Medium to High"
+        );
+    }
+
+    #[test]
+    fn test_same_boundary_flow_no_boost() {
+        let model = sample_model();
+        let threats = analyze(&model);
+        // flow-1 is web-app → db, both in boundary-1 (same boundary)
+        let dos_threat = threats
+            .iter()
+            .find(|t| {
+                t.flow.as_deref() == Some("flow-1")
+                    && t.category == StrideCategory::DenialOfService
+            });
+        assert!(dos_threat.is_some());
+        assert_eq!(
+            dos_threat.unwrap().severity,
+            Severity::Medium,
+            "Same-boundary flow should keep base severity Medium"
+        );
+    }
+}

--- a/src/components/panels/properties-tab.tsx
+++ b/src/components/panels/properties-tab.tsx
@@ -1,0 +1,216 @@
+import { useCanvasStore } from "@/stores/canvas-store";
+import { useModelStore } from "@/stores/model-store";
+import { useUiStore } from "@/stores/ui-store";
+
+export function PropertiesTab() {
+	const selectedElementId = useModelStore((s) => s.selectedElementId);
+	const model = useModelStore((s) => s.model);
+	const updateElement = useModelStore((s) => s.updateElement);
+
+	if (!model) {
+		return <p className="text-xs text-muted-foreground">No model open.</p>;
+	}
+
+	if (!selectedElementId) {
+		return (
+			<p className="text-xs text-muted-foreground">
+				Select an element on the canvas to view its properties.
+			</p>
+		);
+	}
+
+	const element = model.elements.find((e) => e.id === selectedElementId);
+	if (!element) {
+		return <p className="text-xs text-muted-foreground">Element not found.</p>;
+	}
+
+	const elementTypeLabel = element.type
+		.split("_")
+		.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+		.join(" ");
+
+	const relatedThreats = model.threats.filter((t) => t.element === element.id);
+
+	return (
+		<div className="flex flex-col gap-3">
+			{/* Read-only fields */}
+			<ReadOnlyField label="ID" value={element.id} />
+			<ReadOnlyField label="Type" value={elementTypeLabel} />
+
+			{/* Editable fields */}
+			<EditableField
+				label="Name"
+				value={element.name}
+				onChange={(value) => {
+					updateElement(element.id, { name: value });
+					syncNodeLabel(element.id, value);
+				}}
+			/>
+
+			<EditableField
+				label="Trust Zone"
+				value={element.trust_zone}
+				placeholder="e.g. internal, dmz, external"
+				onChange={(value) => {
+					updateElement(element.id, { trust_zone: value });
+					syncNodeTrustZone(element.id, value);
+				}}
+			/>
+
+			<EditableTextarea
+				label="Description"
+				value={element.description}
+				placeholder="Describe this element..."
+				onChange={(value) => updateElement(element.id, { description: value })}
+			/>
+
+			<EditableField
+				label="Technologies"
+				value={element.technologies.join(", ")}
+				placeholder="e.g. nginx, TLS, OAuth"
+				onChange={(value) => {
+					const technologies = value
+						.split(",")
+						.map((t) => t.trim())
+						.filter((t) => t.length > 0);
+					updateElement(element.id, { technologies });
+				}}
+			/>
+
+			{/* Related threats summary */}
+			{relatedThreats.length > 0 && (
+				<div className="border-t border-border pt-3">
+					<p className="mb-1.5 text-[10px] font-medium text-muted-foreground">
+						Related Threats ({relatedThreats.length})
+					</p>
+					<div className="flex flex-col gap-1">
+						{relatedThreats.map((threat) => (
+							<ThreatLink
+								key={threat.id}
+								threatId={threat.id}
+								title={threat.title}
+								severity={threat.severity}
+							/>
+						))}
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}
+
+function ThreatLink({
+	threatId,
+	title,
+	severity,
+}: {
+	threatId: string;
+	title: string;
+	severity: string;
+}) {
+	const setSelectedThreat = useModelStore((s) => s.setSelectedThreat);
+	const setRightPanelTab = useUiStore((s) => s.setRightPanelTab);
+
+	return (
+		<button
+			type="button"
+			onClick={() => {
+				setSelectedThreat(threatId);
+				setRightPanelTab("threats");
+			}}
+			className="flex items-center justify-between rounded px-1.5 py-1 text-xs hover:bg-accent transition-colors text-left"
+		>
+			<span className="truncate">{title}</span>
+			<SeverityDot severity={severity} />
+		</button>
+	);
+}
+
+function SeverityDot({ severity }: { severity: string }) {
+	const colorMap: Record<string, string> = {
+		critical: "bg-red-400",
+		high: "bg-orange-400",
+		medium: "bg-yellow-400",
+		low: "bg-blue-400",
+		info: "bg-gray-400",
+	};
+
+	return (
+		<span className={`h-2 w-2 shrink-0 rounded-full ${colorMap[severity] ?? "bg-gray-400"}`} />
+	);
+}
+
+function syncNodeLabel(elementId: string, name: string) {
+	const nodes = useCanvasStore.getState().nodes;
+	const updatedNodes = nodes.map((n) =>
+		n.id === elementId ? { ...n, data: { ...n.data, label: name } } : n,
+	);
+	useCanvasStore.setState({ nodes: updatedNodes });
+}
+
+function syncNodeTrustZone(elementId: string, trustZone: string) {
+	const nodes = useCanvasStore.getState().nodes;
+	const updatedNodes = nodes.map((n) =>
+		n.id === elementId ? { ...n, data: { ...n.data, trustZone } } : n,
+	);
+	useCanvasStore.setState({ nodes: updatedNodes });
+}
+
+function ReadOnlyField({ label, value }: { label: string; value: string }) {
+	return (
+		<div>
+			<dt className="text-[10px] font-medium text-muted-foreground">{label}</dt>
+			<dd className="mt-0.5 text-xs text-foreground/80">{value}</dd>
+		</div>
+	);
+}
+
+function EditableField({
+	label,
+	value,
+	placeholder,
+	onChange,
+}: {
+	label: string;
+	value: string;
+	placeholder?: string;
+	onChange: (value: string) => void;
+}) {
+	return (
+		<label className="block">
+			<span className="mb-0.5 block text-[10px] font-medium text-muted-foreground">{label}</span>
+			<input
+				type="text"
+				value={value}
+				placeholder={placeholder}
+				onChange={(e) => onChange(e.target.value)}
+				className="w-full rounded border border-border bg-background px-2 py-1 text-xs placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none"
+			/>
+		</label>
+	);
+}
+
+function EditableTextarea({
+	label,
+	value,
+	placeholder,
+	onChange,
+}: {
+	label: string;
+	value: string;
+	placeholder?: string;
+	onChange: (value: string) => void;
+}) {
+	return (
+		<label className="block">
+			<span className="mb-0.5 block text-[10px] font-medium text-muted-foreground">{label}</span>
+			<textarea
+				value={value}
+				placeholder={placeholder}
+				onChange={(e) => onChange(e.target.value)}
+				rows={3}
+				className="w-full resize-none rounded border border-border bg-background px-2 py-1 text-xs placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none"
+			/>
+		</label>
+	);
+}

--- a/src/components/panels/right-panel.tsx
+++ b/src/components/panels/right-panel.tsx
@@ -1,6 +1,8 @@
 import { cn } from "@/lib/utils";
 import { useModelStore } from "@/stores/model-store";
 import { useUiStore } from "@/stores/ui-store";
+import { PropertiesTab } from "./properties-tab";
+import { ThreatsTab } from "./threats-tab";
 
 export function RightPanel() {
 	const tab = useUiStore((s) => s.rightPanelTab);
@@ -54,100 +56,5 @@ function TabButton({
 		>
 			{children}
 		</button>
-	);
-}
-
-function PropertiesTab() {
-	const selectedElementId = useModelStore((s) => s.selectedElementId);
-	const model = useModelStore((s) => s.model);
-
-	if (!model) {
-		return <p className="text-xs text-muted-foreground">No model open.</p>;
-	}
-
-	if (!selectedElementId) {
-		return (
-			<p className="text-xs text-muted-foreground">
-				Select an element on the canvas to view its properties.
-			</p>
-		);
-	}
-
-	const element = model.elements.find((e) => e.id === selectedElementId);
-	if (!element) {
-		return <p className="text-xs text-muted-foreground">Element not found.</p>;
-	}
-
-	return (
-		<div className="flex flex-col gap-3">
-			<PropertyRow label="ID" value={element.id} />
-			<PropertyRow label="Name" value={element.name} />
-			<PropertyRow label="Type" value={element.type} />
-			<PropertyRow label="Trust Zone" value={element.trust_zone || "—"} />
-			<PropertyRow label="Description" value={element.description || "—"} />
-		</div>
-	);
-}
-
-function ThreatsTab() {
-	const model = useModelStore((s) => s.model);
-
-	if (!model) {
-		return <p className="text-xs text-muted-foreground">No model open.</p>;
-	}
-
-	if (model.threats.length === 0) {
-		return (
-			<p className="text-xs text-muted-foreground">
-				No threats identified yet. Add elements to the canvas and run STRIDE analysis.
-			</p>
-		);
-	}
-
-	return (
-		<div className="flex flex-col gap-2">
-			{model.threats.map((threat) => (
-				<div
-					key={threat.id}
-					className="rounded-md border border-border p-2 text-xs transition-colors hover:bg-accent"
-				>
-					<div className="flex items-center justify-between">
-						<span className="font-medium">{threat.title}</span>
-						<SeverityBadge severity={threat.severity} />
-					</div>
-					<span className="text-muted-foreground">{threat.category}</span>
-				</div>
-			))}
-		</div>
-	);
-}
-
-function PropertyRow({ label, value }: { label: string; value: string }) {
-	return (
-		<div>
-			<dt className="text-xs font-medium text-muted-foreground">{label}</dt>
-			<dd className="mt-0.5 text-sm">{value}</dd>
-		</div>
-	);
-}
-
-function SeverityBadge({ severity }: { severity: string }) {
-	const colorMap: Record<string, string> = {
-		critical: "bg-red-500/20 text-red-400",
-		high: "bg-orange-500/20 text-orange-400",
-		medium: "bg-yellow-500/20 text-yellow-400",
-		low: "bg-blue-500/20 text-blue-400",
-		info: "bg-gray-500/20 text-gray-400",
-	};
-
-	return (
-		<span
-			className={cn(
-				"rounded px-1.5 py-0.5 text-[10px] font-medium uppercase",
-				colorMap[severity] ?? "bg-gray-500/20 text-gray-400",
-			)}
-		>
-			{severity}
-		</span>
 	);
 }

--- a/src/components/panels/threats-tab.tsx
+++ b/src/components/panels/threats-tab.tsx
@@ -1,0 +1,406 @@
+import {
+	AlertTriangle,
+	ChevronDown,
+	ChevronRight,
+	Loader2,
+	Shield,
+	Trash2,
+	Zap,
+} from "lucide-react";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { useModelStore } from "@/stores/model-store";
+import { useUiStore } from "@/stores/ui-store";
+import type {
+	Mitigation,
+	MitigationStatus,
+	Severity,
+	StrideCategory,
+	Threat,
+} from "@/types/threat-model";
+
+const STRIDE_CATEGORIES: StrideCategory[] = [
+	"Spoofing",
+	"Tampering",
+	"Repudiation",
+	"Information Disclosure",
+	"Denial of Service",
+	"Elevation of Privilege",
+];
+
+const SEVERITIES: Severity[] = ["critical", "high", "medium", "low", "info"];
+
+const MITIGATION_STATUSES: MitigationStatus[] = [
+	"not_started",
+	"in_progress",
+	"mitigated",
+	"accepted",
+	"transferred",
+];
+
+export function ThreatsTab() {
+	const model = useModelStore((s) => s.model);
+	const selectedElementId = useModelStore((s) => s.selectedElementId);
+	const selectedThreatId = useModelStore((s) => s.selectedThreatId);
+	const setSelectedThreat = useModelStore((s) => s.setSelectedThreat);
+	const isAnalyzing = useModelStore((s) => s.isAnalyzing);
+	const analyzeThreats = useModelStore((s) => s.analyzeThreats);
+	const [filterByElement, setFilterByElement] = useState(false);
+
+	if (!model) {
+		return <p className="text-xs text-muted-foreground">No model open.</p>;
+	}
+
+	const hasElements = model.elements.length > 0;
+	const threats =
+		filterByElement && selectedElementId
+			? model.threats.filter((t) => t.element === selectedElementId || t.flow === selectedElementId)
+			: model.threats;
+
+	const selectedElement = selectedElementId
+		? model.elements.find((e) => e.id === selectedElementId)
+		: null;
+
+	return (
+		<div className="flex flex-col gap-3">
+			{/* Analyze button */}
+			<button
+				type="button"
+				disabled={!hasElements || isAnalyzing}
+				onClick={() => void analyzeThreats()}
+				className={cn(
+					"flex w-full items-center justify-center gap-2 rounded-md px-3 py-2 text-xs font-medium transition-colors",
+					hasElements
+						? "bg-primary text-primary-foreground hover:bg-primary/90"
+						: "cursor-not-allowed bg-muted text-muted-foreground",
+				)}
+			>
+				{isAnalyzing ? (
+					<>
+						<Loader2 className="h-3.5 w-3.5 animate-spin" />
+						Analyzing...
+					</>
+				) : (
+					<>
+						<Zap className="h-3.5 w-3.5" />
+						Run STRIDE Analysis
+					</>
+				)}
+			</button>
+
+			{/* Filter toggle when element is selected */}
+			{selectedElement && model.threats.length > 0 && (
+				<button
+					type="button"
+					onClick={() => setFilterByElement(!filterByElement)}
+					className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+				>
+					<Shield className="h-3 w-3" />
+					{filterByElement
+						? `Showing threats for "${selectedElement.name}"`
+						: "Filter by selected element"}
+				</button>
+			)}
+
+			{/* Empty states */}
+			{!hasElements && (
+				<div className="flex flex-col items-center gap-2 py-6 text-center">
+					<AlertTriangle className="h-8 w-8 text-muted-foreground/50" />
+					<p className="text-xs text-muted-foreground">
+						Add elements to the canvas, then run STRIDE analysis to identify threats.
+					</p>
+				</div>
+			)}
+
+			{hasElements && threats.length === 0 && (
+				<p className="text-xs text-muted-foreground">
+					{filterByElement
+						? "No threats linked to this element."
+						: 'No threats identified yet. Click "Run STRIDE Analysis" to get started.'}
+				</p>
+			)}
+
+			{/* Threat list */}
+			{threats.map((threat) => (
+				<ThreatCard
+					key={threat.id}
+					threat={threat}
+					isSelected={selectedThreatId === threat.id}
+					onSelect={() => setSelectedThreat(selectedThreatId === threat.id ? null : threat.id)}
+				/>
+			))}
+		</div>
+	);
+}
+
+function ThreatCard({
+	threat,
+	isSelected,
+	onSelect,
+}: {
+	threat: Threat;
+	isSelected: boolean;
+	onSelect: () => void;
+}) {
+	const setSelectedElement = useModelStore((s) => s.setSelectedElement);
+	const setRightPanelTab = useUiStore((s) => s.setRightPanelTab);
+	const model = useModelStore((s) => s.model);
+
+	const linkedElement = model?.elements.find((e) => e.id === threat.element);
+
+	return (
+		<div
+			className={cn(
+				"rounded-md border text-xs transition-colors",
+				isSelected ? "border-primary bg-primary/5" : "border-border hover:bg-accent",
+			)}
+		>
+			{/* Header - clickable to expand/collapse */}
+			<button type="button" onClick={onSelect} className="flex w-full items-start gap-2 p-2">
+				{isSelected ? (
+					<ChevronDown className="mt-0.5 h-3 w-3 shrink-0 text-muted-foreground" />
+				) : (
+					<ChevronRight className="mt-0.5 h-3 w-3 shrink-0 text-muted-foreground" />
+				)}
+				<div className="flex flex-1 flex-col items-start gap-1">
+					<span className="font-medium text-left">{threat.title}</span>
+					<div className="flex items-center gap-1.5">
+						<CategoryBadge category={threat.category} />
+						<SeverityBadge severity={threat.severity} />
+						{threat.mitigation && <MitigationBadge status={threat.mitigation.status} />}
+					</div>
+				</div>
+			</button>
+
+			{/* Linked element link */}
+			{linkedElement && !isSelected && (
+				<div className="border-t border-border/50 px-2 py-1">
+					<button
+						type="button"
+						onClick={() => {
+							setSelectedElement(linkedElement.id);
+							setRightPanelTab("properties");
+						}}
+						className="text-[10px] text-muted-foreground hover:text-primary transition-colors"
+					>
+						{linkedElement.name}
+					</button>
+				</div>
+			)}
+
+			{/* Expanded detail editor */}
+			{isSelected && <ThreatEditor threat={threat} />}
+		</div>
+	);
+}
+
+function ThreatEditor({ threat }: { threat: Threat }) {
+	const updateThreat = useModelStore((s) => s.updateThreat);
+	const deleteThreat = useModelStore((s) => s.deleteThreat);
+	const setSelectedThreat = useModelStore((s) => s.setSelectedThreat);
+	const setSelectedElement = useModelStore((s) => s.setSelectedElement);
+	const setRightPanelTab = useUiStore((s) => s.setRightPanelTab);
+	const model = useModelStore((s) => s.model);
+
+	const linkedElement = model?.elements.find((e) => e.id === threat.element);
+
+	const handleMitigationChange = (updates: Partial<Mitigation>) => {
+		const current: Mitigation = threat.mitigation ?? {
+			status: "not_started",
+			description: "",
+		};
+		updateThreat(threat.id, { mitigation: { ...current, ...updates } });
+	};
+
+	return (
+		<div className="flex flex-col gap-2 border-t border-border/50 p-2">
+			{/* Title */}
+			<FieldGroup label="Title">
+				<input
+					type="text"
+					value={threat.title}
+					onChange={(e) => updateThreat(threat.id, { title: e.target.value })}
+					className="w-full rounded border border-border bg-background px-2 py-1 text-xs focus:border-primary focus:outline-none"
+				/>
+			</FieldGroup>
+
+			{/* Category + Severity row */}
+			<div className="grid grid-cols-2 gap-2">
+				<FieldGroup label="Category">
+					<select
+						value={threat.category}
+						onChange={(e) =>
+							updateThreat(threat.id, {
+								category: e.target.value as StrideCategory,
+							})
+						}
+						className="w-full rounded border border-border bg-background px-2 py-1 text-xs focus:border-primary focus:outline-none"
+					>
+						{STRIDE_CATEGORIES.map((c) => (
+							<option key={c} value={c}>
+								{c}
+							</option>
+						))}
+					</select>
+				</FieldGroup>
+
+				<FieldGroup label="Severity">
+					<select
+						value={threat.severity}
+						onChange={(e) =>
+							updateThreat(threat.id, {
+								severity: e.target.value as Severity,
+							})
+						}
+						className="w-full rounded border border-border bg-background px-2 py-1 text-xs focus:border-primary focus:outline-none"
+					>
+						{SEVERITIES.map((s) => (
+							<option key={s} value={s}>
+								{s.charAt(0).toUpperCase() + s.slice(1)}
+							</option>
+						))}
+					</select>
+				</FieldGroup>
+			</div>
+
+			{/* Description */}
+			<FieldGroup label="Description">
+				<textarea
+					value={threat.description}
+					onChange={(e) => updateThreat(threat.id, { description: e.target.value })}
+					rows={3}
+					className="w-full resize-none rounded border border-border bg-background px-2 py-1 text-xs focus:border-primary focus:outline-none"
+				/>
+			</FieldGroup>
+
+			{/* Linked element */}
+			{linkedElement && (
+				<FieldGroup label="Element">
+					<button
+						type="button"
+						onClick={() => {
+							setSelectedElement(linkedElement.id);
+							setRightPanelTab("properties");
+						}}
+						className="text-xs text-primary hover:underline"
+					>
+						{linkedElement.name} ({linkedElement.type.replace("_", " ")})
+					</button>
+				</FieldGroup>
+			)}
+
+			{/* Mitigation */}
+			<FieldGroup label="Mitigation Status">
+				<select
+					value={threat.mitigation?.status ?? "not_started"}
+					onChange={(e) =>
+						handleMitigationChange({
+							status: e.target.value as MitigationStatus,
+						})
+					}
+					className="w-full rounded border border-border bg-background px-2 py-1 text-xs focus:border-primary focus:outline-none"
+				>
+					{MITIGATION_STATUSES.map((s) => (
+						<option key={s} value={s}>
+							{formatMitigationStatus(s)}
+						</option>
+					))}
+				</select>
+			</FieldGroup>
+
+			<FieldGroup label="Mitigation Notes">
+				<textarea
+					value={threat.mitigation?.description ?? ""}
+					onChange={(e) => handleMitigationChange({ description: e.target.value })}
+					rows={2}
+					placeholder="Describe the mitigation approach..."
+					className="w-full resize-none rounded border border-border bg-background px-2 py-1 text-xs placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none"
+				/>
+			</FieldGroup>
+
+			{/* Delete */}
+			<button
+				type="button"
+				onClick={() => {
+					deleteThreat(threat.id);
+					setSelectedThreat(null);
+				}}
+				className="flex items-center gap-1 self-start rounded px-2 py-1 text-xs text-destructive hover:bg-destructive/10 transition-colors"
+			>
+				<Trash2 className="h-3 w-3" />
+				Delete threat
+			</button>
+		</div>
+	);
+}
+
+function FieldGroup({ label, children }: { label: string; children: React.ReactNode }) {
+	return (
+		// biome-ignore lint/a11y/noLabelWithoutControl: children always contain a form control
+		<label className="block">
+			<span className="mb-0.5 block text-[10px] font-medium text-muted-foreground">{label}</span>
+			{children}
+		</label>
+	);
+}
+
+function SeverityBadge({ severity }: { severity: string }) {
+	const colorMap: Record<string, string> = {
+		critical: "bg-red-500/20 text-red-400",
+		high: "bg-orange-500/20 text-orange-400",
+		medium: "bg-yellow-500/20 text-yellow-400",
+		low: "bg-blue-500/20 text-blue-400",
+		info: "bg-gray-500/20 text-gray-400",
+	};
+
+	return (
+		<span
+			className={cn(
+				"rounded px-1.5 py-0.5 text-[10px] font-medium uppercase",
+				colorMap[severity] ?? "bg-gray-500/20 text-gray-400",
+			)}
+		>
+			{severity}
+		</span>
+	);
+}
+
+function CategoryBadge({ category }: { category: StrideCategory }) {
+	const initial =
+		category === "Information Disclosure"
+			? "ID"
+			: category === "Denial of Service"
+				? "DoS"
+				: category === "Elevation of Privilege"
+					? "EoP"
+					: category.charAt(0);
+
+	return (
+		<span className="rounded bg-secondary px-1.5 py-0.5 text-[10px] font-medium text-secondary-foreground">
+			{initial}
+		</span>
+	);
+}
+
+function MitigationBadge({ status }: { status: MitigationStatus }) {
+	const colorMap: Record<MitigationStatus, string> = {
+		not_started: "bg-gray-500/20 text-gray-400",
+		in_progress: "bg-blue-500/20 text-blue-400",
+		mitigated: "bg-green-500/20 text-green-400",
+		accepted: "bg-yellow-500/20 text-yellow-400",
+		transferred: "bg-purple-500/20 text-purple-400",
+	};
+
+	return (
+		<span className={cn("rounded px-1.5 py-0.5 text-[10px] font-medium", colorMap[status])}>
+			{formatMitigationStatus(status)}
+		</span>
+	);
+}
+
+function formatMitigationStatus(status: MitigationStatus): string {
+	return status
+		.split("_")
+		.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+		.join(" ");
+}

--- a/src/stores/model-store.ts
+++ b/src/stores/model-store.ts
@@ -1,5 +1,6 @@
+import { invoke } from "@tauri-apps/api/core";
 import { create } from "zustand";
-import type { ThreatModel } from "@/types/threat-model";
+import type { Element, Threat, ThreatModel } from "@/types/threat-model";
 
 interface ModelState {
 	/** The currently loaded threat model, or null if no model is open */
@@ -12,6 +13,8 @@ interface ModelState {
 	selectedElementId: string | null;
 	/** Currently selected threat ID */
 	selectedThreatId: string | null;
+	/** Whether STRIDE analysis is running */
+	isAnalyzing: boolean;
 
 	// Actions
 	setModel: (model: ThreatModel, filePath: string | null) => void;
@@ -20,14 +23,27 @@ interface ModelState {
 	markClean: () => void;
 	setSelectedElement: (id: string | null) => void;
 	setSelectedThreat: (id: string | null) => void;
+
+	// Element editing
+	updateElement: (id: string, updates: Partial<Element>) => void;
+
+	// Threat CRUD
+	addThreat: (threat: Threat) => void;
+	addThreats: (threats: Threat[]) => void;
+	updateThreat: (id: string, updates: Partial<Threat>) => void;
+	deleteThreat: (id: string) => void;
+
+	// STRIDE analysis
+	analyzeThreats: () => Promise<void>;
 }
 
-export const useModelStore = create<ModelState>((set) => ({
+export const useModelStore = create<ModelState>((set, get) => ({
 	model: null,
 	filePath: null,
 	isDirty: false,
 	selectedElementId: null,
 	selectedThreatId: null,
+	isAnalyzing: false,
 
 	setModel: (model, filePath) =>
 		set({
@@ -51,4 +67,73 @@ export const useModelStore = create<ModelState>((set) => ({
 	markClean: () => set({ isDirty: false }),
 	setSelectedElement: (id) => set({ selectedElementId: id }),
 	setSelectedThreat: (id) => set({ selectedThreatId: id }),
+
+	updateElement: (id, updates) => {
+		const { model } = get();
+		if (!model) return;
+
+		const updatedElements = model.elements.map((e) => (e.id === id ? { ...e, ...updates } : e));
+		set({
+			model: { ...model, elements: updatedElements },
+			isDirty: true,
+		});
+	},
+
+	addThreat: (threat) => {
+		const { model } = get();
+		if (!model) return;
+
+		set({
+			model: { ...model, threats: [...model.threats, threat] },
+			isDirty: true,
+		});
+	},
+
+	addThreats: (threats) => {
+		const { model } = get();
+		if (!model) return;
+		if (threats.length === 0) return;
+
+		set({
+			model: { ...model, threats: [...model.threats, ...threats] },
+			isDirty: true,
+		});
+	},
+
+	updateThreat: (id, updates) => {
+		const { model } = get();
+		if (!model) return;
+
+		const updatedThreats = model.threats.map((t) => (t.id === id ? { ...t, ...updates } : t));
+		set({
+			model: { ...model, threats: updatedThreats },
+			isDirty: true,
+		});
+	},
+
+	deleteThreat: (id) => {
+		const { model, selectedThreatId } = get();
+		if (!model) return;
+
+		set({
+			model: { ...model, threats: model.threats.filter((t) => t.id !== id) },
+			isDirty: true,
+			selectedThreatId: selectedThreatId === id ? null : selectedThreatId,
+		});
+	},
+
+	analyzeThreats: async () => {
+		const { model } = get();
+		if (!model) return;
+
+		set({ isAnalyzing: true });
+		try {
+			const newThreats = await invoke<Threat[]>("analyze_stride", { model });
+			if (newThreats.length > 0) {
+				get().addThreats(newThreats);
+			}
+		} finally {
+			set({ isAnalyzing: false });
+		}
+	},
 }));


### PR DESCRIPTION
## Summary

- **Rust STRIDE engine** (`src-tauri/src/stride/mod.rs`): 14 hardcoded STRIDE rules (6 Process, 3 DataStore, 2 ExternalEntity, 3 DataFlow) with cross-boundary severity boosting and deduplication against existing threats
- **Tauri command** (`analyze_stride`): IPC bridge for frontend to invoke STRIDE analysis on the current model
- **Threat CRUD** in model-store: `addThreat`, `addThreats`, `updateThreat`, `deleteThreat`, `analyzeThreats` (Tauri IPC), `updateElement`, `isAnalyzing` loading state
- **Interactive ThreatsTab**: "Run STRIDE Analysis" button, expandable threat cards with inline editing (title, category, severity, description, mitigation status/notes), element-to-threat filtering, threat-to-element navigation
- **Editable PropertiesTab**: name, trust zone, description, technologies fields with live canvas node sync; related threats section with clickable links
- **26 frontend tests** (7 new model-store tests) + **22 Rust tests** (9 new STRIDE engine tests)

## Test plan

- [x] `npx biome check .` — 33 files, 0 errors
- [x] `npx vitest --run` — 26 tests passing
- [x] `npx tsc --noEmit` — no type errors
- [x] `cargo test` — 22 tests passing
- [x] `cargo clippy` — clean (1 expected dead_code warning)
- [ ] Manual: drop elements on canvas, click "Run STRIDE Analysis", verify threats appear
- [ ] Manual: expand a threat card, edit fields, verify changes persist
- [ ] Manual: edit element name in properties tab, verify canvas node label updates
- [ ] Manual: click threat's element link, verify canvas selection changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)