### PR TITLE
feat(ai): BYOK AI chat pane with streaming Anthropic + OpenAI support

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -430,6 +430,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +486,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -501,7 +517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -514,7 +530,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -631,6 +647,27 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dbus"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b3aa68d7e7abee336255bd7248ea965cc393f3e70411135a6f6a4b651345d4"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "dbus",
+ "zeroize",
 ]
 
 [[package]]
@@ -970,12 +1007,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1043,6 +1096,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1189,8 +1243,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1200,9 +1256,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1481,6 +1539,23 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1816,6 +1891,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "kuchikiki"
 version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,6 +1960,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1915,6 +2014,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac"
@@ -2728,6 +2833,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2768,6 +2928,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2788,6 +2958,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2803,6 +2983,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2900,6 +3089,47 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -2928,7 +3158,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -2957,6 +3187,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2976,6 +3226,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -3055,6 +3340,42 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3177,6 +3498,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3408,6 +3741,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3481,7 +3820,7 @@ checksum = "f3a753bdc39c07b192151523a3f77cd0394aa75413802c883a0f6f6a0e5ee2e7"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dispatch",
@@ -3560,7 +3899,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3893,6 +4232,9 @@ name = "threat-forge"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "futures",
+ "keyring",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3902,6 +4244,8 @@ dependencies = [
  "tauri-plugin-opener",
  "tempfile",
  "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
  "uuid",
 ]
 
