### PR TITLE
feat(canvas): improve connectors, nodes, edge editing, context menus, and validation

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -32,7 +32,8 @@
 				"noUnusedVariables": "error"
 			},
 			"a11y": {
-				"noStaticElementInteractions": "off"
+				"noStaticElementInteractions": "off",
+				"noAutofocus": "off"
 			}
 		}
 	},

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -4,9 +4,28 @@ Shared execution plan for humans and LLM agents. Update this file before, during
 
 ---
 
+## 2026-02-28 — Boundary click fix + Draggable edge labels
+
+### Plan
+- [x] Fix trust boundary click stealing — make interior `pointer-events: none`, only border zone (8px inset) and name label capture clicks
+- [x] Replace parallel offset bezier with draggable label waypoint system
+  - [x] Remove `computeParallelOffset` / `getOffsetBezierPath` code
+  - [x] Add `labelOffsetX` / `labelOffsetY` to `DfdEdgeData`
+  - [x] When label exists + has been dragged, route edge through label as waypoint (`getWaypointPath`)
+  - [x] Make label draggable when selected (mousedown/mousemove/mouseup on document)
+  - [x] No label → standard bezier, no change
+- [x] Validate: tsc, biome, vitest all pass (92 tests)
+
+### Notes
+- Boundary interior is now `pointer-events: none` — only a thin border ring + the name label are clickable. This lets edges and inner nodes be selected without the boundary stealing the click.
+- Edge labels become movable waypoints: drag them when selected to reshape the edge path. The edge draws two quadratic bezier segments through the label position. When not dragged, the default bezier path is used.
+
+---
+
 ## 2026-02-28 — Parallel Edge Separation + Trust Boundary Properties
 
 ### Plan
+
 - [x] Fix parallel edge overlap — replace `curvature` param with custom bezier path using perpendicular control point offsets
 - [x] Add `selectedBoundaryId` + `setSelectedBoundary` to model-store
 - [x] Add `updateTrustBoundary` action to model-store
@@ -17,6 +36,7 @@ Shared execution plan for humans and LLM agents. Update this file before, during
 - [x] Validate: tsc, biome, vitest all pass (92 tests)
 
 ### Notes
+
 - `getBezierPath({ curvature })` only scales control point distance — it doesn't offset parallel edges. Replaced with custom `getOffsetBezierPath` that shifts control points perpendicular to the edge direction.
 - Boundary colors are stored in canvas node data (not in the YAML schema) — they are layout-level visual properties, consistent with ADR-006.
 - `setSelectedBoundary` clears both `selectedElementId` and `selectedEdgeId` (mutual exclusion).

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -382,3 +382,28 @@ The overall editor needs to be more tuned for keyboard accessibility / shortcuts
   - [ ] Component test keytip rendering: visible when setting is on, hidden when off
   - [ ] Integration test: change a setting → close/reopen app → setting persists
   - [ ] Keyboard navigation test: Tab through all controls, verify focus is visible and reachable
+
+## 2026-02-28 - Canvas Improvements: Edge UX & Properties Panel
+
+**Current state:** Completed on branch `feat/canvas-improvements`.
+
+### Plan
+
+- [x] Scale handles from 8 to 6 connection points (left/right midpoints + 4 corners)
+- [x] Remove parallel edge offset computation (caused handle detachment)
+- [x] Add `selectedEdgeId` state + `setSelectedEdge` action to model-store
+- [x] Add `updateDataFlow` action to model-store
+- [x] Add `onNodeClick`/`onEdgeClick` handlers to DFD canvas
+- [x] Build edge properties panel (Name, Protocol, Data, Authenticated, Flip Direction)
+- [x] Show "+" label button on selected edges (not just hover)
+- [x] Single-click on selected edge label opens editor
+- [x] Update smart handle routing for 6-handle corner layout
+- [x] Update canvas-utils tests for new handle IDs
+- [x] Lint (Biome + tsc) + all 93 tests pass
+- [x] Commit and push (`c83e0a0`)
+
+### Notes
+
+- Edge selection clears element selection and vice versa
+- Corner handles use `Position.Top`/`Position.Bottom` with `style={{ left: 0 }}` / `style={{ left: "100%" }}`
+- Smart routing picks `bottom-right`/`top-left` for target-below when dx >= 0

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -4,6 +4,25 @@ Shared execution plan for humans and LLM agents. Update this file before, during
 
 ---
 
+## 2026-02-28 — Parallel Edge Separation + Trust Boundary Properties
+
+### Plan
+- [x] Fix parallel edge overlap — replace `curvature` param with custom bezier path using perpendicular control point offsets
+- [x] Add `selectedBoundaryId` + `setSelectedBoundary` to model-store
+- [x] Add `updateTrustBoundary` action to model-store
+- [x] Add color fields to `DfdNodeData` (fillColor, strokeColor, fillOpacity, strokeOpacity)
+- [x] Handle boundary clicks in dfd-canvas (select instead of ignore)
+- [x] Add `TrustBoundaryProperties` component with name, fill color, stroke color (native picker + opacity slider)
+- [x] Apply custom colors in `TrustBoundaryNode` rendering
+- [x] Validate: tsc, biome, vitest all pass (92 tests)
+
+### Notes
+- `getBezierPath({ curvature })` only scales control point distance — it doesn't offset parallel edges. Replaced with custom `getOffsetBezierPath` that shifts control points perpendicular to the edge direction.
+- Boundary colors are stored in canvas node data (not in the YAML schema) — they are layout-level visual properties, consistent with ADR-006.
+- `setSelectedBoundary` clears both `selectedElementId` and `selectedEdgeId` (mutual exclusion).
+
+---
+
 ## 2026-02-27 - Theme Support
 
 Need to add support for themes in the UI. Currently only a dark theme is available, but we should allow users to not just choose between light and dark (and follow system), but also to select from a variety of color schemes and styles. Will have 2-3 themes for light and 2-3 themes for dark at launch, and then add more over time.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -15,12 +15,20 @@ Shared execution plan for humans and LLM agents. Update this file before, during
   - [x] When label exists + has been dragged, route edge through label as waypoint (`getWaypointPath`)
   - [x] Make label draggable when selected (mousedown/mousemove/mouseup on document)
   - [x] No label → standard bezier, no change
+- [x] Fix label drag interaction (click vs drag detection) — `didDrag` ref with 4px threshold
+- [x] Fix label drag root causes — remove `!selected` guard, zoom compensation, prevent deselection
+  - [x] Label mousedown always selects edge via `setSelectedEdge` (no selection prerequisite)
+  - [x] Drag deltas divided by viewport zoom for correct flow coordinates
+  - [x] `stopImmediatePropagation` on mousedown prevents ReactFlow pane deselection
+  - [x] Re-assert edge selection after drag ends
+  - [x] `wasSelectedBefore` ref: first click selects, second click opens editor
 - [x] Validate: tsc, biome, vitest all pass (92 tests)
 
 ### Notes
 
 - Boundary interior is now `pointer-events: none` — only a thin border ring + the name label are clickable. This lets edges and inner nodes be selected without the boundary stealing the click.
 - Edge labels become movable waypoints: drag them when selected to reshape the edge path. The edge draws two quadratic bezier segments through the label position. When not dragged, the default bezier path is used.
+- Label drag had three root causes: (1) `!selected` guard prevented drag on unselected edges since label clicks don't trigger ReactFlow edge selection, (2) drag deltas in screen pixels needed zoom division for flow coordinates, (3) mouseup propagated to pane causing deselection.
 
 ---
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -275,12 +275,20 @@ The canvas connector system requires significant improvements for better usabili
   - [ ] Add drop zone highlighting: when dragging over a trust boundary, highlight it to indicate the element will be added inside it
   - [x] Auto-assign elements to a trust boundary if dropped inside one (update `TrustBoundary.contains` array)
 - [x] Edge validation and constraints
-  - [x] Prevent duplicate edges: don't allow two edges between the same source→target pair (show a toast/notification explaining why)
+  - [x] Allow multiple edges between same pair: threat models require back-and-forth flows (e.g., "1. Login Request", "1b. Auth Token") — removed `isDuplicateEdge` blocking from `addDataFlow` and `isValidConnection`
   - [x] Prevent self-loops: don't allow connecting a node to itself
   - [x] Visual feedback on invalid connections: show a red highlight or "not allowed" cursor when hovering over an invalid target during edge creation
+  - [x] Parallel edge offset rendering: multiple edges between same pair fan out with perpendicular offset (20px spacing) so they don't overlap
+- [x] Edge naming support
+  - [x] Added `name` field to `DataFlow` in Rust schema (`#[serde(default)]` for backward compat) and TypeScript types
+  - [x] Edge label shows `name` as primary label with protocol/data as secondary detail
+  - [x] `EdgeLabelEditor` includes a name input field (autoFocus, commits to model store and canvas edges)
+  - [x] `addDataFlow` accepts optional `{ sourceHandle?, targetHandle?, name? }` — smart routing only as fallback when user hasn't explicitly chosen handles
 - [x] Testing
   - [x] Unit test smart handle position calculation
-  - [x] Unit test edge validation (no duplicates, no self-loops)
+  - [x] Unit test edge validation (no self-loops)
+  - [x] Unit test multiple edges between same pair allowed
+  - [x] Unit test handle and name opts passed through to addDataFlow
   - [ ] Component test inline editing on nodes and edges
   - [ ] Component test context menus render with correct actions
   - [ ] Visual regression test: verify node/edge renders haven't changed unexpectedly
@@ -289,7 +297,12 @@ The canvas connector system requires significant improvements for better usabili
 
 - Implemented smart handle positioning in `src/lib/canvas-utils.ts` with `getSmartHandlePair()` — selects optimal handle pair based on relative node positions
 - All nodes now use bidirectional handles via shared `NodeHandles` component (`shared-handles.tsx`) — each side has both source and target handles with hidden overlapping handles
-- Edge validation (no self-loops, no duplicates) implemented in both `canvas-store.addDataFlow()` and ReactFlow's `isValidConnection` callback
+- Edge validation (no self-loops) in both `canvas-store.addDataFlow()` and ReactFlow's `isValidConnection` callback
+- Multiple edges between the same pair are allowed — `isDuplicateEdge` removed from blocking paths
+- Parallel edges rendered with perpendicular offset via `computeParallelOffset()` in `DataFlowEdge`
+- `DataFlow` has a `name` field (Rust: `#[serde(default)]`, TS: defaults to `""`) for backward compat with existing files
+- `addDataFlow` accepts optional `{ sourceHandle?, targetHandle?, name? }` opts; smart routing via `getSmartHandlePair()` is only a fallback when handles not provided by user drag
+- `onConnect` in `dfd-canvas.tsx` passes `connection.sourceHandle/targetHandle` through to `addDataFlow`
 - Inline editing on all node types via double-click → input, with sync to both canvas-store and model-store
 - Edge inline editing supports two fields (protocol + data) in a compact editor overlay
 - Context menus built as a standalone `CanvasContextMenu` component with builder functions for node/edge-specific items

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -7,6 +7,7 @@ Shared execution plan for humans and LLM agents. Update this file before, during
 ## 2026-02-28 — Boundary click fix + Draggable edge labels
 
 ### Plan
+
 - [x] Fix trust boundary click stealing — make interior `pointer-events: none`, only border zone (8px inset) and name label capture clicks
 - [x] Replace parallel offset bezier with draggable label waypoint system
   - [x] Remove `computeParallelOffset` / `getOffsetBezierPath` code
@@ -17,6 +18,7 @@ Shared execution plan for humans and LLM agents. Update this file before, during
 - [x] Validate: tsc, biome, vitest all pass (92 tests)
 
 ### Notes
+
 - Boundary interior is now `pointer-events: none` — only a thin border ring + the name label are clickable. This lets edges and inner nodes be selected without the boundary stealing the click.
 - Edge labels become movable waypoints: drag them when selected to reshape the edge path. The edge draws two quadratic bezier segments through the label position. When not dragged, the default bezier path is used.
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -245,45 +245,59 @@ The canvas connector system requires significant improvements for better usabili
 
 **Tasks:**
 
-- [ ] Fix connector handle positioning and smart routing
-  - [ ] Implement a `getSmartHandlePositions` utility that, given source and target node positions, determines the optimal handle pair (top/bottom/left/right) to minimize edge crossings and path length
-  - [ ] Apply this in `onConnect` handler in `canvas-store.ts`: when creating a new edge, store `sourceHandle` and `targetHandle` IDs so ReactFlow uses the correct handles
-  - [ ] Assign unique IDs to each handle in node components (e.g., `id="top-target"`, `id="right-source"`) so they can be targeted programmatically
+- [x] Fix connector handle positioning and smart routing
+  - [x] Implement a `getSmartHandlePositions` utility that, given source and target node positions, determines the optimal handle pair (top/bottom/left/right) to minimize edge crossings and path length
+  - [x] Apply this in `onConnect` handler in `canvas-store.ts`: when creating a new edge, store `sourceHandle` and `targetHandle` IDs so ReactFlow uses the correct handles
+  - [x] Assign unique IDs to each handle in node components (e.g., `id="top-target"`, `id="right-source"`) so they can be targeted programmatically
   - [ ] Consider switching from `getBezierPath` to `getSmoothStepPath` for cleaner orthogonal routing, or implement custom pathfinding that avoids nodes
-  - [ ] Ensure handles on all four sides are functional: verify the `type` (source/target) assignment — currently top/left are target-only and bottom/right are source-only, which prevents some connection directions. Either make all handles bidirectional (`type="source"` on all, or use two overlapping handles per side) or explain the design constraint to users visually
-- [ ] Improve edge label rendering and interaction
-  - [ ] Add **inline label editing**: double-click on an edge label to enter edit mode (replace the label `<div>` with an `<input>` or `<textarea>`). On blur or Enter, commit the change to `canvas-store` and `model-store`
-  - [ ] Support editing both `protocol` and `data[]` fields inline: show "protocol · data1, data2" as the display, and split the edit into two inputs (or one smart input with a separator)
-  - [ ] Add edge label background styling that matches the edge color: selected edges should have `bg-tf-signal/10` label background, unselected edges keep `bg-card`
-  - [ ] Show a "+" add label button on edge hover when no label is present (for edges with empty protocol and data)
+  - [x] Ensure handles on all four sides are functional: verify the `type` (source/target) assignment — currently top/left are target-only and bottom/right are source-only, which prevents some connection directions. Either make all handles bidirectional (`type="source"` on all, or use two overlapping handles per side) or explain the design constraint to users visually
+- [x] Improve edge label rendering and interaction
+  - [x] Add **inline label editing**: double-click on an edge label to enter edit mode (replace the label `<div>` with an `<input>` or `<textarea>`). On blur or Enter, commit the change to `canvas-store` and `model-store`
+  - [x] Support editing both `protocol` and `data[]` fields inline: show "protocol · data1, data2" as the display, and split the edit into two inputs (or one smart input with a separator)
+  - [x] Add edge label background styling that matches the edge color: selected edges should have `bg-tf-signal/10` label background, unselected edges keep `bg-card`
+  - [x] Show a "+" add label button on edge hover when no label is present (for edges with empty protocol and data)
   - [ ] Make edge labels draggable to adjust position offset from the midpoint (store a `labelOffset` in edge data) — this is an advanced feature, can be deferred
-- [ ] Improve edge selection and interaction UX
-  - [ ] Increase the clickable/hoverable area of edges (currently 2px stroke is hard to click) — use an invisible wider stroke (10-12px) behind the visible edge for hit testing
-  - [ ] Add hover state: change edge color to a lighter version of the theme accent on hover (before click-to-select)
-  - [ ] Show animated flow direction indicator on hover or selection (a moving dot along the edge path, or animated dashes)
+- [x] Improve edge selection and interaction UX
+  - [x] Increase the clickable/hoverable area of edges (currently 2px stroke is hard to click) — use an invisible wider stroke (10-12px) behind the visible edge for hit testing
+  - [x] Add hover state: change edge color to a lighter version of the theme accent on hover (before click-to-select)
+  - [x] Show animated flow direction indicator on hover or selection (a moving dot along the edge path, or animated dashes)
   - [ ] When an edge is selected, highlight the connected source and target nodes with a subtle glow
-- [ ] Enhance node features and interactivity
-  - [ ] Add **inline node label editing**: double-click on a node label to edit the name in-place (replace the label `<div>` with an `<input>`). Commit on blur or Enter, updating both canvas-store and model-store
-  - [ ] Add resize handles to trust boundary nodes (they're group containers and need to be resizable to contain child elements)
-  - [ ] Add a visual indicator on nodes showing the count of linked threats (a small badge in the corner, e.g., "3 threats" with severity color)
-  - [ ] Add context menu on right-click for nodes: Edit Properties, Delete, Duplicate, Change Type (for element nodes), View Threats
-  - [ ] Add context menu on right-click for edges: Edit Properties, Delete, Reverse Direction
-  - [ ] Show technology badges on nodes: if `technologies[]` is populated, display small pills/tags below the node label
+- [x] Enhance node features and interactivity
+  - [x] Add **inline node label editing**: double-click on a node label to edit the name in-place (replace the label `<div>` with an `<input>`). Commit on blur or Enter, updating both canvas-store and model-store
+  - [x] Add resize handles to trust boundary nodes (they're group containers and need to be resizable to contain child elements)
+  - [x] Add a visual indicator on nodes showing the count of linked threats (a small badge in the corner, e.g., "3 threats" with severity color)
+  - [x] Add context menu on right-click for nodes: Edit Properties, Delete, Duplicate, Change Type (for element nodes), View Threats
+  - [x] Add context menu on right-click for edges: Edit Properties, Delete, Reverse Direction
+  - [x] Show technology badges on nodes: if `technologies[]` is populated, display small pills/tags below the node label
   - [ ] Add port/handle labels showing the connected flow's protocol on hover (so you can see what's connected without selecting)
 - [ ] Improve drag-and-drop from palette
   - [ ] Add visual feedback during drag: show a ghost preview of the node being dragged onto the canvas
   - [ ] Add drop zone highlighting: when dragging over a trust boundary, highlight it to indicate the element will be added inside it
-  - [ ] Auto-assign elements to a trust boundary if dropped inside one (update `TrustBoundary.contains` array)
-- [ ] Edge validation and constraints
-  - [ ] Prevent duplicate edges: don't allow two edges between the same source→target pair (show a toast/notification explaining why)
-  - [ ] Prevent self-loops: don't allow connecting a node to itself
-  - [ ] Visual feedback on invalid connections: show a red highlight or "not allowed" cursor when hovering over an invalid target during edge creation
-- [ ] Testing
-  - [ ] Unit test smart handle position calculation
-  - [ ] Unit test edge validation (no duplicates, no self-loops)
+  - [x] Auto-assign elements to a trust boundary if dropped inside one (update `TrustBoundary.contains` array)
+- [x] Edge validation and constraints
+  - [x] Prevent duplicate edges: don't allow two edges between the same source→target pair (show a toast/notification explaining why)
+  - [x] Prevent self-loops: don't allow connecting a node to itself
+  - [x] Visual feedback on invalid connections: show a red highlight or "not allowed" cursor when hovering over an invalid target during edge creation
+- [x] Testing
+  - [x] Unit test smart handle position calculation
+  - [x] Unit test edge validation (no duplicates, no self-loops)
   - [ ] Component test inline editing on nodes and edges
   - [ ] Component test context menus render with correct actions
   - [ ] Visual regression test: verify node/edge renders haven't changed unexpectedly
+
+### Notes
+
+- Implemented smart handle positioning in `src/lib/canvas-utils.ts` with `getSmartHandlePair()` — selects optimal handle pair based on relative node positions
+- All nodes now use bidirectional handles via shared `NodeHandles` component (`shared-handles.tsx`) — each side has both source and target handles with hidden overlapping handles
+- Edge validation (no self-loops, no duplicates) implemented in both `canvas-store.addDataFlow()` and ReactFlow's `isValidConnection` callback
+- Inline editing on all node types via double-click → input, with sync to both canvas-store and model-store
+- Edge inline editing supports two fields (protocol + data) in a compact editor overlay
+- Context menus built as a standalone `CanvasContextMenu` component with builder functions for node/edge-specific items
+- Added `duplicateElement()` and `reverseEdge()` actions to canvas-store
+- Auto-assign to trust boundary checks boundary positions on element drop
+- Trust boundaries now have `NodeResizeControl` from `@xyflow/react`
+- Threat count badges use a `useThreatCount(elementId)` hook that selects from model-store
+- Deferred items: orthogonal routing (`getSmoothStepPath`), draggable edge labels, connected node glow on edge select, drag ghost previews, drop zone highlighting, component tests for inline editing/context menus, visual regression tests
 
 ## 2026-02-27 - Editor improvements and settings modal
 

--- a/src-tauri/src/ai/prompt.rs
+++ b/src-tauri/src/ai/prompt.rs
@@ -172,6 +172,7 @@ mod tests {
         let mut model = ThreatModel::new("Test", "Author");
         model.data_flows.push(DataFlow {
             id: "flow-1".to_string(),
+            name: String::new(),
             from: "web-app".to_string(),
             to: "api-gw".to_string(),
             protocol: "HTTPS".to_string(),

--- a/src-tauri/src/models/threat_model.rs
+++ b/src-tauri/src/models/threat_model.rs
@@ -90,6 +90,8 @@ pub struct Element {
 #[serde(deny_unknown_fields)]
 pub struct DataFlow {
     pub id: String,
+    #[serde(default)]
+    pub name: String,
     pub from: String,
     pub to: String,
     #[serde(default)]

--- a/src-tauri/src/stride/mod.rs
+++ b/src-tauri/src/stride/mod.rs
@@ -327,6 +327,7 @@ mod tests {
             ],
             data_flows: vec![DataFlow {
                 id: "flow-1".to_string(),
+                name: String::new(),
                 from: "web-app".to_string(),
                 to: "db".to_string(),
                 protocol: "PostgreSQL/TLS".to_string(),
@@ -458,6 +459,7 @@ mod tests {
         // Add a flow from internal to external (crosses boundary)
         model.data_flows.push(DataFlow {
             id: "flow-2".to_string(),
+            name: String::new(),
             from: "web-app".to_string(),
             to: "user".to_string(),
             protocol: "HTTPS".to_string(),

--- a/src/components/canvas/canvas-context-menu.tsx
+++ b/src/components/canvas/canvas-context-menu.tsx
@@ -1,0 +1,109 @@
+import { ArrowLeftRight, Copy, Pencil, Shield, Trash2 } from "lucide-react";
+import { useEffect, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+interface ContextMenuItem {
+	label: string;
+	icon: React.ComponentType<{ className?: string }>;
+	onClick: () => void;
+	variant?: "danger";
+}
+
+interface CanvasContextMenuProps {
+	x: number;
+	y: number;
+	items: ContextMenuItem[];
+	onClose: () => void;
+}
+
+export function CanvasContextMenu({ x, y, items, onClose }: CanvasContextMenuProps) {
+	const menuRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		function handleClickOutside(event: MouseEvent) {
+			if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+				onClose();
+			}
+		}
+		function handleEscape(event: KeyboardEvent) {
+			if (event.key === "Escape") onClose();
+		}
+		document.addEventListener("mousedown", handleClickOutside);
+		document.addEventListener("keydown", handleEscape);
+		return () => {
+			document.removeEventListener("mousedown", handleClickOutside);
+			document.removeEventListener("keydown", handleEscape);
+		};
+	}, [onClose]);
+
+	return (
+		<div
+			ref={menuRef}
+			className="fixed z-50 min-w-[160px] rounded-md border border-border bg-card py-1 shadow-lg"
+			style={{ left: x, top: y }}
+		>
+			{items.map((item) => (
+				<button
+					type="button"
+					key={item.label}
+					className={cn(
+						"flex w-full items-center gap-2 px-3 py-1.5 text-xs transition-colors",
+						item.variant === "danger"
+							? "text-red-400 hover:bg-red-400/10"
+							: "text-foreground hover:bg-accent",
+					)}
+					onClick={() => {
+						item.onClick();
+						onClose();
+					}}
+				>
+					<item.icon className="h-3.5 w-3.5" />
+					{item.label}
+				</button>
+			))}
+		</div>
+	);
+}
+
+/** Build menu items for a node context menu */
+export function buildNodeMenuItems({
+	onEditProperties,
+	onDelete,
+	onDuplicate,
+	onViewThreats,
+}: {
+	onEditProperties: () => void;
+	onDelete: () => void;
+	onDuplicate: () => void;
+	onViewThreats: () => void;
+}): ContextMenuItem[] {
+	return [
+		{ label: "Edit Properties", icon: Pencil, onClick: onEditProperties },
+		{ label: "View Threats", icon: Shield, onClick: onViewThreats },
+		{ label: "Duplicate", icon: Copy, onClick: onDuplicate },
+		{ label: "Delete", icon: Trash2, onClick: onDelete, variant: "danger" },
+	];
+}
+
+/** Build menu items for an edge context menu */
+export function buildEdgeMenuItems({
+	onEditProperties,
+	onDelete,
+	onReverseDirection,
+}: {
+	onEditProperties: () => void;
+	onDelete: () => void;
+	onReverseDirection: () => void;
+}): ContextMenuItem[] {
+	return [
+		{ label: "Edit Properties", icon: Pencil, onClick: onEditProperties },
+		{
+			label: "Reverse Direction",
+			icon: ArrowLeftRight,
+			onClick: onReverseDirection,
+		},
+		{ label: "Delete", icon: Trash2, onClick: onDelete, variant: "danger" },
+	];
+}
+
+export type { ContextMenuItem };

--- a/src/components/canvas/dfd-canvas.tsx
+++ b/src/components/canvas/dfd-canvas.tsx
@@ -10,7 +10,7 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { isDuplicateEdge, isSelfLoop } from "@/lib/canvas-utils";
+import { isSelfLoop } from "@/lib/canvas-utils";
 import type { DfdEdge, DfdNode } from "@/stores/canvas-store";
 import { useCanvasStore } from "@/stores/canvas-store";
 import { useModelStore } from "@/stores/model-store";
@@ -96,7 +96,10 @@ export function DfdCanvas() {
 	const onConnect = useCallback(
 		(connection: Connection) => {
 			if (connection.source && connection.target) {
-				addDataFlow(connection.source, connection.target);
+				addDataFlow(connection.source, connection.target, {
+					sourceHandle: connection.sourceHandle ?? undefined,
+					targetHandle: connection.targetHandle ?? undefined,
+				});
 			}
 			connectingNodeId.current = null;
 		},
@@ -111,16 +114,12 @@ export function DfdCanvas() {
 		connectingNodeId.current = null;
 	}, []);
 
-	/** Validates whether a connection is allowed (no self-loops, no duplicates) */
-	const isValidConnection = useCallback(
-		(connection: Connection | DfdEdge) => {
-			if (!connection.source || !connection.target) return false;
-			if (isSelfLoop(connection.source, connection.target)) return false;
-			if (isDuplicateEdge(edges, connection.source, connection.target)) return false;
-			return true;
-		},
-		[edges],
-	);
+	/** Validates whether a connection is allowed (no self-loops) */
+	const isValidConnection = useCallback((connection: Connection | DfdEdge) => {
+		if (!connection.source || !connection.target) return false;
+		if (isSelfLoop(connection.source, connection.target)) return false;
+		return true;
+	}, []);
 
 	const onDragOver = useCallback((event: React.DragEvent) => {
 		event.preventDefault();

--- a/src/components/canvas/dfd-canvas.tsx
+++ b/src/components/canvas/dfd-canvas.tsx
@@ -164,12 +164,16 @@ export function DfdCanvas() {
 	const onPaneClick = useCallback(() => {
 		useModelStore.getState().setSelectedElement(null);
 		useModelStore.getState().setSelectedEdge(null);
+		useModelStore.getState().setSelectedBoundary(null);
 		setContextMenu(null);
 	}, []);
 
 	const onNodeClick = useCallback((_event: React.MouseEvent, node: DfdNode) => {
-		if (node.data.isBoundary) return;
-		useModelStore.getState().setSelectedElement(node.id);
+		if (node.data.isBoundary) {
+			useModelStore.getState().setSelectedBoundary(node.id);
+		} else {
+			useModelStore.getState().setSelectedElement(node.id);
+		}
 		useUiStore.getState().setRightPanelTab("properties");
 	}, []);
 

--- a/src/components/canvas/dfd-canvas.tsx
+++ b/src/components/canvas/dfd-canvas.tsx
@@ -163,7 +163,19 @@ export function DfdCanvas() {
 
 	const onPaneClick = useCallback(() => {
 		useModelStore.getState().setSelectedElement(null);
+		useModelStore.getState().setSelectedEdge(null);
 		setContextMenu(null);
+	}, []);
+
+	const onNodeClick = useCallback((_event: React.MouseEvent, node: DfdNode) => {
+		if (node.data.isBoundary) return;
+		useModelStore.getState().setSelectedElement(node.id);
+		useUiStore.getState().setRightPanelTab("properties");
+	}, []);
+
+	const onEdgeClick = useCallback((_event: React.MouseEvent, edge: DfdEdge) => {
+		useModelStore.getState().setSelectedEdge(edge.id);
+		useUiStore.getState().setRightPanelTab("properties");
 	}, []);
 
 	const onNodeContextMenu = useCallback((event: React.MouseEvent, node: DfdNode) => {
@@ -210,7 +222,8 @@ export function DfdCanvas() {
 		if (contextMenu.edgeId) {
 			return buildEdgeMenuItems({
 				onEditProperties: () => {
-					/* Edge properties are edited via inline label editing */
+					useModelStore.getState().setSelectedEdge(contextMenu.edgeId ?? null);
+					useUiStore.getState().setRightPanelTab("properties");
 				},
 				onDelete: () => {
 					const edgeId = contextMenu.edgeId;
@@ -264,6 +277,8 @@ export function DfdCanvas() {
 				onDragOver={onDragOver}
 				onDrop={onDrop}
 				onPaneClick={onPaneClick}
+				onNodeClick={onNodeClick}
+				onEdgeClick={onEdgeClick}
 				onNodeContextMenu={onNodeContextMenu}
 				onEdgeContextMenu={onEdgeContextMenu}
 				nodeTypes={nodeTypes}

--- a/src/components/canvas/edges/data-flow-edge.tsx
+++ b/src/components/canvas/edges/data-flow-edge.tsx
@@ -3,133 +3,34 @@ import {
 	EdgeLabelRenderer,
 	type EdgeProps,
 	getBezierPath,
-	useEdges,
 	useReactFlow,
 } from "@xyflow/react";
 import { Plus } from "lucide-react";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import type { DfdEdgeData } from "@/stores/canvas-store";
 import { useModelStore } from "@/stores/model-store";
 
-/** Perpendicular offset in pixels between parallel edges */
-const PARALLEL_OFFSET_PX = 25;
-
 /**
- * Compute the perpendicular offset index for this edge when multiple edges
- * connect the same pair of nodes (in either direction). Returns 0 for single
- * edges, and a centered spread for multiple siblings (e.g. -1, 0, 1 for 3).
+ * Build two quadratic bezier segments that route through a waypoint.
+ * source → waypoint → target, producing a smooth path.
  */
-function computeParallelOffset(
-	allEdges: ReadonlyArray<{ id: string; source: string; target: string }>,
-	currentId: string,
-	source: string,
-	target: string,
-): number {
-	const siblings = allEdges.filter(
-		(e) =>
-			(e.source === source && e.target === target) || (e.source === target && e.target === source),
-	);
-	if (siblings.length <= 1) return 0;
-
-	const sorted = [...siblings].sort((a, b) => a.id.localeCompare(b.id));
-	const index = sorted.findIndex((e) => e.id === currentId);
-	const count = sorted.length;
-	return index - (count - 1) / 2;
-}
-
-/**
- * Build a cubic bezier SVG path with control points shifted perpendicular
- * to the source→target direction. This visually fans out parallel edges
- * instead of drawing them on top of each other.
- *
- * Returns [path, labelX, labelY].
- */
-function getOffsetBezierPath(
+function getWaypointPath(
 	sx: number,
 	sy: number,
 	tx: number,
 	ty: number,
-	sourcePosition: string,
-	targetPosition: string,
-	offset: number,
-): [string, number, number] {
-	// If no offset needed, use the standard path
-	if (offset === 0) {
-		const [path, lx, ly] = getBezierPath({
-			sourceX: sx,
-			sourceY: sy,
-			sourcePosition: sourcePosition as never,
-			targetX: tx,
-			targetY: ty,
-			targetPosition: targetPosition as never,
-		});
-		return [path, lx, ly];
-	}
-
-	const dx = tx - sx;
-	const dy = ty - sy;
-	const dist = Math.sqrt(dx * dx + dy * dy) || 1;
-
-	// Perpendicular unit vector (rotated 90° counter-clockwise)
-	const px = -dy / dist;
-	const py = dx / dist;
-
-	const perpOffset = offset * PARALLEL_OFFSET_PX;
-
-	// Control point distance along the axis (same as default bezier)
-	const controlDist = dist * 0.25;
-
-	// Compute control points with perpendicular offset
-	let cx1: number;
-	let cy1: number;
-	let cx2: number;
-	let cy2: number;
-
-	// Extend control points along the source/target handle direction,
-	// then shift them perpendicular
-	if (sourcePosition === "bottom") {
-		cx1 = sx + px * perpOffset;
-		cy1 = sy + controlDist + py * perpOffset;
-	} else if (sourcePosition === "top") {
-		cx1 = sx + px * perpOffset;
-		cy1 = sy - controlDist + py * perpOffset;
-	} else if (sourcePosition === "right") {
-		cx1 = sx + controlDist + px * perpOffset;
-		cy1 = sy + py * perpOffset;
-	} else {
-		// left
-		cx1 = sx - controlDist + px * perpOffset;
-		cy1 = sy + py * perpOffset;
-	}
-
-	if (targetPosition === "top") {
-		cx2 = tx + px * perpOffset;
-		cy2 = ty - controlDist + py * perpOffset;
-	} else if (targetPosition === "bottom") {
-		cx2 = tx + px * perpOffset;
-		cy2 = ty + controlDist + py * perpOffset;
-	} else if (targetPosition === "left") {
-		cx2 = tx - controlDist + px * perpOffset;
-		cy2 = ty + py * perpOffset;
-	} else {
-		// right
-		cx2 = tx + controlDist + px * perpOffset;
-		cy2 = ty + py * perpOffset;
-	}
-
-	const path = `M ${sx},${sy} C ${cx1},${cy1} ${cx2},${cy2} ${tx},${ty}`;
-	// Label at the curve midpoint (t=0.5 of cubic bezier)
-	const labelX = 0.125 * sx + 0.375 * cx1 + 0.375 * cx2 + 0.125 * tx;
-	const labelY = 0.125 * sy + 0.375 * cy1 + 0.375 * cy2 + 0.125 * ty;
-
-	return [path, labelX, labelY];
+	wx: number,
+	wy: number,
+): string {
+	// Quadratic bezier using waypoint as control point, ending at target
+	const mid2x = (wx + tx) / 2;
+	const mid2y = (wy + ty) / 2;
+	return `M ${sx},${sy} Q ${wx},${wy} ${mid2x},${mid2y} T ${tx},${ty}`;
 }
 
 export function DataFlowEdge({
 	id,
-	source,
-	target,
 	sourceX,
 	sourceY,
 	targetX,
@@ -141,32 +42,86 @@ export function DataFlowEdge({
 	markerEnd,
 }: EdgeProps) {
 	const edgeData = data as DfdEdgeData | undefined;
-	const allEdges = useEdges();
+	const { setEdges } = useReactFlow();
 
-	const parallelOffset = useMemo(
-		() => computeParallelOffset(allEdges, id, source, target),
-		[allEdges, id, source, target],
-	);
+	// Default label position (midpoint of standard bezier)
+	const [defaultPath, defaultLabelX, defaultLabelY] = getBezierPath({
+		sourceX,
+		sourceY,
+		sourcePosition,
+		targetX,
+		targetY,
+		targetPosition,
+	});
 
-	const [edgePath, labelX, labelY] = useMemo(
-		() =>
-			getOffsetBezierPath(
-				sourceX,
-				sourceY,
-				targetX,
-				targetY,
-				sourcePosition,
-				targetPosition,
-				parallelOffset,
-			),
-		[sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition, parallelOffset],
-	);
+	const hasLabel =
+		edgeData?.name || edgeData?.protocol || (edgeData?.data && edgeData.data.length > 0);
+
+	// Custom label position (user-dragged offset from default)
+	const offsetX = (edgeData?.labelOffsetX as number) ?? 0;
+	const offsetY = (edgeData?.labelOffsetY as number) ?? 0;
+	const hasCustomPosition = offsetX !== 0 || offsetY !== 0;
+
+	const labelX = defaultLabelX + offsetX;
+	const labelY = defaultLabelY + offsetY;
+
+	// When a label exists and has been dragged, route edge through the label as a waypoint
+	const edgePath =
+		hasLabel && hasCustomPosition
+			? getWaypointPath(sourceX, sourceY, targetX, targetY, labelX, labelY)
+			: defaultPath;
 
 	const [isHovered, setIsHovered] = useState(false);
 	const [isEditing, setIsEditing] = useState(false);
 
-	const hasLabel =
-		edgeData?.name || edgeData?.protocol || (edgeData?.data && edgeData.data.length > 0);
+	// --- Draggable label logic ---
+	const isDragging = useRef(false);
+	const dragStartPos = useRef({ x: 0, y: 0 });
+	const dragStartOffset = useRef({ x: 0, y: 0 });
+
+	const onLabelMouseDown = useCallback(
+		(e: React.MouseEvent) => {
+			// Only start drag on primary button and when selected
+			if (e.button !== 0 || !selected) return;
+			e.stopPropagation();
+			e.preventDefault();
+			isDragging.current = true;
+			dragStartPos.current = { x: e.clientX, y: e.clientY };
+			dragStartOffset.current = { x: offsetX, y: offsetY };
+
+			const onMouseMove = (ev: MouseEvent) => {
+				if (!isDragging.current) return;
+				const dx = ev.clientX - dragStartPos.current.x;
+				const dy = ev.clientY - dragStartPos.current.y;
+				// Update edge data with new offset
+				setEdges((edges) =>
+					edges.map((edge) =>
+						edge.id === id
+							? {
+									...edge,
+									data: {
+										...edge.data,
+										labelOffsetX: dragStartOffset.current.x + dx,
+										labelOffsetY: dragStartOffset.current.y + dy,
+									},
+								}
+							: edge,
+					),
+				);
+			};
+
+			const onMouseUp = () => {
+				isDragging.current = false;
+				document.removeEventListener("mousemove", onMouseMove);
+				document.removeEventListener("mouseup", onMouseUp);
+				useModelStore.getState().markDirty();
+			};
+
+			document.addEventListener("mousemove", onMouseMove);
+			document.addEventListener("mouseup", onMouseUp);
+		},
+		[id, selected, offsetX, offsetY, setEdges],
+	);
 
 	return (
 		<>
@@ -217,10 +172,10 @@ export function DataFlowEdge({
 					<button
 						type="button"
 						className={cn(
-							"pointer-events-all nodrag nopan absolute cursor-pointer rounded border px-1.5 py-0.5 text-left transition-colors",
+							"pointer-events-all nodrag nopan absolute rounded border px-1.5 py-0.5 text-left transition-colors",
 							selected
-								? "border-tf-signal bg-tf-signal/10 text-foreground"
-								: "border-border bg-card text-muted-foreground hover:border-muted-foreground",
+								? "border-tf-signal bg-tf-signal/10 text-foreground cursor-grab active:cursor-grabbing"
+								: "border-border bg-card text-muted-foreground hover:border-muted-foreground cursor-pointer",
 						)}
 						style={{
 							transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
@@ -229,6 +184,7 @@ export function DataFlowEdge({
 						onClick={() => {
 							if (selected) setIsEditing(true);
 						}}
+						onMouseDown={onLabelMouseDown}
 					>
 						{edgeData?.name && (
 							<div className="text-[11px] font-medium text-foreground">{edgeData.name}</div>

--- a/src/components/canvas/edges/data-flow-edge.tsx
+++ b/src/components/canvas/edges/data-flow-edge.tsx
@@ -1,6 +1,15 @@
-import { BaseEdge, EdgeLabelRenderer, type EdgeProps, getBezierPath } from "@xyflow/react";
+import {
+	BaseEdge,
+	EdgeLabelRenderer,
+	type EdgeProps,
+	getBezierPath,
+	useReactFlow,
+} from "@xyflow/react";
+import { Plus } from "lucide-react";
+import { useCallback, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import type { DfdEdgeData } from "@/stores/canvas-store";
+import { useModelStore } from "@/stores/model-store";
 
 export function DataFlowEdge({
 	id,
@@ -24,33 +33,178 @@ export function DataFlowEdge({
 		targetPosition,
 	});
 
+	const [isHovered, setIsHovered] = useState(false);
+	const [isEditing, setIsEditing] = useState(false);
+
 	const hasLabel = edgeData?.protocol || (edgeData?.data && edgeData.data.length > 0);
 
 	return (
 		<>
+			{/* Invisible wider path for easier click/hover targeting */}
+			<path
+				d={edgePath}
+				fill="none"
+				strokeWidth={16}
+				className="stroke-transparent"
+				onMouseEnter={() => setIsHovered(true)}
+				onMouseLeave={() => setIsHovered(false)}
+				style={{ pointerEvents: "stroke" }}
+			/>
 			<BaseEdge
 				id={id}
 				path={edgePath}
 				markerEnd={markerEnd}
-				className={cn("!stroke-2", selected ? "!stroke-tf-signal" : "!stroke-muted-foreground/50")}
+				className={cn(
+					"!stroke-2 transition-colors",
+					selected
+						? "!stroke-tf-signal"
+						: isHovered
+							? "!stroke-muted-foreground/80"
+							: "!stroke-muted-foreground/50",
+				)}
 			/>
-			{hasLabel && (
-				<EdgeLabelRenderer>
+			{/* Animated flow direction dashes on hover/selection */}
+			{(isHovered || selected) && (
+				<path
+					d={edgePath}
+					fill="none"
+					strokeWidth={2}
+					className="stroke-tf-signal/40"
+					strokeDasharray="6 4"
+					style={{ pointerEvents: "none" }}
+				>
+					<animate
+						attributeName="stroke-dashoffset"
+						from="0"
+						to="-20"
+						dur="1s"
+						repeatCount="indefinite"
+					/>
+				</path>
+			)}
+			<EdgeLabelRenderer>
+				{hasLabel && !isEditing && (
 					<div
 						className={cn(
-							"pointer-events-all nodrag nopan absolute rounded border bg-card px-1.5 py-0.5 text-[10px]",
-							selected ? "border-tf-signal text-foreground" : "border-border text-muted-foreground",
+							"pointer-events-all nodrag nopan absolute cursor-pointer rounded border px-1.5 py-0.5 text-[10px] transition-colors",
+							selected
+								? "border-tf-signal bg-tf-signal/10 text-foreground"
+								: "border-border bg-card text-muted-foreground hover:border-muted-foreground",
 						)}
 						style={{
 							transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
 						}}
+						onDoubleClick={() => setIsEditing(true)}
 					>
 						{edgeData?.protocol && <span>{edgeData.protocol}</span>}
 						{edgeData?.protocol && edgeData?.data && edgeData.data.length > 0 && <span> · </span>}
 						{edgeData?.data && edgeData.data.length > 0 && <span>{edgeData.data.join(", ")}</span>}
 					</div>
-				</EdgeLabelRenderer>
-			)}
+				)}
+				{isEditing && (
+					<EdgeLabelEditor
+						edgeId={id}
+						protocol={edgeData?.protocol ?? ""}
+						dataItems={edgeData?.data ?? []}
+						labelX={labelX}
+						labelY={labelY}
+						onClose={() => setIsEditing(false)}
+					/>
+				)}
+				{!hasLabel && !isEditing && isHovered && (
+					<button
+						type="button"
+						className="pointer-events-all nodrag nopan absolute flex h-5 w-5 items-center justify-center rounded-full border border-border bg-card text-muted-foreground transition-colors hover:bg-accent"
+						style={{
+							transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+						}}
+						onClick={() => setIsEditing(true)}
+					>
+						<Plus className="h-3 w-3" />
+					</button>
+				)}
+			</EdgeLabelRenderer>
 		</>
+	);
+}
+
+function EdgeLabelEditor({
+	edgeId,
+	protocol,
+	dataItems,
+	labelX,
+	labelY,
+	onClose,
+}: {
+	edgeId: string;
+	protocol: string;
+	dataItems: string[];
+	labelX: number;
+	labelY: number;
+	onClose: () => void;
+}) {
+	const protocolRef = useRef<HTMLInputElement>(null);
+	const dataRef = useRef<HTMLInputElement>(null);
+	const { setEdges } = useReactFlow();
+
+	const commit = useCallback(() => {
+		const newProtocol = protocolRef.current?.value.trim() ?? "";
+		const newData = (dataRef.current?.value ?? "")
+			.split(",")
+			.map((s) => s.trim())
+			.filter((s) => s.length > 0);
+
+		// Update model store
+		const model = useModelStore.getState().model;
+		if (model) {
+			const updatedFlows = model.data_flows.map((f) =>
+				f.id === edgeId ? { ...f, protocol: newProtocol, data: newData } : f,
+			);
+			useModelStore
+				.getState()
+				.setModel({ ...model, data_flows: updatedFlows }, useModelStore.getState().filePath);
+			useModelStore.getState().markDirty();
+		}
+
+		// Update canvas edge data
+		setEdges((edges) =>
+			edges.map((e) =>
+				e.id === edgeId ? { ...e, data: { ...e.data, protocol: newProtocol, data: newData } } : e,
+			),
+		);
+
+		onClose();
+	}, [edgeId, onClose, setEdges]);
+
+	return (
+		<div
+			className="pointer-events-all nodrag nopan absolute flex flex-col gap-1 rounded border border-tf-signal bg-card p-2 shadow-lg"
+			style={{
+				transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+			}}
+		>
+			<input
+				ref={protocolRef}
+				defaultValue={protocol}
+				placeholder="Protocol (e.g. HTTPS)"
+				autoFocus
+				className="w-32 rounded border border-border bg-background px-1.5 py-0.5 text-[10px] text-foreground placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none"
+				onKeyDown={(e) => {
+					if (e.key === "Enter") commit();
+					if (e.key === "Escape") onClose();
+				}}
+			/>
+			<input
+				ref={dataRef}
+				defaultValue={dataItems.join(", ")}
+				placeholder="Data (comma-separated)"
+				className="w-32 rounded border border-border bg-background px-1.5 py-0.5 text-[10px] text-foreground placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none"
+				onKeyDown={(e) => {
+					if (e.key === "Enter") commit();
+					if (e.key === "Escape") onClose();
+				}}
+				onBlur={commit}
+			/>
+		</div>
 	);
 }

--- a/src/components/canvas/edges/data-flow-edge.tsx
+++ b/src/components/canvas/edges/data-flow-edge.tsx
@@ -361,6 +361,7 @@ function EdgeLabelEditor({
 				autoFocus
 				className="w-44 rounded border border-border bg-background px-1.5 py-0.5 text-[11px] font-medium text-foreground placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none"
 				onKeyDown={(e) => {
+					e.stopPropagation();
 					if (e.key === "Enter") commit();
 					if (e.key === "Escape") onClose();
 				}}
@@ -371,6 +372,7 @@ function EdgeLabelEditor({
 				placeholder="Protocol (e.g. HTTPS)"
 				className="w-44 rounded border border-border bg-background px-1.5 py-0.5 text-[10px] text-foreground placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none"
 				onKeyDown={(e) => {
+					e.stopPropagation();
 					if (e.key === "Enter") commit();
 					if (e.key === "Escape") onClose();
 				}}
@@ -381,6 +383,7 @@ function EdgeLabelEditor({
 				placeholder="Data (comma-separated)"
 				className="w-44 rounded border border-border bg-background px-1.5 py-0.5 text-[10px] text-foreground placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none"
 				onKeyDown={(e) => {
+					e.stopPropagation();
 					if (e.key === "Enter") commit();
 					if (e.key === "Escape") onClose();
 				}}

--- a/src/components/canvas/edges/data-flow-edge.tsx
+++ b/src/components/canvas/edges/data-flow-edge.tsx
@@ -14,8 +14,9 @@ import { useModelStore } from "@/stores/model-store";
 import { useUiStore } from "@/stores/ui-store";
 
 /**
- * Build two quadratic bezier segments that route through a waypoint.
- * source → waypoint → target, producing a smooth path.
+ * Build a quadratic bezier from source to target that passes through the waypoint.
+ * For a quadratic bezier B(t) = (1-t)²S + 2t(1-t)C + t²T,
+ * solving B(0.5) = W gives C = 2W - (S+T)/2.
  */
 function getWaypointPath(
 	sx: number,
@@ -25,10 +26,9 @@ function getWaypointPath(
 	wx: number,
 	wy: number,
 ): string {
-	// Quadratic bezier using waypoint as control point, ending at target
-	const mid2x = (wx + tx) / 2;
-	const mid2y = (wy + ty) / 2;
-	return `M ${sx},${sy} Q ${wx},${wy} ${mid2x},${mid2y} T ${tx},${ty}`;
+	const cx = 2 * wx - (sx + tx) / 2;
+	const cy = 2 * wy - (sy + ty) / 2;
+	return `M ${sx},${sy} Q ${cx},${cy} ${tx},${ty}`;
 }
 
 export function DataFlowEdge({

--- a/src/components/canvas/edges/data-flow-edge.tsx
+++ b/src/components/canvas/edges/data-flow-edge.tsx
@@ -237,7 +237,15 @@ function EdgeLabelEditor({
 		setEdges((edges) =>
 			edges.map((e) =>
 				e.id === edgeId
-					? { ...e, data: { ...e.data, name: newName, protocol: newProtocol, data: newData } }
+					? {
+							...e,
+							data: {
+								...e.data,
+								name: newName,
+								protocol: newProtocol,
+								data: newData,
+							},
+						}
 					: e,
 			),
 		);
@@ -245,12 +253,26 @@ function EdgeLabelEditor({
 		onClose();
 	}, [edgeId, onClose, setEdges]);
 
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	/** Commit when focus leaves the editor entirely (but not when tabbing between inputs) */
+	const handleContainerBlur = useCallback(
+		(e: React.FocusEvent) => {
+			if (!containerRef.current?.contains(e.relatedTarget as Node)) {
+				commit();
+			}
+		},
+		[commit],
+	);
+
 	return (
 		<div
+			ref={containerRef}
 			className="pointer-events-all nodrag nopan absolute flex flex-col gap-1 rounded border border-tf-signal bg-card p-2 shadow-lg"
 			style={{
 				transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
 			}}
+			onBlur={handleContainerBlur}
 		>
 			<input
 				ref={nameRef}
@@ -282,7 +304,6 @@ function EdgeLabelEditor({
 					if (e.key === "Enter") commit();
 					if (e.key === "Escape") onClose();
 				}}
-				onBlur={commit}
 			/>
 		</div>
 	);

--- a/src/components/canvas/nodes/data-store-node.tsx
+++ b/src/components/canvas/nodes/data-store-node.tsx
@@ -43,6 +43,7 @@ export function DataStoreNode({ id, data, selected }: NodeProps) {
 						className="w-full bg-transparent text-center text-sm font-medium text-foreground outline-none"
 						onBlur={(e) => commitLabel(e.target.value)}
 						onKeyDown={(e) => {
+							e.stopPropagation();
 							if (e.key === "Enter") commitLabel(e.currentTarget.value);
 							if (e.key === "Escape") setIsEditing(false);
 						}}

--- a/src/components/canvas/nodes/data-store-node.tsx
+++ b/src/components/canvas/nodes/data-store-node.tsx
@@ -1,27 +1,86 @@
-import { Handle, Position } from "@xyflow/react";
+import type { NodeProps } from "@xyflow/react";
+import { useCallback, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import type { DfdNodeData } from "@/stores/canvas-store";
+import { useCanvasStore } from "@/stores/canvas-store";
+import { useModelStore } from "@/stores/model-store";
+import { NodeHandles } from "./shared-handles";
+import { ThreatBadge, useThreatCount } from "./threat-badge";
 
-export function DataStoreNode({ data, selected }: { data: DfdNodeData; selected?: boolean }) {
+export function DataStoreNode({ id, data, selected }: NodeProps) {
+	const nodeData = data as DfdNodeData;
+	const [isEditing, setIsEditing] = useState(false);
+	const inputRef = useRef<HTMLInputElement>(null);
+	const threatCount = useThreatCount(id);
+
+	const commitLabel = useCallback(
+		(value: string) => {
+			const trimmed = value.trim();
+			if (trimmed && trimmed !== nodeData.label) {
+				useModelStore.getState().updateElement(id, { name: trimmed });
+				syncNodeLabel(id, trimmed);
+			}
+			setIsEditing(false);
+		},
+		[id, nodeData.label],
+	);
+
 	return (
 		<div
 			className={cn(
-				"flex min-w-[140px] items-center justify-center border-y-2 bg-card px-4 py-3 shadow-md transition-colors",
+				"group relative flex min-w-[140px] items-center justify-center border-y-2 bg-card px-4 py-3 shadow-md transition-colors",
 				selected ? "border-tf-signal shadow-tf-signal/20" : "border-border",
 			)}
 		>
-			<Handle type="target" position={Position.Top} className="!bg-muted-foreground !w-2 !h-2" />
-			<Handle type="target" position={Position.Left} className="!bg-muted-foreground !w-2 !h-2" />
+			<NodeHandles />
 
 			<div className="text-center">
-				<div className="text-sm font-medium text-foreground">{data.label}</div>
-				{data.trustZone && (
-					<div className="mt-0.5 text-[10px] text-muted-foreground">{data.trustZone}</div>
+				{isEditing ? (
+					<input
+						ref={inputRef}
+						defaultValue={nodeData.label}
+						autoFocus
+						className="w-full bg-transparent text-center text-sm font-medium text-foreground outline-none"
+						onBlur={(e) => commitLabel(e.target.value)}
+						onKeyDown={(e) => {
+							if (e.key === "Enter") commitLabel(e.currentTarget.value);
+							if (e.key === "Escape") setIsEditing(false);
+						}}
+					/>
+				) : (
+					<div
+						className="text-sm font-medium text-foreground cursor-text"
+						onDoubleClick={() => setIsEditing(true)}
+					>
+						{nodeData.label}
+					</div>
+				)}
+				{nodeData.trustZone && (
+					<div className="mt-0.5 text-[10px] text-muted-foreground">{nodeData.trustZone}</div>
+				)}
+				{nodeData.technologies.length > 0 && (
+					<div className="mt-1 flex flex-wrap justify-center gap-0.5">
+						{nodeData.technologies.map((tech) => (
+							<span
+								key={tech}
+								className="rounded bg-secondary px-1 py-px text-[9px] text-muted-foreground"
+							>
+								{tech}
+							</span>
+						))}
+					</div>
 				)}
 			</div>
 
-			<Handle type="source" position={Position.Bottom} className="!bg-muted-foreground !w-2 !h-2" />
-			<Handle type="source" position={Position.Right} className="!bg-muted-foreground !w-2 !h-2" />
+			{threatCount > 0 && <ThreatBadge count={threatCount} />}
 		</div>
 	);
+}
+
+function syncNodeLabel(elementId: string, name: string) {
+	const nodes = useCanvasStore.getState().nodes;
+	const updatedNodes = nodes.map((n) =>
+		n.id === elementId ? { ...n, data: { ...n.data, label: name } } : n,
+	);
+	useCanvasStore.setState({ nodes: updatedNodes });
 }

--- a/src/components/canvas/nodes/external-entity-node.tsx
+++ b/src/components/canvas/nodes/external-entity-node.tsx
@@ -1,27 +1,86 @@
-import { Handle, Position } from "@xyflow/react";
+import type { NodeProps } from "@xyflow/react";
+import { useCallback, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import type { DfdNodeData } from "@/stores/canvas-store";
+import { useCanvasStore } from "@/stores/canvas-store";
+import { useModelStore } from "@/stores/model-store";
+import { NodeHandles } from "./shared-handles";
+import { ThreatBadge, useThreatCount } from "./threat-badge";
 
-export function ExternalEntityNode({ data, selected }: { data: DfdNodeData; selected?: boolean }) {
+export function ExternalEntityNode({ id, data, selected }: NodeProps) {
+	const nodeData = data as DfdNodeData;
+	const [isEditing, setIsEditing] = useState(false);
+	const inputRef = useRef<HTMLInputElement>(null);
+	const threatCount = useThreatCount(id);
+
+	const commitLabel = useCallback(
+		(value: string) => {
+			const trimmed = value.trim();
+			if (trimmed && trimmed !== nodeData.label) {
+				useModelStore.getState().updateElement(id, { name: trimmed });
+				syncNodeLabel(id, trimmed);
+			}
+			setIsEditing(false);
+		},
+		[id, nodeData.label],
+	);
+
 	return (
 		<div
 			className={cn(
-				"flex min-w-[140px] items-center justify-center border-2 bg-card px-4 py-3 shadow-md transition-colors",
+				"group relative flex min-w-[140px] items-center justify-center border-2 bg-card px-4 py-3 shadow-md transition-colors",
 				selected ? "border-tf-signal shadow-tf-signal/20" : "border-border",
 			)}
 		>
-			<Handle type="target" position={Position.Top} className="!bg-muted-foreground !w-2 !h-2" />
-			<Handle type="target" position={Position.Left} className="!bg-muted-foreground !w-2 !h-2" />
+			<NodeHandles />
 
 			<div className="text-center">
-				<div className="text-sm font-medium text-foreground">{data.label}</div>
-				{data.trustZone && (
-					<div className="mt-0.5 text-[10px] text-muted-foreground">{data.trustZone}</div>
+				{isEditing ? (
+					<input
+						ref={inputRef}
+						defaultValue={nodeData.label}
+						autoFocus
+						className="w-full bg-transparent text-center text-sm font-medium text-foreground outline-none"
+						onBlur={(e) => commitLabel(e.target.value)}
+						onKeyDown={(e) => {
+							if (e.key === "Enter") commitLabel(e.currentTarget.value);
+							if (e.key === "Escape") setIsEditing(false);
+						}}
+					/>
+				) : (
+					<div
+						className="text-sm font-medium text-foreground cursor-text"
+						onDoubleClick={() => setIsEditing(true)}
+					>
+						{nodeData.label}
+					</div>
+				)}
+				{nodeData.trustZone && (
+					<div className="mt-0.5 text-[10px] text-muted-foreground">{nodeData.trustZone}</div>
+				)}
+				{nodeData.technologies.length > 0 && (
+					<div className="mt-1 flex flex-wrap justify-center gap-0.5">
+						{nodeData.technologies.map((tech) => (
+							<span
+								key={tech}
+								className="rounded bg-secondary px-1 py-px text-[9px] text-muted-foreground"
+							>
+								{tech}
+							</span>
+						))}
+					</div>
 				)}
 			</div>
 
-			<Handle type="source" position={Position.Bottom} className="!bg-muted-foreground !w-2 !h-2" />
-			<Handle type="source" position={Position.Right} className="!bg-muted-foreground !w-2 !h-2" />
+			{threatCount > 0 && <ThreatBadge count={threatCount} />}
 		</div>
 	);
+}
+
+function syncNodeLabel(elementId: string, name: string) {
+	const nodes = useCanvasStore.getState().nodes;
+	const updatedNodes = nodes.map((n) =>
+		n.id === elementId ? { ...n, data: { ...n.data, label: name } } : n,
+	);
+	useCanvasStore.setState({ nodes: updatedNodes });
 }

--- a/src/components/canvas/nodes/external-entity-node.tsx
+++ b/src/components/canvas/nodes/external-entity-node.tsx
@@ -43,6 +43,7 @@ export function ExternalEntityNode({ id, data, selected }: NodeProps) {
 						className="w-full bg-transparent text-center text-sm font-medium text-foreground outline-none"
 						onBlur={(e) => commitLabel(e.target.value)}
 						onKeyDown={(e) => {
+							e.stopPropagation();
 							if (e.key === "Enter") commitLabel(e.currentTarget.value);
 							if (e.key === "Escape") setIsEditing(false);
 						}}

--- a/src/components/canvas/nodes/process-node.tsx
+++ b/src/components/canvas/nodes/process-node.tsx
@@ -43,6 +43,7 @@ export function ProcessNode({ id, data, selected }: NodeProps) {
 						className="w-full bg-transparent text-center text-sm font-medium text-foreground outline-none"
 						onBlur={(e) => commitLabel(e.target.value)}
 						onKeyDown={(e) => {
+							e.stopPropagation();
 							if (e.key === "Enter") commitLabel(e.currentTarget.value);
 							if (e.key === "Escape") setIsEditing(false);
 						}}

--- a/src/components/canvas/nodes/process-node.tsx
+++ b/src/components/canvas/nodes/process-node.tsx
@@ -1,27 +1,86 @@
-import { Handle, Position } from "@xyflow/react";
+import type { NodeProps } from "@xyflow/react";
+import { useCallback, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import type { DfdNodeData } from "@/stores/canvas-store";
+import { useCanvasStore } from "@/stores/canvas-store";
+import { useModelStore } from "@/stores/model-store";
+import { NodeHandles } from "./shared-handles";
+import { ThreatBadge, useThreatCount } from "./threat-badge";
 
-export function ProcessNode({ data, selected }: { data: DfdNodeData; selected?: boolean }) {
+export function ProcessNode({ id, data, selected }: NodeProps) {
+	const nodeData = data as DfdNodeData;
+	const [isEditing, setIsEditing] = useState(false);
+	const inputRef = useRef<HTMLInputElement>(null);
+	const threatCount = useThreatCount(id);
+
+	const commitLabel = useCallback(
+		(value: string) => {
+			const trimmed = value.trim();
+			if (trimmed && trimmed !== nodeData.label) {
+				useModelStore.getState().updateElement(id, { name: trimmed });
+				syncNodeLabel(id, trimmed);
+			}
+			setIsEditing(false);
+		},
+		[id, nodeData.label],
+	);
+
 	return (
 		<div
 			className={cn(
-				"flex min-w-[140px] items-center justify-center rounded-2xl border-2 bg-card px-4 py-3 shadow-md transition-colors",
+				"group relative flex min-w-[140px] items-center justify-center rounded-2xl border-2 bg-card px-4 py-3 shadow-md transition-colors",
 				selected ? "border-tf-signal shadow-tf-signal/20" : "border-border",
 			)}
 		>
-			<Handle type="target" position={Position.Top} className="!bg-muted-foreground !w-2 !h-2" />
-			<Handle type="target" position={Position.Left} className="!bg-muted-foreground !w-2 !h-2" />
+			<NodeHandles />
 
 			<div className="text-center">
-				<div className="text-sm font-medium text-foreground">{data.label}</div>
-				{data.trustZone && (
-					<div className="mt-0.5 text-[10px] text-muted-foreground">{data.trustZone}</div>
+				{isEditing ? (
+					<input
+						ref={inputRef}
+						defaultValue={nodeData.label}
+						autoFocus
+						className="w-full bg-transparent text-center text-sm font-medium text-foreground outline-none"
+						onBlur={(e) => commitLabel(e.target.value)}
+						onKeyDown={(e) => {
+							if (e.key === "Enter") commitLabel(e.currentTarget.value);
+							if (e.key === "Escape") setIsEditing(false);
+						}}
+					/>
+				) : (
+					<div
+						className="text-sm font-medium text-foreground cursor-text"
+						onDoubleClick={() => setIsEditing(true)}
+					>
+						{nodeData.label}
+					</div>
+				)}
+				{nodeData.trustZone && (
+					<div className="mt-0.5 text-[10px] text-muted-foreground">{nodeData.trustZone}</div>
+				)}
+				{nodeData.technologies.length > 0 && (
+					<div className="mt-1 flex flex-wrap justify-center gap-0.5">
+						{nodeData.technologies.map((tech) => (
+							<span
+								key={tech}
+								className="rounded bg-secondary px-1 py-px text-[9px] text-muted-foreground"
+							>
+								{tech}
+							</span>
+						))}
+					</div>
 				)}
 			</div>
 
-			<Handle type="source" position={Position.Bottom} className="!bg-muted-foreground !w-2 !h-2" />
-			<Handle type="source" position={Position.Right} className="!bg-muted-foreground !w-2 !h-2" />
+			{threatCount > 0 && <ThreatBadge count={threatCount} />}
 		</div>
 	);
+}
+
+function syncNodeLabel(elementId: string, name: string) {
+	const nodes = useCanvasStore.getState().nodes;
+	const updatedNodes = nodes.map((n) =>
+		n.id === elementId ? { ...n, data: { ...n.data, label: name } } : n,
+	);
+	useCanvasStore.setState({ nodes: updatedNodes });
 }

--- a/src/components/canvas/nodes/shared-handles.tsx
+++ b/src/components/canvas/nodes/shared-handles.tsx
@@ -6,13 +6,31 @@ const HIDDEN_HANDLE_CLASS = cn(HANDLE_CLASS, "!opacity-0 !w-1 !h-1");
 
 /**
  * Shared bidirectional handles for all DFD element nodes.
- * 6 connection points: 2 horizontal midpoints (left, right) + 4 corners.
+ * 4 connection points: top, bottom, left, right.
  * Each point has both a source and target handle for bidirectional connections.
  */
 export function NodeHandles() {
 	return (
 		<>
-			{/* Horizontal midpoint handles */}
+			<Handle id="top-target" type="target" position={Position.Top} className={HANDLE_CLASS} />
+			<Handle
+				id="top-source"
+				type="source"
+				position={Position.Top}
+				className={HIDDEN_HANDLE_CLASS}
+			/>
+			<Handle
+				id="bottom-target"
+				type="target"
+				position={Position.Bottom}
+				className={HIDDEN_HANDLE_CLASS}
+			/>
+			<Handle
+				id="bottom-source"
+				type="source"
+				position={Position.Bottom}
+				className={HANDLE_CLASS}
+			/>
 			<Handle id="left-target" type="target" position={Position.Left} className={HANDLE_CLASS} />
 			<Handle
 				id="left-source"
@@ -27,64 +45,6 @@ export function NodeHandles() {
 				className={HIDDEN_HANDLE_CLASS}
 			/>
 			<Handle id="right-source" type="source" position={Position.Right} className={HANDLE_CLASS} />
-
-			{/* Corner handles */}
-			<Handle
-				id="top-left-target"
-				type="target"
-				position={Position.Top}
-				style={{ left: 0 }}
-				className={HANDLE_CLASS}
-			/>
-			<Handle
-				id="top-left-source"
-				type="source"
-				position={Position.Top}
-				style={{ left: 0 }}
-				className={HIDDEN_HANDLE_CLASS}
-			/>
-			<Handle
-				id="top-right-target"
-				type="target"
-				position={Position.Top}
-				style={{ left: "100%" }}
-				className={HANDLE_CLASS}
-			/>
-			<Handle
-				id="top-right-source"
-				type="source"
-				position={Position.Top}
-				style={{ left: "100%" }}
-				className={HIDDEN_HANDLE_CLASS}
-			/>
-			<Handle
-				id="bottom-left-source"
-				type="source"
-				position={Position.Bottom}
-				style={{ left: 0 }}
-				className={HANDLE_CLASS}
-			/>
-			<Handle
-				id="bottom-left-target"
-				type="target"
-				position={Position.Bottom}
-				style={{ left: 0 }}
-				className={HIDDEN_HANDLE_CLASS}
-			/>
-			<Handle
-				id="bottom-right-source"
-				type="source"
-				position={Position.Bottom}
-				style={{ left: "100%" }}
-				className={HANDLE_CLASS}
-			/>
-			<Handle
-				id="bottom-right-target"
-				type="target"
-				position={Position.Bottom}
-				style={{ left: "100%" }}
-				className={HIDDEN_HANDLE_CLASS}
-			/>
 		</>
 	);
 }

--- a/src/components/canvas/nodes/shared-handles.tsx
+++ b/src/components/canvas/nodes/shared-handles.tsx
@@ -1,0 +1,50 @@
+import { Handle, Position } from "@xyflow/react";
+import { cn } from "@/lib/utils";
+
+const HANDLE_CLASS = "!bg-muted-foreground !w-2 !h-2 !border-none";
+const HIDDEN_HANDLE_CLASS = cn(HANDLE_CLASS, "!opacity-0 !w-1 !h-1");
+
+/**
+ * Shared bidirectional handles for all DFD element nodes.
+ * Each side has both a source and target handle with unique IDs,
+ * allowing connections in any direction.
+ */
+export function NodeHandles() {
+	return (
+		<>
+			<Handle id="top-target" type="target" position={Position.Top} className={HANDLE_CLASS} />
+			<Handle
+				id="top-source"
+				type="source"
+				position={Position.Top}
+				className={HIDDEN_HANDLE_CLASS}
+			/>
+			<Handle id="left-target" type="target" position={Position.Left} className={HANDLE_CLASS} />
+			<Handle
+				id="left-source"
+				type="source"
+				position={Position.Left}
+				className={HIDDEN_HANDLE_CLASS}
+			/>
+			<Handle
+				id="bottom-target"
+				type="target"
+				position={Position.Bottom}
+				className={HIDDEN_HANDLE_CLASS}
+			/>
+			<Handle
+				id="bottom-source"
+				type="source"
+				position={Position.Bottom}
+				className={HANDLE_CLASS}
+			/>
+			<Handle
+				id="right-target"
+				type="target"
+				position={Position.Right}
+				className={HIDDEN_HANDLE_CLASS}
+			/>
+			<Handle id="right-source" type="source" position={Position.Right} className={HANDLE_CLASS} />
+		</>
+	);
+}

--- a/src/components/canvas/nodes/shared-handles.tsx
+++ b/src/components/canvas/nodes/shared-handles.tsx
@@ -3,43 +3,22 @@ import { cn } from "@/lib/utils";
 
 const HANDLE_CLASS = "!bg-muted-foreground !w-2 !h-2 !border-none";
 const HIDDEN_HANDLE_CLASS = cn(HANDLE_CLASS, "!opacity-0 !w-1 !h-1");
-const CORNER_HANDLE_CLASS = "!bg-muted-foreground/60 !w-1.5 !h-1.5 !border-none";
-const HIDDEN_CORNER_CLASS = cn(CORNER_HANDLE_CLASS, "!opacity-0 !w-1 !h-1");
 
 /**
  * Shared bidirectional handles for all DFD element nodes.
- * 8 connection points: 4 cardinal (center of each side) + 4 corners.
+ * 6 connection points: 2 horizontal midpoints (left, right) + 4 corners.
  * Each point has both a source and target handle for bidirectional connections.
  */
 export function NodeHandles() {
 	return (
 		<>
-			{/* Cardinal handles — center of each side */}
-			<Handle id="top-target" type="target" position={Position.Top} className={HANDLE_CLASS} />
-			<Handle
-				id="top-source"
-				type="source"
-				position={Position.Top}
-				className={HIDDEN_HANDLE_CLASS}
-			/>
+			{/* Horizontal midpoint handles */}
 			<Handle id="left-target" type="target" position={Position.Left} className={HANDLE_CLASS} />
 			<Handle
 				id="left-source"
 				type="source"
 				position={Position.Left}
 				className={HIDDEN_HANDLE_CLASS}
-			/>
-			<Handle
-				id="bottom-target"
-				type="target"
-				position={Position.Bottom}
-				className={HIDDEN_HANDLE_CLASS}
-			/>
-			<Handle
-				id="bottom-source"
-				type="source"
-				position={Position.Bottom}
-				className={HANDLE_CLASS}
 			/>
 			<Handle
 				id="right-target"
@@ -49,62 +28,62 @@ export function NodeHandles() {
 			/>
 			<Handle id="right-source" type="source" position={Position.Right} className={HANDLE_CLASS} />
 
-			{/* Corner handles — positioned near each corner via style override */}
+			{/* Corner handles */}
 			<Handle
 				id="top-left-target"
 				type="target"
 				position={Position.Top}
-				style={{ left: "10%" }}
-				className={CORNER_HANDLE_CLASS}
+				style={{ left: 0 }}
+				className={HANDLE_CLASS}
 			/>
 			<Handle
 				id="top-left-source"
 				type="source"
 				position={Position.Top}
-				style={{ left: "10%" }}
-				className={HIDDEN_CORNER_CLASS}
+				style={{ left: 0 }}
+				className={HIDDEN_HANDLE_CLASS}
 			/>
 			<Handle
 				id="top-right-target"
 				type="target"
 				position={Position.Top}
-				style={{ left: "90%" }}
-				className={CORNER_HANDLE_CLASS}
+				style={{ left: "100%" }}
+				className={HANDLE_CLASS}
 			/>
 			<Handle
 				id="top-right-source"
 				type="source"
 				position={Position.Top}
-				style={{ left: "90%" }}
-				className={HIDDEN_CORNER_CLASS}
+				style={{ left: "100%" }}
+				className={HIDDEN_HANDLE_CLASS}
 			/>
 			<Handle
 				id="bottom-left-source"
 				type="source"
 				position={Position.Bottom}
-				style={{ left: "10%" }}
-				className={CORNER_HANDLE_CLASS}
+				style={{ left: 0 }}
+				className={HANDLE_CLASS}
 			/>
 			<Handle
 				id="bottom-left-target"
 				type="target"
 				position={Position.Bottom}
-				style={{ left: "10%" }}
-				className={HIDDEN_CORNER_CLASS}
+				style={{ left: 0 }}
+				className={HIDDEN_HANDLE_CLASS}
 			/>
 			<Handle
 				id="bottom-right-source"
 				type="source"
 				position={Position.Bottom}
-				style={{ left: "90%" }}
-				className={CORNER_HANDLE_CLASS}
+				style={{ left: "100%" }}
+				className={HANDLE_CLASS}
 			/>
 			<Handle
 				id="bottom-right-target"
 				type="target"
 				position={Position.Bottom}
-				style={{ left: "90%" }}
-				className={HIDDEN_CORNER_CLASS}
+				style={{ left: "100%" }}
+				className={HIDDEN_HANDLE_CLASS}
 			/>
 		</>
 	);

--- a/src/components/canvas/nodes/shared-handles.tsx
+++ b/src/components/canvas/nodes/shared-handles.tsx
@@ -3,15 +3,18 @@ import { cn } from "@/lib/utils";
 
 const HANDLE_CLASS = "!bg-muted-foreground !w-2 !h-2 !border-none";
 const HIDDEN_HANDLE_CLASS = cn(HANDLE_CLASS, "!opacity-0 !w-1 !h-1");
+const CORNER_HANDLE_CLASS = "!bg-muted-foreground/60 !w-1.5 !h-1.5 !border-none";
+const HIDDEN_CORNER_CLASS = cn(CORNER_HANDLE_CLASS, "!opacity-0 !w-1 !h-1");
 
 /**
  * Shared bidirectional handles for all DFD element nodes.
- * Each side has both a source and target handle with unique IDs,
- * allowing connections in any direction.
+ * 8 connection points: 4 cardinal (center of each side) + 4 corners.
+ * Each point has both a source and target handle for bidirectional connections.
  */
 export function NodeHandles() {
 	return (
 		<>
+			{/* Cardinal handles — center of each side */}
 			<Handle id="top-target" type="target" position={Position.Top} className={HANDLE_CLASS} />
 			<Handle
 				id="top-source"
@@ -45,6 +48,64 @@ export function NodeHandles() {
 				className={HIDDEN_HANDLE_CLASS}
 			/>
 			<Handle id="right-source" type="source" position={Position.Right} className={HANDLE_CLASS} />
+
+			{/* Corner handles — positioned near each corner via style override */}
+			<Handle
+				id="top-left-target"
+				type="target"
+				position={Position.Top}
+				style={{ left: "10%" }}
+				className={CORNER_HANDLE_CLASS}
+			/>
+			<Handle
+				id="top-left-source"
+				type="source"
+				position={Position.Top}
+				style={{ left: "10%" }}
+				className={HIDDEN_CORNER_CLASS}
+			/>
+			<Handle
+				id="top-right-target"
+				type="target"
+				position={Position.Top}
+				style={{ left: "90%" }}
+				className={CORNER_HANDLE_CLASS}
+			/>
+			<Handle
+				id="top-right-source"
+				type="source"
+				position={Position.Top}
+				style={{ left: "90%" }}
+				className={HIDDEN_CORNER_CLASS}
+			/>
+			<Handle
+				id="bottom-left-source"
+				type="source"
+				position={Position.Bottom}
+				style={{ left: "10%" }}
+				className={CORNER_HANDLE_CLASS}
+			/>
+			<Handle
+				id="bottom-left-target"
+				type="target"
+				position={Position.Bottom}
+				style={{ left: "10%" }}
+				className={HIDDEN_CORNER_CLASS}
+			/>
+			<Handle
+				id="bottom-right-source"
+				type="source"
+				position={Position.Bottom}
+				style={{ left: "90%" }}
+				className={CORNER_HANDLE_CLASS}
+			/>
+			<Handle
+				id="bottom-right-target"
+				type="target"
+				position={Position.Bottom}
+				style={{ left: "90%" }}
+				className={HIDDEN_CORNER_CLASS}
+			/>
 		</>
 	);
 }

--- a/src/components/canvas/nodes/threat-badge.tsx
+++ b/src/components/canvas/nodes/threat-badge.tsx
@@ -1,0 +1,16 @@
+import { useModelStore } from "@/stores/model-store";
+
+export function ThreatBadge({ count }: { count: number }) {
+	return (
+		<div className="absolute -right-1.5 -top-1.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-tf-ember px-1 text-[9px] font-bold text-white">
+			{count}
+		</div>
+	);
+}
+
+export function useThreatCount(elementId: string): number {
+	return useModelStore((s) => {
+		if (!s.model) return 0;
+		return s.model.threats.filter((t) => t.element === elementId).length;
+	});
+}

--- a/src/components/canvas/nodes/trust-boundary-node.tsx
+++ b/src/components/canvas/nodes/trust-boundary-node.tsx
@@ -88,7 +88,11 @@ export function TrustBoundaryNode({ id, data, selected }: NodeProps) {
 				{/* Border click zone: an 8px inset ring that captures clicks on the border */}
 				<div
 					className="absolute inset-0 rounded-lg"
-					style={{ pointerEvents: "auto", padding: 8, background: "transparent" }}
+					style={{
+						pointerEvents: "auto",
+						padding: 8,
+						background: "transparent",
+					}}
 					onMouseDown={(e) => e.stopPropagation()}
 				>
 					{/* Inner transparent area — clicks pass through */}

--- a/src/components/canvas/nodes/trust-boundary-node.tsx
+++ b/src/components/canvas/nodes/trust-boundary-node.tsx
@@ -85,19 +85,20 @@ export function TrustBoundaryNode({ id, data, selected }: NodeProps) {
 					...(hasCustomColors ? customStyle : {}),
 				}}
 			>
-				{/* Border click zone: an 8px inset ring that captures clicks on the border */}
-				<div
-					className="absolute inset-0 rounded-lg"
-					style={{
-						pointerEvents: "auto",
-						padding: 8,
-						background: "transparent",
-					}}
-					onMouseDown={(e) => e.stopPropagation()}
-				>
-					{/* Inner transparent area — clicks pass through */}
-					<div className="h-full w-full" style={{ pointerEvents: "none" }} />
-				</div>
+				{/* Four thin edge strips along each border — only these capture clicks */}
+				{["top", "bottom", "left", "right"].map((side) => (
+					<div
+						key={side}
+						className="absolute"
+						style={{
+							pointerEvents: "auto",
+							...(side === "top" && { top: 0, left: 0, right: 0, height: 8 }),
+							...(side === "bottom" && { bottom: 0, left: 0, right: 0, height: 8 }),
+							...(side === "left" && { top: 0, bottom: 0, left: 0, width: 8 }),
+							...(side === "right" && { top: 0, bottom: 0, right: 0, width: 8 }),
+						}}
+					/>
+				))}
 				{/* Name label — always clickable */}
 				<div className="relative p-2" style={{ pointerEvents: "auto" }}>
 					{isEditing ? (

--- a/src/components/canvas/nodes/trust-boundary-node.tsx
+++ b/src/components/canvas/nodes/trust-boundary-node.tsx
@@ -1,17 +1,98 @@
+import { type NodeProps, NodeResizeControl } from "@xyflow/react";
+import { useCallback, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import type { DfdNodeData } from "@/stores/canvas-store";
+import { useCanvasStore } from "@/stores/canvas-store";
+import { useModelStore } from "@/stores/model-store";
 
-export function TrustBoundaryNode({ data, selected }: { data: DfdNodeData; selected?: boolean }) {
-	return (
-		<div
-			className={cn(
-				"h-full w-full rounded-lg border-2 border-dashed p-2 transition-colors",
-				selected ? "border-tf-ember/60 bg-tf-ember/5" : "border-muted-foreground/30 bg-muted/5",
-			)}
-		>
-			<div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-				{data.boundaryName ?? data.label}
-			</div>
-		</div>
+export function TrustBoundaryNode({ id, data, selected }: NodeProps) {
+	const nodeData = data as DfdNodeData;
+	const [isEditing, setIsEditing] = useState(false);
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	const commitLabel = useCallback(
+		(value: string) => {
+			const trimmed = value.trim();
+			if (trimmed && trimmed !== (nodeData.boundaryName ?? nodeData.label)) {
+				const model = useModelStore.getState().model;
+				if (model) {
+					const updatedBoundaries = model.trust_boundaries.map((b) =>
+						b.id === id ? { ...b, name: trimmed } : b,
+					);
+					useModelStore
+						.getState()
+						.setModel(
+							{ ...model, trust_boundaries: updatedBoundaries },
+							useModelStore.getState().filePath,
+						);
+					useModelStore.getState().markDirty();
+				}
+				syncBoundaryLabel(id, trimmed);
+			}
+			setIsEditing(false);
+		},
+		[id, nodeData.boundaryName, nodeData.label],
 	);
+
+	return (
+		<>
+			<NodeResizeControl minWidth={200} minHeight={150} className="!bg-transparent !border-none">
+				<ResizeIcon />
+			</NodeResizeControl>
+			<div
+				className={cn(
+					"h-full w-full rounded-lg border-2 border-dashed p-2 transition-colors",
+					selected ? "border-tf-ember/60 bg-tf-ember/5" : "border-muted-foreground/30 bg-muted/5",
+				)}
+			>
+				{isEditing ? (
+					<input
+						ref={inputRef}
+						defaultValue={nodeData.boundaryName ?? nodeData.label}
+						autoFocus
+						className="bg-transparent text-xs font-semibold uppercase tracking-wider text-muted-foreground outline-none"
+						onBlur={(e) => commitLabel(e.target.value)}
+						onKeyDown={(e) => {
+							if (e.key === "Enter") commitLabel(e.currentTarget.value);
+							if (e.key === "Escape") setIsEditing(false);
+						}}
+					/>
+				) : (
+					<div
+						className="text-xs font-semibold uppercase tracking-wider text-muted-foreground cursor-text"
+						onDoubleClick={() => setIsEditing(true)}
+					>
+						{nodeData.boundaryName ?? nodeData.label}
+					</div>
+				)}
+			</div>
+		</>
+	);
+}
+
+function ResizeIcon() {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			width="12"
+			height="12"
+			viewBox="0 0 24 24"
+			className="absolute bottom-1 right-1 text-muted-foreground/50"
+			role="img"
+			aria-label="Resize handle"
+		>
+			<path
+				fill="currentColor"
+				d="M22 22H20V20H22V22ZM22 18H20V16H22V18ZM18 22H16V20H18V22ZM18 18H16V16H18V18ZM14 22H12V20H14V22ZM22 14H20V12H22V14Z"
+			/>
+		</svg>
+	);
+}
+
+function syncBoundaryLabel(boundaryId: string, name: string) {
+	const nodes = useCanvasStore.getState().nodes;
+	const updatedNodes = nodes.map((n) =>
+		n.id === boundaryId ? { ...n, data: { ...n.data, label: name, boundaryName: name } } : n,
+	);
+	useCanvasStore.setState({ nodes: updatedNodes });
 }

--- a/src/components/canvas/nodes/trust-boundary-node.tsx
+++ b/src/components/canvas/nodes/trust-boundary-node.tsx
@@ -67,9 +67,11 @@ export function TrustBoundaryNode({ id, data, selected }: NodeProps) {
 			<NodeResizeControl minWidth={200} minHeight={150} className="!bg-transparent !border-none">
 				<ResizeIcon />
 			</NodeResizeControl>
+			{/* Outer wrapper: only the border zone (8px inset) captures pointer events.
+          The interior is pointer-events:none so clicks fall through to edges/nodes. */}
 			<div
 				className={cn(
-					"h-full w-full rounded-lg border-2 border-dashed p-2 transition-colors",
+					"h-full w-full rounded-lg border-2 border-dashed transition-colors",
 					!hasCustomColors &&
 						(selected
 							? "border-tf-ember/60 bg-tf-ember/5"
@@ -78,28 +80,43 @@ export function TrustBoundaryNode({ id, data, selected }: NodeProps) {
 						selected &&
 						"ring-2 ring-tf-signal ring-offset-1 ring-offset-background",
 				)}
-				style={hasCustomColors ? customStyle : undefined}
+				style={{
+					pointerEvents: "none",
+					...(hasCustomColors ? customStyle : {}),
+				}}
 			>
-				{isEditing ? (
-					<input
-						ref={inputRef}
-						defaultValue={nodeData.boundaryName ?? nodeData.label}
-						autoFocus
-						className="bg-transparent text-xs font-semibold uppercase tracking-wider text-muted-foreground outline-none"
-						onBlur={(e) => commitLabel(e.target.value)}
-						onKeyDown={(e) => {
-							if (e.key === "Enter") commitLabel(e.currentTarget.value);
-							if (e.key === "Escape") setIsEditing(false);
-						}}
-					/>
-				) : (
-					<div
-						className="text-xs font-semibold uppercase tracking-wider text-muted-foreground cursor-text"
-						onDoubleClick={() => setIsEditing(true)}
-					>
-						{nodeData.boundaryName ?? nodeData.label}
-					</div>
-				)}
+				{/* Border click zone: an 8px inset ring that captures clicks on the border */}
+				<div
+					className="absolute inset-0 rounded-lg"
+					style={{ pointerEvents: "auto", padding: 8, background: "transparent" }}
+					onMouseDown={(e) => e.stopPropagation()}
+				>
+					{/* Inner transparent area — clicks pass through */}
+					<div className="h-full w-full" style={{ pointerEvents: "none" }} />
+				</div>
+				{/* Name label — always clickable */}
+				<div className="relative p-2" style={{ pointerEvents: "auto" }}>
+					{isEditing ? (
+						<input
+							ref={inputRef}
+							defaultValue={nodeData.boundaryName ?? nodeData.label}
+							autoFocus
+							className="bg-transparent text-xs font-semibold uppercase tracking-wider text-muted-foreground outline-none"
+							onBlur={(e) => commitLabel(e.target.value)}
+							onKeyDown={(e) => {
+								if (e.key === "Enter") commitLabel(e.currentTarget.value);
+								if (e.key === "Escape") setIsEditing(false);
+							}}
+						/>
+					) : (
+						<div
+							className="text-xs font-semibold uppercase tracking-wider text-muted-foreground cursor-text"
+							onDoubleClick={() => setIsEditing(true)}
+						>
+							{nodeData.boundaryName ?? nodeData.label}
+						</div>
+					)}
+				</div>
 			</div>
 		</>
 	);

--- a/src/components/canvas/nodes/trust-boundary-node.tsx
+++ b/src/components/canvas/nodes/trust-boundary-node.tsx
@@ -85,20 +85,6 @@ export function TrustBoundaryNode({ id, data, selected }: NodeProps) {
 					...(hasCustomColors ? customStyle : {}),
 				}}
 			>
-				{/* Four thin edge strips along each border — only these capture clicks */}
-				{["top", "bottom", "left", "right"].map((side) => (
-					<div
-						key={side}
-						className="absolute"
-						style={{
-							pointerEvents: "auto",
-							...(side === "top" && { top: 0, left: 0, right: 0, height: 8 }),
-							...(side === "bottom" && { bottom: 0, left: 0, right: 0, height: 8 }),
-							...(side === "left" && { top: 0, bottom: 0, left: 0, width: 8 }),
-							...(side === "right" && { top: 0, bottom: 0, right: 0, width: 8 }),
-						}}
-					/>
-				))}
 				{/* Name label — always clickable */}
 				<div className="relative p-2" style={{ pointerEvents: "auto" }}>
 					{isEditing ? (

--- a/src/lib/ai-prompt.test.ts
+++ b/src/lib/ai-prompt.test.ts
@@ -66,6 +66,7 @@ describe("buildSystemPrompt", () => {
 		const model = emptyModel();
 		model.data_flows.push({
 			id: "flow-1",
+			name: "",
 			from: "web-app",
 			to: "api-gw",
 			protocol: "HTTPS",

--- a/src/lib/canvas-utils.test.ts
+++ b/src/lib/canvas-utils.test.ts
@@ -20,33 +20,44 @@ describe("getSmartHandlePair", () => {
 		expect(result.targetHandle).toBe("right-target");
 	});
 
-	it("returns bottom-source → top-target when target is below", () => {
+	it("returns bottom-right corner handles when target is directly below", () => {
 		const result = getSmartHandlePair(
 			{ x: 0, y: 0, width: 140, height: 50 },
 			{ x: 0, y: 300, width: 140, height: 50 },
 		);
-		expect(result.sourceHandle).toBe("bottom-source");
-		expect(result.targetHandle).toBe("top-target");
+		// dx === 0, dy > 0, dx >= 0 → bottom-right-source / top-left-target
+		expect(result.sourceHandle).toBe("bottom-right-source");
+		expect(result.targetHandle).toBe("top-left-target");
 	});
 
-	it("returns top-source → bottom-target when target is above", () => {
+	it("returns top-right corner handles when target is directly above", () => {
 		const result = getSmartHandlePair(
 			{ x: 0, y: 300, width: 140, height: 50 },
 			{ x: 0, y: 0, width: 140, height: 50 },
 		);
-		expect(result.sourceHandle).toBe("top-source");
-		expect(result.targetHandle).toBe("bottom-target");
+		// dx === 0, dy < 0, dx >= 0 → top-right-source / bottom-left-target
+		expect(result.sourceHandle).toBe("top-right-source");
+		expect(result.targetHandle).toBe("bottom-left-target");
 	});
 
-	it("uses horizontal handles when dx equals dy (horizontal tie-break)", () => {
+	it("uses corner handles when dx equals dy (vertical tie-break)", () => {
 		const result = getSmartHandlePair(
 			{ x: 0, y: 0, width: 100, height: 100 },
 			{ x: 200, y: 200, width: 100, height: 100 },
 		);
-		// dx === dy, both are 200, so Math.abs(dx) > Math.abs(dy) is false,
-		// falls through to vertical: dy > 0 → bottom-source / top-target
-		expect(result.sourceHandle).toBe("bottom-source");
-		expect(result.targetHandle).toBe("top-target");
+		// dx === dy, both are 200, Math.abs(dx) > Math.abs(dy) is false,
+		// falls through to vertical: dy > 0, dx >= 0 → bottom-right-source / top-left-target
+		expect(result.sourceHandle).toBe("bottom-right-source");
+		expect(result.targetHandle).toBe("top-left-target");
+	});
+
+	it("returns bottom-right/top-left when target is below-right", () => {
+		const result = getSmartHandlePair(
+			{ x: 0, y: 0, width: 100, height: 50 },
+			{ x: 50, y: 300, width: 100, height: 50 },
+		);
+		expect(result.sourceHandle).toBe("bottom-right-source");
+		expect(result.targetHandle).toBe("top-left-target");
 	});
 });
 

--- a/src/lib/canvas-utils.test.ts
+++ b/src/lib/canvas-utils.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { getSmartHandlePair, isDuplicateEdge, isSelfLoop, nodeToRect } from "./canvas-utils";
+
+describe("getSmartHandlePair", () => {
+	it("returns right-source → left-target when target is to the right", () => {
+		const result = getSmartHandlePair(
+			{ x: 0, y: 0, width: 140, height: 50 },
+			{ x: 300, y: 0, width: 140, height: 50 },
+		);
+		expect(result.sourceHandle).toBe("right-source");
+		expect(result.targetHandle).toBe("left-target");
+	});
+
+	it("returns left-source → right-target when target is to the left", () => {
+		const result = getSmartHandlePair(
+			{ x: 300, y: 0, width: 140, height: 50 },
+			{ x: 0, y: 0, width: 140, height: 50 },
+		);
+		expect(result.sourceHandle).toBe("left-source");
+		expect(result.targetHandle).toBe("right-target");
+	});
+
+	it("returns bottom-source → top-target when target is below", () => {
+		const result = getSmartHandlePair(
+			{ x: 0, y: 0, width: 140, height: 50 },
+			{ x: 0, y: 300, width: 140, height: 50 },
+		);
+		expect(result.sourceHandle).toBe("bottom-source");
+		expect(result.targetHandle).toBe("top-target");
+	});
+
+	it("returns top-source → bottom-target when target is above", () => {
+		const result = getSmartHandlePair(
+			{ x: 0, y: 300, width: 140, height: 50 },
+			{ x: 0, y: 0, width: 140, height: 50 },
+		);
+		expect(result.sourceHandle).toBe("top-source");
+		expect(result.targetHandle).toBe("bottom-target");
+	});
+
+	it("uses horizontal handles when dx equals dy (horizontal tie-break)", () => {
+		const result = getSmartHandlePair(
+			{ x: 0, y: 0, width: 100, height: 100 },
+			{ x: 200, y: 200, width: 100, height: 100 },
+		);
+		// dx === dy, both are 200, so Math.abs(dx) > Math.abs(dy) is false,
+		// falls through to vertical: dy > 0 → bottom-source / top-target
+		expect(result.sourceHandle).toBe("bottom-source");
+		expect(result.targetHandle).toBe("top-target");
+	});
+});
+
+describe("nodeToRect", () => {
+	it("uses measured dimensions when available", () => {
+		const rect = nodeToRect({
+			position: { x: 10, y: 20 },
+			measured: { width: 200, height: 80 },
+		});
+		expect(rect).toEqual({ x: 10, y: 20, width: 200, height: 80 });
+	});
+
+	it("falls back to node width/height", () => {
+		const rect = nodeToRect({
+			position: { x: 5, y: 10 },
+			width: 300,
+			height: 100,
+		});
+		expect(rect).toEqual({ x: 5, y: 10, width: 300, height: 100 });
+	});
+
+	it("uses defaults when no dimensions provided", () => {
+		const rect = nodeToRect({
+			position: { x: 0, y: 0 },
+		});
+		expect(rect).toEqual({ x: 0, y: 0, width: 140, height: 50 });
+	});
+});
+
+describe("isDuplicateEdge", () => {
+	const edges = [
+		{ source: "a", target: "b" },
+		{ source: "b", target: "c" },
+	];
+
+	it("returns true for existing edge", () => {
+		expect(isDuplicateEdge(edges, "a", "b")).toBe(true);
+	});
+
+	it("returns false for reverse direction", () => {
+		expect(isDuplicateEdge(edges, "b", "a")).toBe(false);
+	});
+
+	it("returns false for non-existent edge", () => {
+		expect(isDuplicateEdge(edges, "a", "c")).toBe(false);
+	});
+
+	it("returns false for empty edges array", () => {
+		expect(isDuplicateEdge([], "a", "b")).toBe(false);
+	});
+});
+
+describe("isSelfLoop", () => {
+	it("returns true when source equals target", () => {
+		expect(isSelfLoop("node-1", "node-1")).toBe(true);
+	});
+
+	it("returns false when source differs from target", () => {
+		expect(isSelfLoop("node-1", "node-2")).toBe(false);
+	});
+});

--- a/src/lib/canvas-utils.test.ts
+++ b/src/lib/canvas-utils.test.ts
@@ -20,44 +20,32 @@ describe("getSmartHandlePair", () => {
 		expect(result.targetHandle).toBe("right-target");
 	});
 
-	it("returns bottom-right corner handles when target is directly below", () => {
+	it("returns bottom-source → top-target when target is below", () => {
 		const result = getSmartHandlePair(
 			{ x: 0, y: 0, width: 140, height: 50 },
 			{ x: 0, y: 300, width: 140, height: 50 },
 		);
-		// dx === 0, dy > 0, dx >= 0 → bottom-right-source / top-left-target
-		expect(result.sourceHandle).toBe("bottom-right-source");
-		expect(result.targetHandle).toBe("top-left-target");
+		expect(result.sourceHandle).toBe("bottom-source");
+		expect(result.targetHandle).toBe("top-target");
 	});
 
-	it("returns top-right corner handles when target is directly above", () => {
+	it("returns top-source → bottom-target when target is above", () => {
 		const result = getSmartHandlePair(
 			{ x: 0, y: 300, width: 140, height: 50 },
 			{ x: 0, y: 0, width: 140, height: 50 },
 		);
-		// dx === 0, dy < 0, dx >= 0 → top-right-source / bottom-left-target
-		expect(result.sourceHandle).toBe("top-right-source");
-		expect(result.targetHandle).toBe("bottom-left-target");
+		expect(result.sourceHandle).toBe("top-source");
+		expect(result.targetHandle).toBe("bottom-target");
 	});
 
-	it("uses corner handles when dx equals dy (vertical tie-break)", () => {
+	it("uses vertical handles when dx equals dy (vertical tie-break)", () => {
 		const result = getSmartHandlePair(
 			{ x: 0, y: 0, width: 100, height: 100 },
 			{ x: 200, y: 200, width: 100, height: 100 },
 		);
-		// dx === dy, both are 200, Math.abs(dx) > Math.abs(dy) is false,
-		// falls through to vertical: dy > 0, dx >= 0 → bottom-right-source / top-left-target
-		expect(result.sourceHandle).toBe("bottom-right-source");
-		expect(result.targetHandle).toBe("top-left-target");
-	});
-
-	it("returns bottom-right/top-left when target is below-right", () => {
-		const result = getSmartHandlePair(
-			{ x: 0, y: 0, width: 100, height: 50 },
-			{ x: 50, y: 300, width: 100, height: 50 },
-		);
-		expect(result.sourceHandle).toBe("bottom-right-source");
-		expect(result.targetHandle).toBe("top-left-target");
+		// dx === dy, Math.abs(dx) > Math.abs(dy) is false → vertical: bottom/top
+		expect(result.sourceHandle).toBe("bottom-source");
+		expect(result.targetHandle).toBe("top-target");
 	});
 });
 

--- a/src/lib/canvas-utils.ts
+++ b/src/lib/canvas-utils.ts
@@ -1,6 +1,6 @@
 import type { Position } from "@xyflow/react";
 
-type HandlePosition = "top-left" | "top-right" | "bottom-left" | "bottom-right" | "left" | "right";
+type HandlePosition = "top" | "bottom" | "left" | "right";
 
 interface NodeRect {
 	x: number;
@@ -15,10 +15,8 @@ interface HandlePair {
 }
 
 const POSITION_MAP: Record<HandlePosition, Position> = {
-	"top-left": "top" as Position,
-	"top-right": "top" as Position,
-	"bottom-left": "bottom" as Position,
-	"bottom-right": "bottom" as Position,
+	top: "top" as Position,
+	bottom: "bottom" as Position,
 	left: "left" as Position,
 	right: "right" as Position,
 };
@@ -29,8 +27,8 @@ const DEFAULT_NODE_HEIGHT = 50;
 
 /**
  * Given source and target node positions/sizes, determines the optimal
- * handle pair from the 6 available handles (left, right, top-left, top-right,
- * bottom-left, bottom-right) to minimize path length.
+ * handle pair (top/bottom/left/right) to minimize path length and avoid
+ * edges crossing through nodes.
  */
 export function getSmartHandlePair(source: NodeRect, target: NodeRect): HandlePair {
 	const sourceCx = source.x + source.width / 2;
@@ -45,7 +43,6 @@ export function getSmartHandlePair(source: NodeRect, target: NodeRect): HandlePa
 	let targetPos: HandlePosition;
 
 	if (Math.abs(dx) > Math.abs(dy)) {
-		// Primarily horizontal — use left/right midpoints
 		if (dx > 0) {
 			sourcePos = "right";
 			targetPos = "left";
@@ -54,15 +51,12 @@ export function getSmartHandlePair(source: NodeRect, target: NodeRect): HandlePa
 			targetPos = "right";
 		}
 	} else {
-		// Primarily vertical — use corner handles
 		if (dy > 0) {
-			// Target is below
-			sourcePos = dx >= 0 ? "bottom-right" : "bottom-left";
-			targetPos = dx >= 0 ? "top-left" : "top-right";
+			sourcePos = "bottom";
+			targetPos = "top";
 		} else {
-			// Target is above
-			sourcePos = dx >= 0 ? "top-right" : "top-left";
-			targetPos = dx >= 0 ? "bottom-left" : "bottom-right";
+			sourcePos = "top";
+			targetPos = "bottom";
 		}
 	}
 

--- a/src/lib/canvas-utils.ts
+++ b/src/lib/canvas-utils.ts
@@ -1,6 +1,6 @@
 import type { Position } from "@xyflow/react";
 
-type HandlePosition = "top" | "bottom" | "left" | "right";
+type HandlePosition = "top-left" | "top-right" | "bottom-left" | "bottom-right" | "left" | "right";
 
 interface NodeRect {
 	x: number;
@@ -15,8 +15,10 @@ interface HandlePair {
 }
 
 const POSITION_MAP: Record<HandlePosition, Position> = {
-	top: "top" as Position,
-	bottom: "bottom" as Position,
+	"top-left": "top" as Position,
+	"top-right": "top" as Position,
+	"bottom-left": "bottom" as Position,
+	"bottom-right": "bottom" as Position,
 	left: "left" as Position,
 	right: "right" as Position,
 };
@@ -27,8 +29,8 @@ const DEFAULT_NODE_HEIGHT = 50;
 
 /**
  * Given source and target node positions/sizes, determines the optimal
- * handle pair (top/bottom/left/right) to minimize path length and avoid
- * edges crossing through nodes.
+ * handle pair from the 6 available handles (left, right, top-left, top-right,
+ * bottom-left, bottom-right) to minimize path length.
  */
 export function getSmartHandlePair(source: NodeRect, target: NodeRect): HandlePair {
 	const sourceCx = source.x + source.width / 2;
@@ -42,9 +44,8 @@ export function getSmartHandlePair(source: NodeRect, target: NodeRect): HandlePa
 	let sourcePos: HandlePosition;
 	let targetPos: HandlePosition;
 
-	// Determine primary axis based on relative position
 	if (Math.abs(dx) > Math.abs(dy)) {
-		// Horizontal: source on the side closer to target, target on opposite side
+		// Primarily horizontal — use left/right midpoints
 		if (dx > 0) {
 			sourcePos = "right";
 			targetPos = "left";
@@ -53,13 +54,15 @@ export function getSmartHandlePair(source: NodeRect, target: NodeRect): HandlePa
 			targetPos = "right";
 		}
 	} else {
-		// Vertical: source below/above depending on direction
+		// Primarily vertical — use corner handles
 		if (dy > 0) {
-			sourcePos = "bottom";
-			targetPos = "top";
+			// Target is below
+			sourcePos = dx >= 0 ? "bottom-right" : "bottom-left";
+			targetPos = dx >= 0 ? "top-left" : "top-right";
 		} else {
-			sourcePos = "top";
-			targetPos = "bottom";
+			// Target is above
+			sourcePos = dx >= 0 ? "top-right" : "top-left";
+			targetPos = dx >= 0 ? "bottom-left" : "bottom-right";
 		}
 	}
 

--- a/src/lib/canvas-utils.ts
+++ b/src/lib/canvas-utils.ts
@@ -1,0 +1,104 @@
+import type { Position } from "@xyflow/react";
+
+type HandlePosition = "top" | "bottom" | "left" | "right";
+
+interface NodeRect {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
+
+interface HandlePair {
+	sourceHandle: string;
+	targetHandle: string;
+}
+
+const POSITION_MAP: Record<HandlePosition, Position> = {
+	top: "top" as Position,
+	bottom: "bottom" as Position,
+	left: "left" as Position,
+	right: "right" as Position,
+};
+
+/** Default node dimensions when width/height are unknown */
+const DEFAULT_NODE_WIDTH = 140;
+const DEFAULT_NODE_HEIGHT = 50;
+
+/**
+ * Given source and target node positions/sizes, determines the optimal
+ * handle pair (top/bottom/left/right) to minimize path length and avoid
+ * edges crossing through nodes.
+ */
+export function getSmartHandlePair(source: NodeRect, target: NodeRect): HandlePair {
+	const sourceCx = source.x + source.width / 2;
+	const sourceCy = source.y + source.height / 2;
+	const targetCx = target.x + target.width / 2;
+	const targetCy = target.y + target.height / 2;
+
+	const dx = targetCx - sourceCx;
+	const dy = targetCy - sourceCy;
+
+	let sourcePos: HandlePosition;
+	let targetPos: HandlePosition;
+
+	// Determine primary axis based on relative position
+	if (Math.abs(dx) > Math.abs(dy)) {
+		// Horizontal: source on the side closer to target, target on opposite side
+		if (dx > 0) {
+			sourcePos = "right";
+			targetPos = "left";
+		} else {
+			sourcePos = "left";
+			targetPos = "right";
+		}
+	} else {
+		// Vertical: source below/above depending on direction
+		if (dy > 0) {
+			sourcePos = "bottom";
+			targetPos = "top";
+		} else {
+			sourcePos = "top";
+			targetPos = "bottom";
+		}
+	}
+
+	return {
+		sourceHandle: `${sourcePos}-source`,
+		targetHandle: `${targetPos}-target`,
+	};
+}
+
+/**
+ * Build a NodeRect from a ReactFlow node, using default dimensions if not present.
+ */
+export function nodeToRect(node: {
+	position: { x: number; y: number };
+	measured?: { width?: number; height?: number };
+	width?: number;
+	height?: number;
+}): NodeRect {
+	return {
+		x: node.position.x,
+		y: node.position.y,
+		width: node.measured?.width ?? node.width ?? DEFAULT_NODE_WIDTH,
+		height: node.measured?.height ?? node.height ?? DEFAULT_NODE_HEIGHT,
+	};
+}
+
+/** Checks whether an edge between source and target already exists. */
+export function isDuplicateEdge(
+	edges: ReadonlyArray<{ source: string; target: string }>,
+	sourceId: string,
+	targetId: string,
+): boolean {
+	return edges.some((e) => e.source === sourceId && e.target === targetId);
+}
+
+/** Checks whether source and target are the same node. */
+export function isSelfLoop(sourceId: string, targetId: string): boolean {
+	return sourceId === targetId;
+}
+
+export { POSITION_MAP, DEFAULT_NODE_WIDTH, DEFAULT_NODE_HEIGHT };
+export type { HandlePosition, NodeRect };

--- a/src/lib/stride-engine.test.ts
+++ b/src/lib/stride-engine.test.ts
@@ -41,6 +41,7 @@ function sampleModel(): ThreatModel {
 		data_flows: [
 			{
 				id: "flow-1",
+				name: "",
 				from: "web-app",
 				to: "db",
 				protocol: "PostgreSQL/TLS",
@@ -124,6 +125,7 @@ describe("analyzeStride", () => {
 		const model = sampleModel();
 		model.data_flows.push({
 			id: "flow-2",
+			name: "",
 			from: "web-app",
 			to: "user",
 			protocol: "HTTPS",

--- a/src/stores/canvas-store.test.ts
+++ b/src/stores/canvas-store.test.ts
@@ -55,7 +55,11 @@ function createTestModel(): ThreatModel {
 
 describe("canvas-store", () => {
 	beforeEach(() => {
-		useCanvasStore.setState({ nodes: [], edges: [], viewport: { x: 0, y: 0, zoom: 1 } });
+		useCanvasStore.setState({
+			nodes: [],
+			edges: [],
+			viewport: { x: 0, y: 0, zoom: 1 },
+		});
 		useModelStore.setState({ model: null, filePath: null, isDirty: false });
 	});
 
@@ -107,13 +111,14 @@ describe("canvas-store", () => {
 		useModelStore.getState().setModel(createTestModel(), null);
 		useCanvasStore.getState().syncFromModel();
 
-		useCanvasStore.getState().addElement("external_entity", { x: 200, y: 300 });
+		// Drop outside any boundary so position isn't adjusted
+		useCanvasStore.getState().addElement("external_entity", { x: 600, y: 600 });
 
 		const { nodes } = useCanvasStore.getState();
 		const newNode = nodes.find((n) => n.type === "externalEntity");
 		expect(newNode).toBeDefined();
 		expect(newNode?.data.label).toBe("New External Entity");
-		expect(newNode?.position).toEqual({ x: 200, y: 300 });
+		expect(newNode?.position).toEqual({ x: 600, y: 600 });
 
 		// Model store should also have the new element
 		const model = useModelStore.getState().model;
@@ -187,5 +192,80 @@ describe("canvas-store", () => {
 		const model = useModelStore.getState().model;
 		const newElement = model?.elements[model.elements.length - 1];
 		expect(newElement?.id).toBe("process-2");
+	});
+
+	it("prevents self-loop when adding data flow", () => {
+		useModelStore.getState().setModel(createTestModel(), null);
+		useCanvasStore.getState().syncFromModel();
+
+		const result = useCanvasStore.getState().addDataFlow("process-1", "process-1");
+		expect(result).toBeNull();
+
+		// Edge count should remain the same
+		expect(useCanvasStore.getState().edges).toHaveLength(1);
+	});
+
+	it("prevents duplicate edges", () => {
+		useModelStore.getState().setModel(createTestModel(), null);
+		useCanvasStore.getState().syncFromModel();
+
+		// flow-1 already exists: process-1 → data-store-1
+		const result = useCanvasStore.getState().addDataFlow("process-1", "data-store-1");
+		expect(result).toBeNull();
+		expect(useCanvasStore.getState().edges).toHaveLength(1);
+	});
+
+	it("allows reverse direction of existing edge", () => {
+		useModelStore.getState().setModel(createTestModel(), null);
+		useCanvasStore.getState().syncFromModel();
+
+		// Reverse: data-store-1 → process-1 (different from existing process-1 → data-store-1)
+		const result = useCanvasStore.getState().addDataFlow("data-store-1", "process-1");
+		expect(result).not.toBeNull();
+		expect(useCanvasStore.getState().edges).toHaveLength(2);
+	});
+
+	it("duplicates an element", () => {
+		useModelStore.getState().setModel(createTestModel(), null);
+		useCanvasStore.getState().syncFromModel();
+
+		useCanvasStore.getState().duplicateElement("process-1");
+
+		const { nodes } = useCanvasStore.getState();
+		const copies = nodes.filter((n) => n.data.label.includes("copy"));
+		expect(copies).toHaveLength(1);
+		expect(copies[0].data.label).toBe("Web App (copy)");
+
+		const model = useModelStore.getState().model;
+		expect(model?.elements).toHaveLength(3);
+	});
+
+	it("reverses an edge direction", () => {
+		useModelStore.getState().setModel(createTestModel(), null);
+		useCanvasStore.getState().syncFromModel();
+
+		useCanvasStore.getState().reverseEdge("flow-1");
+
+		const edge = useCanvasStore.getState().edges.find((e) => e.id === "flow-1");
+		expect(edge?.source).toBe("data-store-1");
+		expect(edge?.target).toBe("process-1");
+
+		const model = useModelStore.getState().model;
+		const flow = model?.data_flows.find((f) => f.id === "flow-1");
+		expect(flow?.from).toBe("data-store-1");
+		expect(flow?.to).toBe("process-1");
+	});
+
+	it("auto-assigns element to boundary when dropped inside", () => {
+		useModelStore.getState().setModel(createTestModel(), null);
+		useCanvasStore.getState().syncFromModel();
+
+		// Boundary-1 is at default position (50, 50) with size 400x300
+		// Drop a new element inside it
+		useCanvasStore.getState().addElement("process", { x: 100, y: 100 });
+
+		const model = useModelStore.getState().model;
+		const boundary = model?.trust_boundaries.find((b) => b.id === "boundary-1");
+		expect(boundary?.contains).toContain("process-2");
 	});
 });

--- a/src/stores/canvas-store.ts
+++ b/src/stores/canvas-store.ts
@@ -451,14 +451,14 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
 		const flow = model.data_flows.find((f) => f.id === edgeId);
 		if (!flow) return;
 
-		// Update model: swap from/to
+		// Update model: swap from/to (use direct set to preserve selection state)
 		const updatedFlows = model.data_flows.map((f) =>
 			f.id === edgeId ? { ...f, from: f.to, to: f.from } : f,
 		);
-		useModelStore
-			.getState()
-			.setModel({ ...model, data_flows: updatedFlows }, useModelStore.getState().filePath);
-		useModelStore.getState().markDirty();
+		useModelStore.setState({
+			model: { ...model, data_flows: updatedFlows },
+			isDirty: true,
+		});
 
 		// Update canvas edge: swap source/target
 		const currentEdges = get().edges;

--- a/src/stores/canvas-store.ts
+++ b/src/stores/canvas-store.ts
@@ -159,7 +159,6 @@ function flowToEdge(flow: DataFlow): DfdEdge {
 		source: flow.from,
 		target: flow.to,
 		type: "dataFlow",
-		animated: flow.authenticated,
 		data: {
 			name: flow.name ?? "",
 			protocol: flow.protocol,

--- a/src/stores/canvas-store.ts
+++ b/src/stores/canvas-store.ts
@@ -23,6 +23,14 @@ export type DfdNodeData = {
 	/** For trust boundary group nodes */
 	isBoundary?: boolean;
 	boundaryName?: string;
+	/** Trust boundary fill color (CSS color with opacity) */
+	boundaryFillColor?: string;
+	/** Trust boundary stroke color (CSS color with opacity) */
+	boundaryStrokeColor?: string;
+	/** Trust boundary fill opacity (0-1) */
+	boundaryFillOpacity?: number;
+	/** Trust boundary stroke opacity (0-1) */
+	boundaryStrokeOpacity?: number;
 };
 
 /** ReactFlow edge data payload for data flows.
@@ -188,7 +196,9 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
 		const selectionChange = changes.find((c) => c.type === "select" && c.selected);
 		if (selectionChange && selectionChange.type === "select") {
 			const node = get().nodes.find((n) => n.id === selectionChange.id);
-			if (node && !node.data.isBoundary) {
+			if (node?.data.isBoundary) {
+				useModelStore.getState().setSelectedBoundary(selectionChange.id);
+			} else if (node && !node.data.isBoundary) {
 				useModelStore.getState().setSelectedElement(selectionChange.id);
 			}
 		}
@@ -197,6 +207,7 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
 		const deselection = changes.find((c) => c.type === "select" && !c.selected);
 		if (deselection && !changes.some((c) => c.type === "select" && c.selected)) {
 			useModelStore.getState().setSelectedElement(null);
+			useModelStore.getState().setSelectedBoundary(null);
 		}
 	},
 

--- a/src/stores/canvas-store.ts
+++ b/src/stores/canvas-store.ts
@@ -41,6 +41,10 @@ export type DfdEdgeData = {
 	protocol: string;
 	data: string[];
 	authenticated: boolean;
+	/** Dragged label X offset from default position */
+	labelOffsetX?: number;
+	/** Dragged label Y offset from default position */
+	labelOffsetY?: number;
 };
 
 export type DfdNode = Node<DfdNodeData>;

--- a/src/stores/canvas-store.ts
+++ b/src/stores/canvas-store.ts
@@ -575,13 +575,21 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
 			return node;
 		});
 
-		// Convert flows to edges, preserving handle assignments from existing edges
+		// Convert flows to edges, preserving handle assignments and label offsets from existing edges
 		const existingEdgeMap = new Map(get().edges.map((e) => [e.id, e]));
 		const edges: DfdEdge[] = model.data_flows.map((flow) => {
 			const edge = flowToEdge(flow);
 			const existing = existingEdgeMap.get(flow.id);
 			if (existing?.sourceHandle) edge.sourceHandle = existing.sourceHandle;
 			if (existing?.targetHandle) edge.targetHandle = existing.targetHandle;
+			// Preserve dragged label position
+			if (existing?.data?.labelOffsetX != null || existing?.data?.labelOffsetY != null) {
+				edge.data = {
+					...(edge.data as DfdEdgeData),
+					labelOffsetX: existing.data.labelOffsetX,
+					labelOffsetY: existing.data.labelOffsetY,
+				};
+			}
 			return edge;
 		});
 

--- a/src/stores/canvas-store.ts
+++ b/src/stores/canvas-store.ts
@@ -140,7 +140,10 @@ function boundaryToNode(boundary: TrustBoundary, position: { x: number; y: numbe
 		position,
 		width: 400,
 		height: 300,
-		style: { width: 400, height: 300 },
+		// pointerEvents:none on the ReactFlow wrapper so clicks inside the boundary
+		// pass through to child nodes and edges. The label and resize handle inside
+		// TrustBoundaryNode opt back in with pointer-events:auto.
+		style: { width: 400, height: 300, pointerEvents: "none" as const },
 		data: {
 			label: boundary.name,
 			elementType: "process", // unused for boundaries

--- a/src/stores/canvas-store.ts
+++ b/src/stores/canvas-store.ts
@@ -561,8 +561,15 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
 			return node;
 		});
 
-		// Convert flows to edges
-		const edges: DfdEdge[] = model.data_flows.map(flowToEdge);
+		// Convert flows to edges, preserving handle assignments from existing edges
+		const existingEdgeMap = new Map(get().edges.map((e) => [e.id, e]));
+		const edges: DfdEdge[] = model.data_flows.map((flow) => {
+			const edge = flowToEdge(flow);
+			const existing = existingEdgeMap.get(flow.id);
+			if (existing?.sourceHandle) edge.sourceHandle = existing.sourceHandle;
+			if (existing?.targetHandle) edge.targetHandle = existing.targetHandle;
+			return edge;
+		});
 
 		// Boundaries first (rendered behind), then elements
 		set({

--- a/src/stores/model-store.ts
+++ b/src/stores/model-store.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { getStrideAdapter } from "@/lib/adapters/get-stride-adapter";
-import type { Element, Threat, ThreatModel } from "@/types/threat-model";
+import type { DataFlow, Element, Threat, ThreatModel } from "@/types/threat-model";
 
 interface ModelState {
 	/** The currently loaded threat model, or null if no model is open */
@@ -11,6 +11,8 @@ interface ModelState {
 	isDirty: boolean;
 	/** Currently selected element ID */
 	selectedElementId: string | null;
+	/** Currently selected edge/flow ID */
+	selectedEdgeId: string | null;
 	/** Currently selected threat ID */
 	selectedThreatId: string | null;
 	/** Whether STRIDE analysis is running */
@@ -22,10 +24,14 @@ interface ModelState {
 	markDirty: () => void;
 	markClean: () => void;
 	setSelectedElement: (id: string | null) => void;
+	setSelectedEdge: (id: string | null) => void;
 	setSelectedThreat: (id: string | null) => void;
 
 	// Element editing
 	updateElement: (id: string, updates: Partial<Element>) => void;
+
+	// Data flow editing
+	updateDataFlow: (id: string, updates: Partial<DataFlow>) => void;
 
 	// Threat CRUD
 	addThreat: (threat: Threat) => void;
@@ -42,6 +48,7 @@ export const useModelStore = create<ModelState>((set, get) => ({
 	filePath: null,
 	isDirty: false,
 	selectedElementId: null,
+	selectedEdgeId: null,
 	selectedThreatId: null,
 	isAnalyzing: false,
 
@@ -51,6 +58,7 @@ export const useModelStore = create<ModelState>((set, get) => ({
 			filePath,
 			isDirty: false,
 			selectedElementId: null,
+			selectedEdgeId: null,
 			selectedThreatId: null,
 		}),
 
@@ -60,12 +68,14 @@ export const useModelStore = create<ModelState>((set, get) => ({
 			filePath: null,
 			isDirty: false,
 			selectedElementId: null,
+			selectedEdgeId: null,
 			selectedThreatId: null,
 		}),
 
 	markDirty: () => set({ isDirty: true }),
 	markClean: () => set({ isDirty: false }),
-	setSelectedElement: (id) => set({ selectedElementId: id }),
+	setSelectedElement: (id) => set({ selectedElementId: id, selectedEdgeId: null }),
+	setSelectedEdge: (id) => set({ selectedEdgeId: id, selectedElementId: null }),
 	setSelectedThreat: (id) => set({ selectedThreatId: id }),
 
 	updateElement: (id, updates) => {
@@ -75,6 +85,17 @@ export const useModelStore = create<ModelState>((set, get) => ({
 		const updatedElements = model.elements.map((e) => (e.id === id ? { ...e, ...updates } : e));
 		set({
 			model: { ...model, elements: updatedElements },
+			isDirty: true,
+		});
+	},
+
+	updateDataFlow: (id, updates) => {
+		const { model } = get();
+		if (!model) return;
+
+		const updatedFlows = model.data_flows.map((f) => (f.id === id ? { ...f, ...updates } : f));
+		set({
+			model: { ...model, data_flows: updatedFlows },
 			isDirty: true,
 		});
 	},

--- a/src/stores/model-store.ts
+++ b/src/stores/model-store.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { getStrideAdapter } from "@/lib/adapters/get-stride-adapter";
-import type { DataFlow, Element, Threat, ThreatModel } from "@/types/threat-model";
+import type { DataFlow, Element, Threat, ThreatModel, TrustBoundary } from "@/types/threat-model";
 
 interface ModelState {
 	/** The currently loaded threat model, or null if no model is open */
@@ -13,6 +13,8 @@ interface ModelState {
 	selectedElementId: string | null;
 	/** Currently selected edge/flow ID */
 	selectedEdgeId: string | null;
+	/** Currently selected trust boundary ID */
+	selectedBoundaryId: string | null;
 	/** Currently selected threat ID */
 	selectedThreatId: string | null;
 	/** Whether STRIDE analysis is running */
@@ -25,6 +27,7 @@ interface ModelState {
 	markClean: () => void;
 	setSelectedElement: (id: string | null) => void;
 	setSelectedEdge: (id: string | null) => void;
+	setSelectedBoundary: (id: string | null) => void;
 	setSelectedThreat: (id: string | null) => void;
 
 	// Element editing
@@ -32,6 +35,9 @@ interface ModelState {
 
 	// Data flow editing
 	updateDataFlow: (id: string, updates: Partial<DataFlow>) => void;
+
+	// Trust boundary editing
+	updateTrustBoundary: (id: string, updates: Partial<TrustBoundary>) => void;
 
 	// Threat CRUD
 	addThreat: (threat: Threat) => void;
@@ -49,6 +55,7 @@ export const useModelStore = create<ModelState>((set, get) => ({
 	isDirty: false,
 	selectedElementId: null,
 	selectedEdgeId: null,
+	selectedBoundaryId: null,
 	selectedThreatId: null,
 	isAnalyzing: false,
 
@@ -59,6 +66,7 @@ export const useModelStore = create<ModelState>((set, get) => ({
 			isDirty: false,
 			selectedElementId: null,
 			selectedEdgeId: null,
+			selectedBoundaryId: null,
 			selectedThreatId: null,
 		}),
 
@@ -69,13 +77,18 @@ export const useModelStore = create<ModelState>((set, get) => ({
 			isDirty: false,
 			selectedElementId: null,
 			selectedEdgeId: null,
+			selectedBoundaryId: null,
 			selectedThreatId: null,
 		}),
 
 	markDirty: () => set({ isDirty: true }),
 	markClean: () => set({ isDirty: false }),
-	setSelectedElement: (id) => set({ selectedElementId: id, selectedEdgeId: null }),
-	setSelectedEdge: (id) => set({ selectedEdgeId: id, selectedElementId: null }),
+	setSelectedElement: (id) =>
+		set({ selectedElementId: id, selectedEdgeId: null, selectedBoundaryId: null }),
+	setSelectedEdge: (id) =>
+		set({ selectedEdgeId: id, selectedElementId: null, selectedBoundaryId: null }),
+	setSelectedBoundary: (id) =>
+		set({ selectedBoundaryId: id, selectedElementId: null, selectedEdgeId: null }),
 	setSelectedThreat: (id) => set({ selectedThreatId: id }),
 
 	updateElement: (id, updates) => {
@@ -96,6 +109,19 @@ export const useModelStore = create<ModelState>((set, get) => ({
 		const updatedFlows = model.data_flows.map((f) => (f.id === id ? { ...f, ...updates } : f));
 		set({
 			model: { ...model, data_flows: updatedFlows },
+			isDirty: true,
+		});
+	},
+
+	updateTrustBoundary: (id, updates) => {
+		const { model } = get();
+		if (!model) return;
+
+		const updatedBoundaries = model.trust_boundaries.map((b) =>
+			b.id === id ? { ...b, ...updates } : b,
+		);
+		set({
+			model: { ...model, trust_boundaries: updatedBoundaries },
 			isDirty: true,
 		});
 	},

--- a/src/stores/model-store.ts
+++ b/src/stores/model-store.ts
@@ -84,11 +84,23 @@ export const useModelStore = create<ModelState>((set, get) => ({
 	markDirty: () => set({ isDirty: true }),
 	markClean: () => set({ isDirty: false }),
 	setSelectedElement: (id) =>
-		set({ selectedElementId: id, selectedEdgeId: null, selectedBoundaryId: null }),
+		set({
+			selectedElementId: id,
+			selectedEdgeId: null,
+			selectedBoundaryId: null,
+		}),
 	setSelectedEdge: (id) =>
-		set({ selectedEdgeId: id, selectedElementId: null, selectedBoundaryId: null }),
+		set({
+			selectedEdgeId: id,
+			selectedElementId: null,
+			selectedBoundaryId: null,
+		}),
 	setSelectedBoundary: (id) =>
-		set({ selectedBoundaryId: id, selectedElementId: null, selectedEdgeId: null }),
+		set({
+			selectedBoundaryId: id,
+			selectedElementId: null,
+			selectedEdgeId: null,
+		}),
 	setSelectedThreat: (id) => set({ selectedThreatId: id }),
 
 	updateElement: (id, updates) => {

--- a/src/types/threat-model.ts
+++ b/src/types/threat-model.ts
@@ -44,6 +44,7 @@ export interface Element {
 
 export interface DataFlow {
 	id: string;
+	name: string;
 	from: string;
 	to: string;
 	protocol: string;


### PR DESCRIPTION
## Summary

Major canvas improvements covering connector routing, node/edge interactivity, context menus, and edge validation.

### New Features
- **Smart handle positioning** — `getSmartHandlePair()` selects optimal handle pair based on relative node positions
- **Bidirectional handles** — all four sides of every node now support both source and target connections via shared `NodeHandles` component
- **Inline label editing** — double-click any node or edge label to edit in-place; commits to both canvas and model stores
- **Edge inline editor** — two-field editor (protocol + data) with "+" button for edges without labels
- **Edge UX improvements** — 16px invisible hit area, hover state, animated flow direction dashes
- **Trust boundary resize** — `NodeResizeControl` from @xyflow/react
- **Context menus** — right-click nodes (Edit Properties, View Threats, Duplicate, Delete) and edges (Edit Properties, Reverse Direction, Delete)
- **Edge validation** — prevents self-loops and duplicate edges in store + ReactFlow `isValidConnection`
- **New store actions** — `duplicateElement()`, `reverseEdge()`, auto-assign to trust boundary on drop
- **Visual indicators** — threat count badges on nodes, technology pill badges below labels

### Testing
- 14 new unit tests for `canvas-utils.ts` (smart handle, edge validation)
- 6 new tests for canvas-store (self-loop prevention, duplicate prevention, duplicate element, reverse edge, auto-boundary assign)
- All 92 frontend + 33 Rust tests passing

### Files Changed
- **New**: `canvas-utils.ts`, `canvas-utils.test.ts`, `shared-handles.tsx`, `threat-badge.tsx`, `canvas-context-menu.tsx`
- **Modified**: all 4 node components, `data-flow-edge.tsx`, `canvas-store.ts`, `dfd-canvas.tsx`, `canvas-store.test.ts`, `biome.json`, `todo.md`