@@ -3947,6 +4291,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3955,9 +4314,44 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -4262,6 +4656,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4474,6 +4874,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
@@ -4502,6 +4915,16 @@ name = "web-sys"
 version = "0.3.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "705eceb4ce901230f8625bd1d665128056ccbe4b7408faa625eec1ba80f59a97"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4549,6 +4972,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4779,6 +5211,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5323,6 +5764,26 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,11 @@ serde_yaml = "0.9"
 thiserror = "2"
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
+reqwest = { version = "0.12", features = ["json", "stream", "rustls-tls"], default-features = false }
+keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
+tokio = { version = "1", features = ["full"] }
+tokio-stream = "0.1"
+futures = "0.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/ai/keychain.rs
+++ b/src-tauri/src/ai/keychain.rs
@@ -1,0 +1,80 @@
+use crate::ai::types::AiProvider;
+use crate::errors::ThreatForgeError;
+
+const SERVICE_NAME: &str = "com.exitzerolabs.threatforge";
+
+/// Build the keychain entry key for a given provider
+fn entry_key(provider: &AiProvider) -> String {
+    format!("api-key-{}", provider.keychain_key())
+}
+
+/// Store an API key in the OS keychain
+pub fn store_key(provider: &AiProvider, key: &str) -> Result<(), ThreatForgeError> {
+    let entry = keyring::Entry::new(SERVICE_NAME, &entry_key(provider)).map_err(|e| {
+        ThreatForgeError::Keychain {
+            message: format!("Failed to create keychain entry: {e}"),
+        }
+    })?;
+    entry
+        .set_password(key)
+        .map_err(|e| ThreatForgeError::Keychain {
+            message: format!("Failed to store API key: {e}"),
+        })
+}
+
+/// Check whether an API key exists in the keychain (does NOT return the key itself)
+pub fn has_key(provider: &AiProvider) -> Result<bool, ThreatForgeError> {
+    let entry = keyring::Entry::new(SERVICE_NAME, &entry_key(provider)).map_err(|e| {
+        ThreatForgeError::Keychain {
+            message: format!("Failed to create keychain entry: {e}"),
+        }
+    })?;
+    match entry.get_password() {
+        Ok(_) => Ok(true),
+        Err(keyring::Error::NoEntry) => Ok(false),
+        Err(e) => Err(ThreatForgeError::Keychain {
+            message: format!("Failed to check API key: {e}"),
+        }),
+    }
+}
+
+/// Retrieve an API key from the keychain (internal use only — never expose to frontend)
+pub fn get_key(provider: &AiProvider) -> Result<String, ThreatForgeError> {
+    let entry = keyring::Entry::new(SERVICE_NAME, &entry_key(provider)).map_err(|e| {
+        ThreatForgeError::Keychain {
+            message: format!("Failed to create keychain entry: {e}"),
+        }
+    })?;
+    entry
+        .get_password()
+        .map_err(|e| ThreatForgeError::Keychain {
+            message: format!("Failed to retrieve API key: {e}"),
+        })
+}
+
+/// Delete an API key from the keychain
+pub fn delete_key(provider: &AiProvider) -> Result<(), ThreatForgeError> {
+    let entry = keyring::Entry::new(SERVICE_NAME, &entry_key(provider)).map_err(|e| {
+        ThreatForgeError::Keychain {
+            message: format!("Failed to create keychain entry: {e}"),
+        }
+    })?;
+    match entry.delete_credential() {
+        Ok(()) => Ok(()),
+        Err(keyring::Error::NoEntry) => Ok(()), // Already deleted — not an error
+        Err(e) => Err(ThreatForgeError::Keychain {
+            message: format!("Failed to delete API key: {e}"),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_entry_key_format() {
+        assert_eq!(entry_key(&AiProvider::Anthropic), "api-key-anthropic");
+        assert_eq!(entry_key(&AiProvider::OpenAi), "api-key-openai");
+    }
+}

--- a/src-tauri/src/ai/mod.rs
+++ b/src-tauri/src/ai/mod.rs
@@ -1,0 +1,4 @@
+pub mod keychain;
+pub mod prompt;
+pub mod providers;
+pub mod types;

--- a/src-tauri/src/ai/prompt.rs
+++ b/src-tauri/src/ai/prompt.rs
@@ -1,0 +1,189 @@
+use crate::models::ThreatModel;
+
+/// Build a system prompt that includes the current threat model context.
+///
+/// The prompt instructs the AI to act as a threat modeling expert and provides
+/// the full model state so the AI can make contextual suggestions.
+pub fn build_system_prompt(model: &ThreatModel) -> String {
+    let mut prompt = String::with_capacity(4096);
+
+    prompt.push_str(
+        "You are a senior security architect and threat modeling expert. \
+         You are helping a user analyze and improve their threat model using the STRIDE methodology.\n\n\
+         STRIDE categories:\n\
+         - Spoofing: Can an attacker pretend to be someone/something else?\n\
+         - Tampering: Can an attacker modify data in transit or at rest?\n\
+         - Repudiation: Can an attacker deny performing an action?\n\
+         - Information Disclosure: Can an attacker access data they shouldn't?\n\
+         - Denial of Service: Can an attacker prevent legitimate access?\n\
+         - Elevation of Privilege: Can an attacker gain unauthorized access levels?\n\n",
+    );
+
+    prompt.push_str("When suggesting new threats, format them in a fenced code block with the language tag `threats` using YAML syntax:\n\n");
+    prompt.push_str("```threats\n");
+    prompt.push_str("- title: \"Threat title here\"\n");
+    prompt.push_str("  category: Spoofing|Tampering|Repudiation|Information Disclosure|Denial of Service|Elevation of Privilege\n");
+    prompt.push_str("  element: element-id-here\n");
+    prompt.push_str("  severity: critical|high|medium|low|info\n");
+    prompt.push_str("  description: \"Description of the threat and its impact.\"\n");
+    prompt.push_str("```\n\n");
+
+    prompt.push_str(
+        "Only use element IDs that exist in the current model. \
+         Be specific and actionable in your threat descriptions. \
+         Consider the trust zones and data flows when assessing severity.\n\n",
+    );
+
+    // Serialize the current model context
+    prompt.push_str("--- CURRENT THREAT MODEL ---\n\n");
+
+    prompt.push_str(&format!("Title: {}\n", model.metadata.title));
+    prompt.push_str(&format!("Author: {}\n", model.metadata.author));
+    if !model.metadata.description.is_empty() {
+        prompt.push_str(&format!("Description: {}\n", model.metadata.description));
+    }
+    prompt.push('\n');
+
+    // Elements
+    if !model.elements.is_empty() {
+        prompt.push_str("Elements:\n");
+        for el in &model.elements {
+            prompt.push_str(&format!(
+                "  - {} (id: {}, type: {:?}, trust_zone: {}",
+                el.name, el.id, el.element_type, el.trust_zone
+            ));
+            if !el.technologies.is_empty() {
+                prompt.push_str(&format!(", technologies: [{}]", el.technologies.join(", ")));
+            }
+            if !el.description.is_empty() {
+                prompt.push_str(&format!(", description: \"{}\"", el.description));
+            }
+            prompt.push_str(")\n");
+        }
+        prompt.push('\n');
+    }
+
+    // Data flows
+    if !model.data_flows.is_empty() {
+        prompt.push_str("Data Flows:\n");
+        for flow in &model.data_flows {
+            prompt.push_str(&format!(
+                "  - {} -> {} (id: {}, protocol: {}, data: [{}], authenticated: {})\n",
+                flow.from,
+                flow.to,
+                flow.id,
+                flow.protocol,
+                flow.data.join(", "),
+                flow.authenticated
+            ));
+        }
+        prompt.push('\n');
+    }
+
+    // Trust boundaries
+    if !model.trust_boundaries.is_empty() {
+        prompt.push_str("Trust Boundaries:\n");
+        for boundary in &model.trust_boundaries {
+            prompt.push_str(&format!(
+                "  - {} (id: {}, contains: [{}])\n",
+                boundary.name,
+                boundary.id,
+                boundary.contains.join(", ")
+            ));
+        }
+        prompt.push('\n');
+    }
+
+    // Existing threats
+    if !model.threats.is_empty() {
+        prompt.push_str("Existing Threats (already identified):\n");
+        for threat in &model.threats {
+            prompt.push_str(&format!(
+                "  - {} (id: {}, category: {:?}, severity: {:?}",
+                threat.title, threat.id, threat.category, threat.severity
+            ));
+            if let Some(ref el) = threat.element {
+                prompt.push_str(&format!(", element: {el}"));
+            }
+            if let Some(ref mitigation) = threat.mitigation {
+                prompt.push_str(&format!(", mitigation: {:?}", mitigation.status));
+            }
+            prompt.push_str(")\n");
+        }
+        prompt.push('\n');
+    }
+
+    prompt.push_str("--- END THREAT MODEL ---\n");
+
+    prompt
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_system_prompt_empty_model() {
+        let model = ThreatModel::new("Test Model", "Test Author");
+        let prompt = build_system_prompt(&model);
+
+        assert!(prompt.contains("STRIDE"));
+        assert!(prompt.contains("Test Model"));
+        assert!(prompt.contains("Test Author"));
+        assert!(prompt.contains("```threats"));
+        assert!(prompt.contains("--- CURRENT THREAT MODEL ---"));
+        assert!(prompt.contains("--- END THREAT MODEL ---"));
+        // Empty model should not have elements/flows sections
+        assert!(!prompt.contains("Elements:"));
+        assert!(!prompt.contains("Data Flows:"));
+    }
+
+    #[test]
+    fn test_build_system_prompt_with_elements() {
+        use crate::models::{Element, ElementType};
+
+        let mut model = ThreatModel::new("Payment Service", "Alice");
+        model.elements.push(Element {
+            id: "api-gw".to_string(),
+            element_type: ElementType::Process,
+            name: "API Gateway".to_string(),
+            trust_zone: "dmz".to_string(),
+            icon: None,
+            description: "Main entry point".to_string(),
+            technologies: vec!["nginx".to_string()],
+            stores: None,
+            encryption: None,
+        });
+
+        let prompt = build_system_prompt(&model);
+
+        assert!(prompt.contains("Elements:"));
+        assert!(prompt.contains("API Gateway"));
+        assert!(prompt.contains("api-gw"));
+        assert!(prompt.contains("dmz"));
+        assert!(prompt.contains("nginx"));
+        assert!(prompt.contains("Main entry point"));
+    }
+
+    #[test]
+    fn test_build_system_prompt_with_flows() {
+        use crate::models::DataFlow;
+
+        let mut model = ThreatModel::new("Test", "Author");
+        model.data_flows.push(DataFlow {
+            id: "flow-1".to_string(),
+            from: "web-app".to_string(),
+            to: "api-gw".to_string(),
+            protocol: "HTTPS".to_string(),
+            data: vec!["user_input".to_string()],
+            authenticated: true,
+        });
+
+        let prompt = build_system_prompt(&model);
+
+        assert!(prompt.contains("Data Flows:"));
+        assert!(prompt.contains("web-app -> api-gw"));
+        assert!(prompt.contains("HTTPS"));
+        assert!(prompt.contains("authenticated: true"));
+    }
+}

--- a/src-tauri/src/ai/providers.rs
+++ b/src-tauri/src/ai/providers.rs
@@ -1,0 +1,276 @@
+use crate::ai::types::{AiProvider, ChatMessage, ChatRole};
+use crate::errors::ThreatForgeError;
+use futures::StreamExt;
+use reqwest::Client;
+use tauri::{AppHandle, Emitter};
+
+const ANTHROPIC_API_URL: &str = "https://api.anthropic.com/v1/messages";
+const OPENAI_API_URL: &str = "https://api.openai.com/v1/chat/completions";
+const ANTHROPIC_MODEL: &str = "claude-sonnet-4-20250514";
+const OPENAI_MODEL: &str = "gpt-4o";
+
+/// Stream a chat response from the configured provider, emitting Tauri events
+/// for each text chunk.
+///
+/// Events emitted:
+/// - `ai:stream-chunk` — `{ "text": "..." }` for each text delta
+/// - `ai:stream-done` — `{}` when the stream completes
+/// - `ai:stream-error` — `{ "error": "..." }` on failure
+pub async fn stream_chat(
+    app: &AppHandle,
+    provider: &AiProvider,
+    api_key: &str,
+    system_prompt: &str,
+    messages: &[ChatMessage],
+) -> Result<(), ThreatForgeError> {
+    let client = Client::new();
+
+    let result = match provider {
+        AiProvider::Anthropic => {
+            stream_anthropic(&client, app, api_key, system_prompt, messages).await
+        }
+        AiProvider::OpenAi => stream_openai(&client, app, api_key, system_prompt, messages).await,
+    };
+
+    match result {
+        Ok(()) => {
+            let _ = app.emit("ai:stream-done", serde_json::json!({}));
+            Ok(())
+        }
+        Err(e) => {
+            let _ = app.emit(
+                "ai:stream-error",
+                serde_json::json!({ "error": e.to_string() }),
+            );
+            Err(e)
+        }
+    }
+}
+
+/// Stream from Anthropic Messages API
+async fn stream_anthropic(
+    client: &Client,
+    app: &AppHandle,
+    api_key: &str,
+    system_prompt: &str,
+    messages: &[ChatMessage],
+) -> Result<(), ThreatForgeError> {
+    let api_messages: Vec<serde_json::Value> = messages
+        .iter()
+        .filter(|m| m.role != ChatRole::System)
+        .map(|m| {
+            serde_json::json!({
+                "role": match m.role {
+                    ChatRole::User => "user",
+                    ChatRole::Assistant => "assistant",
+                    ChatRole::System => "user", // filtered above, but needed for exhaustive match
+                },
+                "content": m.content,
+            })
+        })
+        .collect();
+
+    let body = serde_json::json!({
+        "model": ANTHROPIC_MODEL,
+        "max_tokens": 4096,
+        "system": system_prompt,
+        "messages": api_messages,
+        "stream": true,
+    });
+
+    let response = client
+        .post(ANTHROPIC_API_URL)
+        .header("x-api-key", api_key)
+        .header("anthropic-version", "2023-06-01")
+        .header("content-type", "application/json")
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| ThreatForgeError::AiRequest {
+            message: format!("Anthropic request failed: {e}"),
+        })?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(ThreatForgeError::AiRequest {
+            message: format!("Anthropic API error ({status}): {body}"),
+        });
+    }
+
+    let mut stream = response.bytes_stream();
+    let mut buffer = String::new();
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| ThreatForgeError::AiRequest {
+            message: format!("Stream read error: {e}"),
+        })?;
+
+        buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+        // Process complete SSE lines
+        while let Some(line_end) = buffer.find('\n') {
+            let line = buffer[..line_end].trim().to_string();
+            buffer = buffer[line_end + 1..].to_string();
+
+            if let Some(data) = line.strip_prefix("data: ") {
+                if data == "[DONE]" {
+                    return Ok(());
+                }
+                if let Ok(event) = serde_json::from_str::<serde_json::Value>(data) {
+                    // Anthropic SSE: look for content_block_delta events
+                    if event.get("type").and_then(|t| t.as_str()) == Some("content_block_delta") {
+                        if let Some(text) = event
+                            .get("delta")
+                            .and_then(|d| d.get("text"))
+                            .and_then(|t| t.as_str())
+                        {
+                            let _ =
+                                app.emit("ai:stream-chunk", serde_json::json!({ "text": text }));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Stream from OpenAI Chat Completions API
+async fn stream_openai(
+    client: &Client,
+    app: &AppHandle,
+    api_key: &str,
+    system_prompt: &str,
+    messages: &[ChatMessage],
+) -> Result<(), ThreatForgeError> {
+    let mut api_messages: Vec<serde_json::Value> = vec![serde_json::json!({
+        "role": "system",
+        "content": system_prompt,
+    })];
+
+    for m in messages {
+        if m.role == ChatRole::System {
+            continue;
+        }
+        api_messages.push(serde_json::json!({
+            "role": match m.role {
+                ChatRole::User => "user",
+                ChatRole::Assistant => "assistant",
+                ChatRole::System => "user",
+            },
+            "content": m.content,
+        }));
+    }
+
+    let body = serde_json::json!({
+        "model": OPENAI_MODEL,
+        "max_tokens": 4096,
+        "messages": api_messages,
+        "stream": true,
+    });
+
+    let response = client
+        .post(OPENAI_API_URL)
+        .header("Authorization", format!("Bearer {api_key}"))
+        .header("content-type", "application/json")
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| ThreatForgeError::AiRequest {
+            message: format!("OpenAI request failed: {e}"),
+        })?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(ThreatForgeError::AiRequest {
+            message: format!("OpenAI API error ({status}): {body}"),
+        });
+    }
+
+    let mut stream = response.bytes_stream();
+    let mut buffer = String::new();
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| ThreatForgeError::AiRequest {
+            message: format!("Stream read error: {e}"),
+        })?;
+
+        buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+        // Process complete SSE lines
+        while let Some(line_end) = buffer.find('\n') {
+            let line = buffer[..line_end].trim().to_string();
+            buffer = buffer[line_end + 1..].to_string();
+
+            if let Some(data) = line.strip_prefix("data: ") {
+                if data == "[DONE]" {
+                    return Ok(());
+                }
+                if let Ok(event) = serde_json::from_str::<serde_json::Value>(data) {
+                    // OpenAI SSE: look for choices[0].delta.content
+                    if let Some(text) = event
+                        .get("choices")
+                        .and_then(|c| c.get(0))
+                        .and_then(|c| c.get("delta"))
+                        .and_then(|d| d.get("content"))
+                        .and_then(|t| t.as_str())
+                    {
+                        let _ = app.emit("ai:stream-chunk", serde_json::json!({ "text": text }));
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_anthropic_sse_parsing() {
+        // Simulate an Anthropic SSE data line
+        let data = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#;
+        let event: serde_json::Value = serde_json::from_str(data).unwrap();
+
+        assert_eq!(
+            event.get("type").and_then(|t| t.as_str()),
+            Some("content_block_delta")
+        );
+        let text = event
+            .get("delta")
+            .and_then(|d| d.get("text"))
+            .and_then(|t| t.as_str());
+        assert_eq!(text, Some("Hello"));
+    }
+
+    #[test]
+    fn test_openai_sse_parsing() {
+        // Simulate an OpenAI SSE data line
+        let data = r#"{"id":"chatcmpl-123","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"World"},"finish_reason":null}]}"#;
+        let event: serde_json::Value = serde_json::from_str(data).unwrap();
+
+        let text = event
+            .get("choices")
+            .and_then(|c| c.get(0))
+            .and_then(|c| c.get("delta"))
+            .and_then(|d| d.get("content"))
+            .and_then(|t| t.as_str());
+        assert_eq!(text, Some("World"));
+    }
+
+    #[test]
+    fn test_anthropic_non_content_event_ignored() {
+        let data = r#"{"type":"message_start","message":{"id":"msg_123"}}"#;
+        let event: serde_json::Value = serde_json::from_str(data).unwrap();
+
+        // Should not match content_block_delta
+        assert_ne!(
+            event.get("type").and_then(|t| t.as_str()),
+            Some("content_block_delta")
+        );
+    }
+}

--- a/src-tauri/src/ai/types.rs
+++ b/src-tauri/src/ai/types.rs
@@ -1,0 +1,76 @@
+use serde::{Deserialize, Serialize};
+
+/// Supported AI providers
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum AiProvider {
+    Anthropic,
+    #[serde(rename = "openai")]
+    OpenAi,
+}
+
+impl AiProvider {
+    /// Keychain service suffix for this provider
+    pub fn keychain_key(&self) -> &str {
+        match self {
+            Self::Anthropic => "anthropic",
+            Self::OpenAi => "openai",
+        }
+    }
+}
+
+/// A single message in the chat conversation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatMessage {
+    pub role: ChatRole,
+    pub content: String,
+}
+
+/// Message roles
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ChatRole {
+    User,
+    Assistant,
+    System,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_provider_keychain_key() {
+        assert_eq!(AiProvider::Anthropic.keychain_key(), "anthropic");
+        assert_eq!(AiProvider::OpenAi.keychain_key(), "openai");
+    }
+
+    #[test]
+    fn test_provider_serialization() {
+        let json = serde_json::to_string(&AiProvider::Anthropic).unwrap();
+        assert_eq!(json, r#""anthropic""#);
+
+        let json = serde_json::to_string(&AiProvider::OpenAi).unwrap();
+        assert_eq!(json, r#""openai""#);
+    }
+
+    #[test]
+    fn test_provider_deserialization() {
+        let provider: AiProvider = serde_json::from_str(r#""anthropic""#).unwrap();
+        assert_eq!(provider, AiProvider::Anthropic);
+
+        let provider: AiProvider = serde_json::from_str(r#""openai""#).unwrap();
+        assert_eq!(provider, AiProvider::OpenAi);
+    }
+
+    #[test]
+    fn test_chat_message_serialization() {
+        let msg = ChatMessage {
+            role: ChatRole::User,
+            content: "Hello".to_string(),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains(r#""role":"user""#));
+        assert!(json.contains(r#""content":"Hello""#));
+    }
+}

--- a/src-tauri/src/commands/ai_commands.rs
+++ b/src-tauri/src/commands/ai_commands.rs
@@ -1,0 +1,45 @@
+use crate::ai::keychain;
+use crate::ai::prompt;
+use crate::ai::providers;
+use crate::ai::types::{AiProvider, ChatMessage};
+use crate::models::ThreatModel;
+use tauri::AppHandle;
+
+/// Store an API key in the OS keychain for a given provider
+#[tauri::command]
+pub fn set_api_key(provider: AiProvider, key: String) -> Result<(), String> {
+    keychain::store_key(&provider, &key).map_err(|e| e.to_string())
+}
+
+/// Check whether an API key exists for a given provider (returns bool, NOT the key)
+#[tauri::command]
+pub fn get_api_key_status(provider: AiProvider) -> Result<bool, String> {
+    keychain::has_key(&provider).map_err(|e| e.to_string())
+}
+
+/// Delete an API key from the OS keychain for a given provider
+#[tauri::command]
+pub fn delete_api_key(provider: AiProvider) -> Result<(), String> {
+    keychain::delete_key(&provider).map_err(|e| e.to_string())
+}
+
+/// Send a chat message to an LLM provider with streaming response.
+///
+/// The response is streamed back via Tauri events:
+/// - `ai:stream-chunk` — `{ "text": "..." }` for each text delta
+/// - `ai:stream-done` — `{}` when the stream completes
+/// - `ai:stream-error` — `{ "error": "..." }` on failure
+#[tauri::command]
+pub async fn send_chat_message(
+    app: AppHandle,
+    provider: AiProvider,
+    messages: Vec<ChatMessage>,
+    model: ThreatModel,
+) -> Result<(), String> {
+    let api_key = keychain::get_key(&provider).map_err(|e| e.to_string())?;
+    let system_prompt = prompt::build_system_prompt(&model);
+
+    providers::stream_chat(&app, &provider, &api_key, &system_prompt, &messages)
+        .await
+        .map_err(|e| e.to_string())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,5 +1,7 @@
+mod ai_commands;
 mod file_commands;
 mod stride_commands;
 
+pub use ai_commands::*;
 pub use file_commands::*;
 pub use stride_commands::*;

--- a/src-tauri/src/errors.rs
+++ b/src-tauri/src/errors.rs
@@ -33,9 +33,7 @@ pub enum ThreatForgeError {
     #[error("Failed to serialize JSON: {source}")]
     JsonSerialize { source: serde_json::Error },
 
-    #[error(
-        "Unsupported schema version '{version}'. Supported versions: {supported:?}"
-    )]
+    #[error("Unsupported schema version '{version}'. Supported versions: {supported:?}")]
     UnsupportedVersion {
         version: String,
         supported: Vec<String>,
@@ -50,4 +48,10 @@ pub enum ThreatForgeError {
         reference: String,
         valid: Vec<String>,
     },
+
+    #[error("Keychain error: {message}")]
+    Keychain { message: String },
+
+    #[error("AI request error: {message}")]
+    AiRequest { message: String },
 }

--- a/src-tauri/src/file_io/reader.rs
+++ b/src-tauri/src/file_io/reader.rs
@@ -234,6 +234,9 @@ data_flows:
         let file = write_temp_yaml(yaml);
         let result = read_threat_model(file.path());
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Invalid reference"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Invalid reference"));
     }
 }

--- a/src-tauri/src/file_io/writer.rs
+++ b/src-tauri/src/file_io/writer.rs
@@ -40,9 +40,8 @@ pub fn write_layout(path: &Path, layout: &DiagramLayout) -> Result<(), ThreatFor
         })?;
     }
 
-    let json = serde_json::to_string_pretty(layout).map_err(|e| ThreatForgeError::JsonSerialize {
-        source: e,
-    })?;
+    let json = serde_json::to_string_pretty(layout)
+        .map_err(|e| ThreatForgeError::JsonSerialize { source: e })?;
 
     std::fs::write(path, json).map_err(|e| ThreatForgeError::FileWrite {
         path: path.display().to_string(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod ai;
 mod commands;
 mod errors;
 mod file_io;
@@ -5,8 +6,8 @@ mod models;
 mod stride;
 
 use commands::{
-    analyze_stride, create_new_model, open_layout, open_threat_model, save_layout,
-    save_threat_model,
+    analyze_stride, create_new_model, delete_api_key, get_api_key_status, open_layout,
+    open_threat_model, save_layout, save_threat_model, send_chat_message, set_api_key,
 };
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -21,6 +22,10 @@ pub fn run() {
             open_layout,
             save_layout,
             analyze_stride,
+            set_api_key,
+            get_api_key_status,
+            delete_api_key,
+            send_chat_message,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/models/threat_model.rs
+++ b/src-tauri/src/models/threat_model.rs
@@ -217,7 +217,14 @@ pub fn generate_element_id(name: &str) -> String {
 
 /// Generate a unique threat ID
 pub fn generate_threat_id() -> String {
-    format!("threat-{}", Uuid::new_v4().as_simple().to_string().get(..8).unwrap_or("00000000"))
+    format!(
+        "threat-{}",
+        Uuid::new_v4()
+            .as_simple()
+            .to_string()
+            .get(..8)
+            .unwrap_or("00000000")
+    )
 }
 
 #[cfg(test)]
@@ -228,9 +235,11 @@ mod tests {
     fn test_serialize_deserialize_round_trip() {
         let model = ThreatModel::new("Test Model", "Test Author");
         let yaml = serde_yaml::to_string(&model).expect("Failed to serialize");
-        let deserialized: ThreatModel =
-            serde_yaml::from_str(&yaml).expect("Failed to deserialize");
-        assert_eq!(model, deserialized, "Round-trip serialization should produce equal models");
+        let deserialized: ThreatModel = serde_yaml::from_str(&yaml).expect("Failed to deserialize");
+        assert_eq!(
+            model, deserialized,
+            "Round-trip serialization should produce equal models"
+        );
     }
 
     #[test]
@@ -312,10 +321,7 @@ diagrams:
         assert_eq!(generate_element_id("Web Application"), "web-application");
         assert_eq!(generate_element_id("API Gateway"), "api-gateway");
         assert_eq!(generate_element_id("payment-db"), "payment-db");
-        assert_eq!(
-            generate_element_id("  Stripe  API  "),
-            "stripe-api"
-        );
+        assert_eq!(generate_element_id("  Stripe  API  "), "stripe-api");
     }
 
     #[test]

--- a/src-tauri/src/stride/mod.rs
+++ b/src-tauri/src/stride/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use crate::models::{
-    ElementType, Severity, StrideCategory, Threat, ThreatModel, TrustBoundary, generate_threat_id,
+    generate_threat_id, ElementType, Severity, StrideCategory, Threat, ThreatModel, TrustBoundary,
 };
 
 /// A rule template for generating STRIDE threats.
@@ -333,13 +333,11 @@ mod tests {
                 data: vec!["user_records".to_string()],
                 authenticated: true,
             }],
-            trust_boundaries: vec![
-                TrustBoundary {
-                    id: "boundary-1".to_string(),
-                    name: "Internal Network".to_string(),
-                    contains: vec!["web-app".to_string(), "db".to_string()],
-                },
-            ],
+            trust_boundaries: vec![TrustBoundary {
+                id: "boundary-1".to_string(),
+                name: "Internal Network".to_string(),
+                contains: vec!["web-app".to_string(), "db".to_string()],
+            }],
             threats: vec![],
             diagrams: vec![],
         }
@@ -354,7 +352,11 @@ mod tests {
             .filter(|t| t.element.as_deref() == Some("web-app"))
             .collect();
         // Process should get: Spoofing, Tampering, Repudiation, InfoDisclosure, DoS, EoP
-        assert_eq!(process_threats.len(), 6, "Process should have 6 STRIDE threats");
+        assert_eq!(
+            process_threats.len(),
+            6,
+            "Process should have 6 STRIDE threats"
+        );
     }
 
     #[test]
@@ -398,7 +400,11 @@ mod tests {
         let model = sample_model();
         let threats = analyze(&model);
         // 6 (process) + 3 (data_store) + 2 (external_entity) + 3 (flow) = 14
-        assert_eq!(threats.len(), 14, "Total should be 14 threats for the sample model");
+        assert_eq!(
+            threats.len(),
+            14,
+            "Total should be 14 threats for the sample model"
+        );
     }
 
     #[test]
@@ -419,8 +425,7 @@ mod tests {
         let spoofing_web: Vec<_> = threats
             .iter()
             .filter(|t| {
-                t.element.as_deref() == Some("web-app")
-                    && t.category == StrideCategory::Spoofing
+                t.element.as_deref() == Some("web-app") && t.category == StrideCategory::Spoofing
             })
             .collect();
         assert_eq!(
@@ -470,7 +475,10 @@ mod tests {
         let dos_threat = cross_flow_threats
             .iter()
             .find(|t| t.category == StrideCategory::DenialOfService);
-        assert!(dos_threat.is_some(), "Should have DoS threat for cross-boundary flow");
+        assert!(
+            dos_threat.is_some(),
+            "Should have DoS threat for cross-boundary flow"
+        );
         assert_eq!(
             dos_threat.unwrap().severity,
             Severity::High,
@@ -483,12 +491,9 @@ mod tests {
         let model = sample_model();
         let threats = analyze(&model);
         // flow-1 is web-app → db, both in boundary-1 (same boundary)
-        let dos_threat = threats
-            .iter()
-            .find(|t| {
-                t.flow.as_deref() == Some("flow-1")
-                    && t.category == StrideCategory::DenialOfService
-            });
+        let dos_threat = threats.iter().find(|t| {
+            t.flow.as_deref() == Some("flow-1") && t.category == StrideCategory::DenialOfService
+        });
         assert!(dos_threat.is_some());
         assert_eq!(
             dos_threat.unwrap().severity,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
 			}
 		],
 		"security": {
-			"csp": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: https://asset.localhost; font-src 'self' data:"
+			"csp": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: https://asset.localhost; font-src 'self' data:; connect-src 'self' https://api.anthropic.com https://api.openai.com ipc: http://ipc.localhost"
 		}
 	},
 	"bundle": {

--- a/src/components/panels/ai-chat-tab.tsx
+++ b/src/components/panels/ai-chat-tab.tsx
@@ -1,0 +1,360 @@
+import {
+	AlertCircle,
+	Bot,
+	Check,
+	Loader2,
+	Send,
+	Settings,
+	Sparkles,
+	Trash2,
+	User,
+} from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { extractThreats, suggestionToThreat } from "@/lib/ai-utils";
+import { cn } from "@/lib/utils";
+import { type ChatMessage, useChatStore } from "@/stores/chat-store";
+import { useModelStore } from "@/stores/model-store";
+import type { Threat } from "@/types/threat-model";
+import { AiSettingsDialog } from "./ai-settings-dialog";
+
+export function AiChatTab() {
+	const model = useModelStore((s) => s.model);
+	const hasApiKey = useChatStore((s) => s.hasApiKey);
+	const checkApiKey = useChatStore((s) => s.checkApiKey);
+	const [showSettings, setShowSettings] = useState(false);
+
+	// Check API key on mount
+	useEffect(() => {
+		void checkApiKey();
+	}, [checkApiKey]);
+
+	if (!model) {
+		return (
+			<p className="text-xs text-muted-foreground">Open a threat model to use AI assistance.</p>
+		);
+	}
+
+	return (
+		<div className="flex h-full flex-col">
+			{/* Header with settings */}
+			<div className="mb-2 flex items-center justify-between">
+				<div className="flex items-center gap-1.5">
+					<Sparkles className="h-3.5 w-3.5 text-primary" />
+					<span className="text-xs font-medium">AI Assistant</span>
+				</div>
+				<button
+					type="button"
+					onClick={() => setShowSettings(true)}
+					className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+					title="AI Settings"
+				>
+					<Settings className="h-3.5 w-3.5" />
+				</button>
+			</div>
+
+			{!hasApiKey ? <EmptyState onConfigure={() => setShowSettings(true)} /> : <ChatView />}
+
+			{showSettings && <AiSettingsDialog onClose={() => setShowSettings(false)} />}
+		</div>
+	);
+}
+
+function EmptyState({ onConfigure }: { onConfigure: () => void }) {
+	return (
+		<div className="flex flex-1 flex-col items-center justify-center gap-3 py-8 text-center">
+			<Bot className="h-10 w-10 text-muted-foreground/30" />
+			<div>
+				<p className="text-xs font-medium text-muted-foreground">No API key configured</p>
+				<p className="mt-1 text-[10px] text-muted-foreground/70">
+					Add your Anthropic or OpenAI API key to get AI-powered threat analysis.
+				</p>
+			</div>
+			<button
+				type="button"
+				onClick={onConfigure}
+				className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+			>
+				Configure API Key
+			</button>
+		</div>
+	);
+}
+
+function ChatView() {
+	const messages = useChatStore((s) => s.messages);
+	const isStreaming = useChatStore((s) => s.isStreaming);
+	const error = useChatStore((s) => s.error);
+	const clearError = useChatStore((s) => s.clearError);
+	const clearMessages = useChatStore((s) => s.clearMessages);
+
+	return (
+		<div className="flex flex-1 flex-col gap-2 overflow-hidden">
+			{/* Messages area */}
+			<MessageList messages={messages} isStreaming={isStreaming} />
+
+			{/* Error display */}
+			{error && (
+				<div className="flex items-start gap-1.5 rounded bg-destructive/10 px-2 py-1.5 text-xs text-destructive">
+					<AlertCircle className="mt-0.5 h-3 w-3 shrink-0" />
+					<div className="flex-1">{error}</div>
+					<button type="button" onClick={clearError} className="shrink-0 text-[10px] underline">
+						Dismiss
+					</button>
+				</div>
+			)}
+
+			{/* Clear chat button */}
+			{messages.length > 0 && !isStreaming && (
+				<button
+					type="button"
+					onClick={clearMessages}
+					className="flex items-center gap-1 self-start text-[10px] text-muted-foreground hover:text-foreground transition-colors"
+				>
+					<Trash2 className="h-2.5 w-2.5" />
+					Clear chat
+				</button>
+			)}
+
+			{/* Input */}
+			<ChatInput />
+		</div>
+	);
+}
+
+function MessageList({ messages, isStreaming }: { messages: ChatMessage[]; isStreaming: boolean }) {
+	const messagesEndRef = useRef<HTMLDivElement>(null);
+
+	// Auto-scroll to bottom on new messages
+	// biome-ignore lint/correctness/useExhaustiveDependencies: messages intentionally in deps to trigger scroll on content change
+	useEffect(() => {
+		messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+	}, [messages]);
+
+	if (messages.length === 0) {
+		return (
+			<div className="flex flex-1 flex-col items-center justify-center gap-2 py-8 text-center">
+				<Bot className="h-8 w-8 text-muted-foreground/20" />
+				<p className="text-[10px] text-muted-foreground/70">
+					Ask about threats, mitigations, or your architecture.
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-1 flex-col gap-2 overflow-y-auto">
+			{messages.map((msg, i) => (
+				<MessageBubble
+					// biome-ignore lint/suspicious/noArrayIndexKey: messages are append-only
+					key={i}
+					message={msg}
+					isLast={i === messages.length - 1}
+					isStreaming={isStreaming && i === messages.length - 1 && msg.role === "assistant"}
+				/>
+			))}
+			<div ref={messagesEndRef} />
+		</div>
+	);
+}
+
+function MessageBubble({
+	message,
+	isLast,
+	isStreaming,
+}: {
+	message: ChatMessage;
+	isLast: boolean;
+	isStreaming: boolean;
+}) {
+	const isUser = message.role === "user";
+
+	return (
+		<div className={cn("flex gap-2", isUser ? "flex-row-reverse" : "flex-row")}>
+			<div
+				className={cn(
+					"flex h-5 w-5 shrink-0 items-center justify-center rounded-full",
+					isUser ? "bg-primary/10" : "bg-secondary",
+				)}
+			>
+				{isUser ? (
+					<User className="h-3 w-3 text-primary" />
+				) : (
+					<Bot className="h-3 w-3 text-secondary-foreground" />
+				)}
+			</div>
+			<div
+				className={cn(
+					"max-w-[85%] rounded-lg px-2.5 py-1.5 text-xs",
+					isUser ? "bg-primary text-primary-foreground" : "bg-secondary text-secondary-foreground",
+				)}
+			>
+				{isUser ? (
+					<p className="whitespace-pre-wrap">{message.content}</p>
+				) : (
+					<AssistantContent content={message.content} isStreaming={isStreaming} isLast={isLast} />
+				)}
+			</div>
+		</div>
+	);
+}
+
+function AssistantContent({
+	content,
+	isStreaming,
+	isLast,
+}: {
+	content: string;
+	isStreaming: boolean;
+	isLast: boolean;
+}) {
+	const addThreat = useModelStore((s) => s.addThreat);
+	const [acceptedIds, setAcceptedIds] = useState<Set<number>>(new Set());
+
+	const threats = isLast && !isStreaming ? extractThreats(content) : [];
+
+	const handleAccept = useCallback(
+		(index: number, threat: Threat) => {
+			addThreat(threat);
+			setAcceptedIds((prev) => new Set([...prev, index]));
+		},
+		[addThreat],
+	);
+
+	// Render content with threats extracted as actionable cards
+	const displayContent = content.replace(/```threats\n[\s\S]*?```/g, "").trim();
+
+	return (
+		<div className="flex flex-col gap-2">
+			{displayContent && <p className="whitespace-pre-wrap">{displayContent}</p>}
+			{isStreaming && <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />}
+
+			{threats.length > 0 && (
+				<div className="flex flex-col gap-1.5 border-t border-border/30 pt-1.5">
+					<span className="text-[10px] font-medium text-muted-foreground">
+						Suggested threats ({threats.length}):
+					</span>
+					{threats.map((threat, i) => (
+						<ThreatSuggestionCard
+							// biome-ignore lint/suspicious/noArrayIndexKey: threat index is stable after streaming
+							key={i}
+							title={threat.title}
+							category={threat.category}
+							severity={threat.severity}
+							accepted={acceptedIds.has(i)}
+							onAccept={() => handleAccept(i, suggestionToThreat(threat))}
+						/>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}
+
+function ThreatSuggestionCard({
+	title,
+	category,
+	severity,
+	accepted,
+	onAccept,
+}: {
+	title: string;
+	category: string;
+	severity: string;
+	accepted: boolean;
+	onAccept: () => void;
+}) {
+	return (
+		<div className="flex items-start gap-1.5 rounded border border-border/50 bg-background/50 p-1.5">
+			<div className="flex-1">
+				<p className="text-[10px] font-medium">{title}</p>
+				<div className="mt-0.5 flex items-center gap-1">
+					<span className="rounded bg-secondary/50 px-1 py-0.5 text-[9px]">{category}</span>
+					<span className="rounded bg-secondary/50 px-1 py-0.5 text-[9px] capitalize">
+						{severity}
+					</span>
+				</div>
+			</div>
+			<button
+				type="button"
+				onClick={onAccept}
+				disabled={accepted}
+				className={cn(
+					"shrink-0 rounded p-1 transition-colors",
+					accepted ? "cursor-default text-green-500" : "text-primary hover:bg-primary/10",
+				)}
+				title={accepted ? "Accepted" : "Accept threat"}
+			>
+				<Check className="h-3.5 w-3.5" />
+			</button>
+		</div>
+	);
+}
+
+function ChatInput() {
+	const sendMessage = useChatStore((s) => s.sendMessage);
+	const isStreaming = useChatStore((s) => s.isStreaming);
+	const model = useModelStore((s) => s.model);
+	const [input, setInput] = useState("");
+	const inputRef = useRef<HTMLTextAreaElement>(null);
+
+	// Expose ref for keyboard shortcut focus
+	useEffect(() => {
+		function handleFocusChat(e: KeyboardEvent) {
+			const mod = e.metaKey || e.ctrlKey;
+			if (mod && e.key.toLowerCase() === "l") {
+				e.preventDefault();
+				inputRef.current?.focus();
+			}
+		}
+		window.addEventListener("keydown", handleFocusChat);
+		return () => window.removeEventListener("keydown", handleFocusChat);
+	}, []);
+
+	function handleSubmit() {
+		const trimmed = input.trim();
+		if (!trimmed || isStreaming || !model) return;
+
+		setInput("");
+		void sendMessage(trimmed, model);
+	}
+
+	function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+		if (e.key === "Enter" && !e.shiftKey) {
+			e.preventDefault();
+			handleSubmit();
+		}
+	}
+
+	return (
+		<div className="flex gap-1.5">
+			<textarea
+				ref={inputRef}
+				value={input}
+				onChange={(e) => setInput(e.target.value)}
+				onKeyDown={handleKeyDown}
+				placeholder="Ask about threats..."
+				rows={2}
+				disabled={isStreaming}
+				className="flex-1 resize-none rounded border border-border bg-background px-2 py-1.5 text-xs placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none disabled:opacity-50"
+			/>
+			<button
+				type="button"
+				onClick={handleSubmit}
+				disabled={!input.trim() || isStreaming}
+				className={cn(
+					"self-end rounded p-1.5 transition-colors",
+					input.trim() && !isStreaming
+						? "bg-primary text-primary-foreground hover:bg-primary/90"
+						: "cursor-not-allowed bg-muted text-muted-foreground",
+				)}
+				title="Send (Enter)"
+			>
+				{isStreaming ? (
+					<Loader2 className="h-3.5 w-3.5 animate-spin" />
+				) : (
+					<Send className="h-3.5 w-3.5" />
+				)}
+			</button>
+		</div>
+	);
+}

--- a/src/components/panels/ai-settings-dialog.tsx
+++ b/src/components/panels/ai-settings-dialog.tsx
@@ -1,0 +1,210 @@
+import { invoke } from "@tauri-apps/api/core";
+import { KeyRound, Loader2, Trash2, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+import { type AiProvider, useChatStore } from "@/stores/chat-store";
+
+const PROVIDERS: { value: AiProvider; label: string }[] = [
+	{ value: "anthropic", label: "Anthropic (Claude)" },
+	{ value: "openai", label: "OpenAI (GPT)" },
+];
+
+export function AiSettingsDialog({ onClose }: { onClose: () => void }) {
+	const provider = useChatStore((s) => s.provider);
+	const setProvider = useChatStore((s) => s.setProvider);
+	const checkApiKey = useChatStore((s) => s.checkApiKey);
+
+	const [apiKey, setApiKey] = useState("");
+	const [saving, setSaving] = useState(false);
+	const [deleting, setDeleting] = useState(false);
+	const [keyStatus, setKeyStatus] = useState<Record<AiProvider, boolean>>({
+		anthropic: false,
+		openai: false,
+	});
+	const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+
+	// Check key status on mount
+	useEffect(() => {
+		async function checkStatus() {
+			try {
+				const anthropicStatus = await invoke<boolean>("get_api_key_status", {
+					provider: "anthropic",
+				});
+				const openaiStatus = await invoke<boolean>("get_api_key_status", { provider: "openai" });
+				setKeyStatus({ anthropic: anthropicStatus, openai: openaiStatus });
+			} catch {
+				// Ignore errors — show as unconfigured
+			}
+		}
+		void checkStatus();
+	}, []);
+
+	async function handleSave() {
+		if (!apiKey.trim()) return;
+
+		setSaving(true);
+		setMessage(null);
+
+		try {
+			await invoke("set_api_key", { provider, key: apiKey.trim() });
+			setKeyStatus((prev) => ({ ...prev, [provider]: true }));
+			setApiKey("");
+			setMessage({ type: "success", text: "API key saved securely to OS keychain." });
+			await checkApiKey(provider);
+		} catch (err) {
+			setMessage({ type: "error", text: String(err) });
+		} finally {
+			setSaving(false);
+		}
+	}
+
+	async function handleDelete() {
+		setDeleting(true);
+		setMessage(null);
+
+		try {
+			await invoke("delete_api_key", { provider });
+			setKeyStatus((prev) => ({ ...prev, [provider]: false }));
+			setMessage({ type: "success", text: "API key removed from keychain." });
+			await checkApiKey(provider);
+		} catch (err) {
+			setMessage({ type: "error", text: String(err) });
+		} finally {
+			setDeleting(false);
+		}
+	}
+
+	function handleKeyDown(e: React.KeyboardEvent) {
+		if (e.key === "Escape") {
+			onClose();
+		}
+	}
+
+	return (
+		// biome-ignore lint/a11y/useKeyWithClickEvents: overlay click to close is a convenience, not the primary interaction
+		<div
+			className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+			onClick={(e) => {
+				if (e.target === e.currentTarget) onClose();
+			}}
+		>
+			<div
+				className="w-full max-w-md rounded-lg border border-border bg-background p-4 shadow-lg"
+				onKeyDown={handleKeyDown}
+			>
+				{/* Header */}
+				<div className="mb-4 flex items-center justify-between">
+					<div className="flex items-center gap-2">
+						<KeyRound className="h-4 w-4 text-muted-foreground" />
+						<h2 className="text-sm font-medium">AI Settings</h2>
+					</div>
+					<button
+						type="button"
+						onClick={onClose}
+						className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+					>
+						<X className="h-4 w-4" />
+					</button>
+				</div>
+
+				{/* Provider selector */}
+				<div className="mb-3">
+					<span className="mb-1 block text-[10px] font-medium text-muted-foreground">Provider</span>
+					<select
+						value={provider}
+						onChange={(e) => setProvider(e.target.value as AiProvider)}
+						className="w-full rounded border border-border bg-background px-2 py-1.5 text-xs focus:border-primary focus:outline-none"
+					>
+						{PROVIDERS.map((p) => (
+							<option key={p.value} value={p.value}>
+								{p.label}
+							</option>
+						))}
+					</select>
+				</div>
+
+				{/* Key status */}
+				<div className="mb-3 flex items-center gap-2">
+					<div
+						className={cn(
+							"h-2 w-2 rounded-full",
+							keyStatus[provider] ? "bg-green-500" : "bg-muted-foreground/30",
+						)}
+					/>
+					<span className="text-xs text-muted-foreground">
+						{keyStatus[provider] ? "API key configured" : "No API key configured"}
+					</span>
+				</div>
+
+				{/* API key input */}
+				<div className="mb-3">
+					<span className="mb-1 block text-[10px] font-medium text-muted-foreground">
+						{keyStatus[provider] ? "Replace API Key" : "API Key"}
+					</span>
+					<div className="flex gap-2">
+						<input
+							type="password"
+							value={apiKey}
+							onChange={(e) => setApiKey(e.target.value)}
+							placeholder={provider === "anthropic" ? "sk-ant-..." : "sk-..."}
+							className="flex-1 rounded border border-border bg-background px-2 py-1.5 text-xs placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none"
+							onKeyDown={(e) => {
+								if (e.key === "Enter") void handleSave();
+							}}
+						/>
+						<button
+							type="button"
+							onClick={() => void handleSave()}
+							disabled={!apiKey.trim() || saving}
+							className={cn(
+								"rounded px-3 py-1.5 text-xs font-medium transition-colors",
+								apiKey.trim()
+									? "bg-primary text-primary-foreground hover:bg-primary/90"
+									: "cursor-not-allowed bg-muted text-muted-foreground",
+							)}
+						>
+							{saving ? <Loader2 className="h-3 w-3 animate-spin" /> : "Save"}
+						</button>
+					</div>
+				</div>
+
+				{/* Delete button */}
+				{keyStatus[provider] && (
+					<button
+						type="button"
+						onClick={() => void handleDelete()}
+						disabled={deleting}
+						className="flex items-center gap-1 rounded px-2 py-1 text-xs text-destructive hover:bg-destructive/10 transition-colors"
+					>
+						{deleting ? (
+							<Loader2 className="h-3 w-3 animate-spin" />
+						) : (
+							<Trash2 className="h-3 w-3" />
+						)}
+						Remove API key
+					</button>
+				)}
+
+				{/* Status message */}
+				{message && (
+					<div
+						className={cn(
+							"mt-3 rounded px-2 py-1.5 text-xs",
+							message.type === "success"
+								? "bg-green-500/10 text-green-500"
+								: "bg-destructive/10 text-destructive",
+						)}
+					>
+						{message.text}
+					</div>
+				)}
+
+				{/* Security note */}
+				<p className="mt-3 text-[10px] text-muted-foreground/70">
+					API keys are stored securely in your operating system's keychain. They are never written
+					to files or sent anywhere except the selected AI provider.
+				</p>
+			</div>
+		</div>
+	);
+}

--- a/src/components/panels/right-panel.tsx
+++ b/src/components/panels/right-panel.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@/lib/utils";
 import { useModelStore } from "@/stores/model-store";
 import { useUiStore } from "@/stores/ui-store";
+import { AiChatTab } from "./ai-chat-tab";
 import { PropertiesTab } from "./properties-tab";
 import { ThreatsTab } from "./threats-tab";
 
@@ -24,11 +25,16 @@ export function RightPanel() {
 						</span>
 					)}
 				</TabButton>
+				<TabButton active={tab === "ai"} onClick={() => setTab("ai")}>
+					AI
+				</TabButton>
 			</div>
 
 			{/* Tab content */}
 			<div className="flex-1 overflow-y-auto p-3">
-				{tab === "properties" ? <PropertiesTab /> : <ThreatsTab />}
+				{tab === "properties" && <PropertiesTab />}
+				{tab === "threats" && <ThreatsTab />}
+				{tab === "ai" && <AiChatTab />}
 			</div>
 		</div>
 	);

--- a/src/hooks/use-keyboard-shortcuts.ts
+++ b/src/hooks/use-keyboard-shortcuts.ts
@@ -1,8 +1,10 @@
 import { useEffect } from "react";
+import { useUiStore } from "@/stores/ui-store";
 import { useFileOperations } from "./use-file-operations";
 
 export function useKeyboardShortcuts() {
 	const { newModel, openModel, saveModel } = useFileOperations();
+	const setRightPanelTab = useUiStore((s) => s.setRightPanelTab);
 
 	useEffect(() => {
 		function handleKeyDown(e: KeyboardEvent) {
@@ -22,10 +24,17 @@ export function useKeyboardShortcuts() {
 					e.preventDefault();
 					void saveModel();
 					break;
+				case "l":
+					e.preventDefault();
+					// Open AI tab and ensure right panel is visible
+					useUiStore.getState().rightPanelOpen || useUiStore.getState().toggleRightPanel();
+					setRightPanelTab("ai");
+					// Focus is handled by the ChatInput component's own keydown listener
+					break;
 			}
 		}
 
 		window.addEventListener("keydown", handleKeyDown);
 		return () => window.removeEventListener("keydown", handleKeyDown);
-	}, [newModel, openModel, saveModel]);
+	}, [newModel, openModel, saveModel, setRightPanelTab]);
 }

--- a/src/lib/ai-utils.test.ts
+++ b/src/lib/ai-utils.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import { extractThreats, generateThreatId, suggestionToThreat } from "./ai-utils";
+
+describe("extractThreats", () => {
+	it("extracts threats from a well-formed threats code block", () => {
+		const text = `Here are some threats I identified:
+
+\`\`\`threats
+- title: "SQL Injection via user input"
+  category: Tampering
+  element: api-gateway
+  severity: high
+  description: "Malicious SQL could be injected through unvalidated input."
+- title: "Man-in-the-middle attack"
+  category: Information Disclosure
+  element: web-app
+  severity: medium
+  description: "Data could be intercepted if TLS is not enforced."
+\`\`\`
+
+These threats should be addressed.`;
+
+		const threats = extractThreats(text);
+		expect(threats).toHaveLength(2);
+		expect(threats[0].title).toBe("SQL Injection via user input");
+		expect(threats[0].category).toBe("Tampering");
+		expect(threats[0].element).toBe("api-gateway");
+		expect(threats[0].severity).toBe("high");
+		expect(threats[1].title).toBe("Man-in-the-middle attack");
+		expect(threats[1].category).toBe("Information Disclosure");
+	});
+
+	it("returns empty array when no threats block found", () => {
+		const text = "This is a regular response without any threats.";
+		expect(extractThreats(text)).toHaveLength(0);
+	});
+
+	it("handles threats block with missing fields by skipping invalid entries", () => {
+		const text = `\`\`\`threats
+- title: "Valid threat"
+  category: Spoofing
+  severity: high
+  description: "A valid threat description."
+- title: "Invalid threat"
+  category: Spoofing
+\`\`\``;
+
+		const threats = extractThreats(text);
+		expect(threats).toHaveLength(1);
+		expect(threats[0].title).toBe("Valid threat");
+	});
+
+	it("handles threats without element field", () => {
+		const text = `\`\`\`threats
+- title: "General threat"
+  category: Denial of Service
+  severity: low
+  description: "A general system threat."
+\`\`\``;
+
+		const threats = extractThreats(text);
+		expect(threats).toHaveLength(1);
+		expect(threats[0].element).toBeUndefined();
+	});
+
+	it("rejects threats with invalid category", () => {
+		const text = `\`\`\`threats
+- title: "Bad category"
+  category: InvalidCategory
+  severity: high
+  description: "Should be rejected."
+\`\`\``;
+
+		expect(extractThreats(text)).toHaveLength(0);
+	});
+
+	it("rejects threats with invalid severity", () => {
+		const text = `\`\`\`threats
+- title: "Bad severity"
+  category: Spoofing
+  severity: extreme
+  description: "Should be rejected."
+\`\`\``;
+
+		expect(extractThreats(text)).toHaveLength(0);
+	});
+
+	it("handles multiple threats blocks in one response", () => {
+		const text = `First batch:
+\`\`\`threats
+- title: "Threat A"
+  category: Spoofing
+  severity: high
+  description: "First threat."
+\`\`\`
+
+Second batch:
+\`\`\`threats
+- title: "Threat B"
+  category: Tampering
+  severity: medium
+  description: "Second threat."
+\`\`\``;
+
+		const threats = extractThreats(text);
+		expect(threats).toHaveLength(2);
+		expect(threats[0].title).toBe("Threat A");
+		expect(threats[1].title).toBe("Threat B");
+	});
+
+	it("strips quotes from values", () => {
+		const text = `\`\`\`threats
+- title: 'Single quoted title'
+  category: Repudiation
+  severity: medium
+  description: "Double quoted description."
+\`\`\``;
+
+		const threats = extractThreats(text);
+		expect(threats).toHaveLength(1);
+		expect(threats[0].title).toBe("Single quoted title");
+		expect(threats[0].description).toBe("Double quoted description.");
+	});
+});
+
+describe("generateThreatId", () => {
+	it("generates IDs with threat- prefix", () => {
+		const id = generateThreatId();
+		expect(id).toMatch(/^threat-[0-9a-f]{8}$/);
+	});
+
+	it("generates unique IDs", () => {
+		const ids = new Set(Array.from({ length: 100 }, () => generateThreatId()));
+		expect(ids.size).toBe(100);
+	});
+});
+
+describe("suggestionToThreat", () => {
+	it("converts a suggestion to a full Threat object", () => {
+		const threat = suggestionToThreat({
+			title: "Test threat",
+			category: "Spoofing",
+			element: "web-app",
+			severity: "high",
+			description: "A test threat.",
+		});
+
+		expect(threat.id).toMatch(/^threat-/);
+		expect(threat.title).toBe("Test threat");
+		expect(threat.category).toBe("Spoofing");
+		expect(threat.element).toBe("web-app");
+		expect(threat.severity).toBe("high");
+		expect(threat.description).toBe("A test threat.");
+		expect(threat.mitigation).toBeUndefined();
+	});
+});

--- a/src/lib/ai-utils.ts
+++ b/src/lib/ai-utils.ts
@@ -1,0 +1,137 @@
+import type { Severity, StrideCategory, Threat } from "@/types/threat-model";
+
+const VALID_CATEGORIES: StrideCategory[] = [
+	"Spoofing",
+	"Tampering",
+	"Repudiation",
+	"Information Disclosure",
+	"Denial of Service",
+	"Elevation of Privilege",
+];
+
+const VALID_SEVERITIES: Severity[] = ["critical", "high", "medium", "low", "info"];
+
+interface ParsedThreatSuggestion {
+	title: string;
+	category: StrideCategory;
+	element?: string;
+	severity: Severity;
+	description: string;
+}
+
+/**
+ * Extract threat suggestions from AI response text.
+ * Looks for fenced code blocks with language tag `threats` containing YAML-like content.
+ */
+export function extractThreats(text: string): ParsedThreatSuggestion[] {
+	const threats: ParsedThreatSuggestion[] = [];
+	const codeBlockRegex = /```threats\n([\s\S]*?)```/g;
+
+	let match = codeBlockRegex.exec(text);
+	while (match !== null) {
+		const block = match[1];
+		const parsed = parseThreatsBlock(block);
+		threats.push(...parsed);
+		match = codeBlockRegex.exec(text);
+	}
+
+	return threats;
+}
+
+/**
+ * Parse a YAML-like threats block into threat suggestions.
+ * Uses simple line-based parsing — not a full YAML parser.
+ */
+function parseThreatsBlock(block: string): ParsedThreatSuggestion[] {
+	const threats: ParsedThreatSuggestion[] = [];
+	const lines = block.split("\n");
+
+	let current: Partial<ParsedThreatSuggestion> | null = null;
+
+	for (const line of lines) {
+		const trimmed = line.trim();
+
+		// New threat item starts with "- title:"
+		if (trimmed.startsWith("- title:")) {
+			if (current) {
+				const validated = validateThreat(current);
+				if (validated) threats.push(validated);
+			}
+			current = { title: extractValue(trimmed.slice("- title:".length)) };
+			continue;
+		}
+
+		if (!current) continue;
+
+		if (trimmed.startsWith("category:")) {
+			current.category = extractValue(trimmed.slice("category:".length)) as StrideCategory;
+		} else if (trimmed.startsWith("element:")) {
+			current.element = extractValue(trimmed.slice("element:".length));
+		} else if (trimmed.startsWith("severity:")) {
+			current.severity = extractValue(trimmed.slice("severity:".length)) as Severity;
+		} else if (trimmed.startsWith("description:")) {
+			current.description = extractValue(trimmed.slice("description:".length));
+		}
+	}
+
+	// Don't forget the last threat
+	if (current) {
+		const validated = validateThreat(current);
+		if (validated) threats.push(validated);
+	}
+
+	return threats;
+}
+
+/** Extract value from a YAML-like "key: value" pair, stripping quotes */
+function extractValue(raw: string): string {
+	const trimmed = raw.trim();
+	if (
+		(trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+		(trimmed.startsWith("'") && trimmed.endsWith("'"))
+	) {
+		return trimmed.slice(1, -1);
+	}
+	return trimmed;
+}
+
+/** Validate that a partial threat has all required fields with valid values */
+function validateThreat(partial: Partial<ParsedThreatSuggestion>): ParsedThreatSuggestion | null {
+	if (!partial.title || !partial.category || !partial.severity || !partial.description) {
+		return null;
+	}
+
+	if (!VALID_CATEGORIES.includes(partial.category)) {
+		return null;
+	}
+
+	if (!VALID_SEVERITIES.includes(partial.severity)) {
+		return null;
+	}
+
+	return {
+		title: partial.title,
+		category: partial.category,
+		element: partial.element,
+		severity: partial.severity,
+		description: partial.description,
+	};
+}
+
+/** Generate a unique threat ID for an AI-suggested threat */
+export function generateThreatId(): string {
+	const hex = Math.random().toString(16).slice(2, 10);
+	return `threat-${hex}`;
+}
+
+/** Convert a parsed threat suggestion into a full Threat object */
+export function suggestionToThreat(suggestion: ParsedThreatSuggestion): Threat {
+	return {
+		id: generateThreatId(),
+		title: suggestion.title,
+		category: suggestion.category,
+		element: suggestion.element,
+		severity: suggestion.severity,
+		description: suggestion.description,
+	};
+}

--- a/src/stores/chat-store.ts
+++ b/src/stores/chat-store.ts
@@ -1,0 +1,135 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { UnlistenFn } from "@tauri-apps/api/event";
+import { listen } from "@tauri-apps/api/event";
+import { create } from "zustand";
+import type { ThreatModel } from "@/types/threat-model";
+
+export type AiProvider = "anthropic" | "openai";
+
+export interface ChatMessage {
+	role: "user" | "assistant";
+	content: string;
+}
+
+interface ChatState {
+	/** Chat message history */
+	messages: ChatMessage[];
+	/** Whether the AI is currently streaming a response */
+	isStreaming: boolean;
+	/** Selected AI provider */
+	provider: AiProvider;
+	/** Whether the selected provider has an API key configured */
+	hasApiKey: boolean;
+	/** Error message from the last request, if any */
+	error: string | null;
+
+	// Actions
+	sendMessage: (content: string, model: ThreatModel) => Promise<void>;
+	setProvider: (provider: AiProvider) => void;
+	checkApiKey: (provider?: AiProvider) => Promise<void>;
+	clearMessages: () => void;
+	clearError: () => void;
+}
+
+export const useChatStore = create<ChatState>((set, get) => ({
+	messages: [],
+	isStreaming: false,
+	provider: "anthropic",
+	hasApiKey: false,
+	error: null,
+
+	sendMessage: async (content, model) => {
+		const { provider, messages, isStreaming } = get();
+		if (isStreaming) return;
+
+		const userMessage: ChatMessage = { role: "user", content };
+		const updatedMessages = [...messages, userMessage];
+		const assistantMessage: ChatMessage = { role: "assistant", content: "" };
+
+		set({
+			messages: [...updatedMessages, assistantMessage],
+			isStreaming: true,
+			error: null,
+		});
+
+		// Set up event listeners for streaming
+		const unlisteners: UnlistenFn[] = [];
+
+		try {
+			const unlisten1 = await listen<{ text: string }>("ai:stream-chunk", (event) => {
+				set((state) => {
+					const msgs = [...state.messages];
+					const last = msgs[msgs.length - 1];
+					if (last && last.role === "assistant") {
+						msgs[msgs.length - 1] = { ...last, content: last.content + event.payload.text };
+					}
+					return { messages: msgs };
+				});
+			});
+			unlisteners.push(unlisten1);
+
+			const donePromise = new Promise<void>((resolve, reject) => {
+				listen("ai:stream-done", () => {
+					resolve();
+				}).then((unlisten) => unlisteners.push(unlisten));
+
+				listen<{ error: string }>("ai:stream-error", (event) => {
+					reject(new Error(event.payload.error));
+				}).then((unlisten) => unlisteners.push(unlisten));
+			});
+
+			// Send the chat request to Rust backend
+			const ipcMessages = updatedMessages.map((m) => ({
+				role: m.role,
+				content: m.content,
+			}));
+
+			await invoke("send_chat_message", {
+				provider,
+				messages: ipcMessages,
+				model,
+			});
+
+			// Wait for stream to complete
+			await donePromise;
+		} catch (err) {
+			const errorMessage = err instanceof Error ? err.message : String(err);
+			set({ error: errorMessage });
+
+			// Remove the empty assistant message on error
+			set((state) => {
+				const msgs = [...state.messages];
+				const last = msgs[msgs.length - 1];
+				if (last && last.role === "assistant" && last.content === "") {
+					msgs.pop();
+				}
+				return { messages: msgs };
+			});
+		} finally {
+			// Clean up all event listeners
+			for (const unlisten of unlisteners) {
+				unlisten();
+			}
+			set({ isStreaming: false });
+		}
+	},
+
+	setProvider: (provider) => {
+		set({ provider });
+		// Check API key status for the new provider
+		get().checkApiKey(provider);
+	},
+
+	checkApiKey: async (providerOverride) => {
+		const provider = providerOverride ?? get().provider;
+		try {
+			const hasKey = await invoke<boolean>("get_api_key_status", { provider });
+			set({ hasApiKey: hasKey });
+		} catch {
+			set({ hasApiKey: false });
+		}
+	},
+
+	clearMessages: () => set({ messages: [], error: null }),
+	clearError: () => set({ error: null }),
+}));

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -1,19 +1,21 @@
 import { create } from "zustand";
 
+export type RightPanelTab = "properties" | "threats" | "ai";
+
 interface UiState {
 	/** Whether the left sidebar (component palette) is visible */
 	leftPanelOpen: boolean;
-	/** Whether the right panel (properties/threats) is visible */
+	/** Whether the right panel (properties/threats/ai) is visible */
 	rightPanelOpen: boolean;
 	/** Width of the right panel in pixels */
 	rightPanelWidth: number;
 	/** Current right panel tab */
-	rightPanelTab: "properties" | "threats";
+	rightPanelTab: RightPanelTab;
 
 	// Actions
 	toggleLeftPanel: () => void;
 	toggleRightPanel: () => void;
-	setRightPanelTab: (tab: "properties" | "threats") => void;
+	setRightPanelTab: (tab: RightPanelTab) => void;
 	setRightPanelWidth: (width: number) => void;
 }
 


### PR DESCRIPTION
## Summary

- Add AI chat tab to right panel with BYOK (bring your own key) support for Anthropic Claude and OpenAI GPT
- API keys stored securely in OS keychain via `keyring` crate — never written to files or logs
- Streaming responses via Tauri events with one-click threat acceptance from AI suggestions
- `Cmd/Ctrl+L` keyboard shortcut to focus AI chat input

### Rust backend (`src-tauri/src/ai/`)
- **types.rs** — `AiProvider` enum, `ChatMessage`, `ChatRole`
- **keychain.rs** — OS keychain CRUD (macOS Keychain, Windows Credential Manager, Linux Secret Service)
- **providers.rs** — Anthropic + OpenAI streaming HTTP clients with SSE parsing
- **prompt.rs** — System prompt builder that serializes full model context (elements, flows, boundaries, threats)
- **ai_commands.rs** — 4 Tauri commands: `set_api_key`, `get_api_key_status`, `delete_api_key`, `send_chat_message`

### Frontend
- **chat-store.ts** — Zustand store for chat messages, streaming state, provider selection
- **ai-utils.ts** — Parses AI responses for threat suggestions in fenced `threats` code blocks
- **ai-chat-tab.tsx** — Chat UI with message bubbles, streaming indicator, Accept Threat buttons
- **ai-settings-dialog.tsx** — API key configuration modal with provider selector and status indicator

### New Rust dependencies
`reqwest` (rustls-tls), `keyring`, `tokio`, `tokio-stream`, `futures`

## Test plan

- [x] `cargo test` — 33 tests pass (11 new AI tests)
- [x] `cargo clippy` — clean
- [x] `npx vitest --run` — 37 tests pass (11 new ai-utils tests)
- [x] `npx biome check .` — clean (40 files)
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: configure API key via settings dialog, send message, see streaming response
- [ ] Manual: AI suggests threats in response, click "Accept", threat appears in model
- [ ] Manual: switch between Anthropic and OpenAI providers
- [ ] Manual: delete API key, verify empty state shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)