### PR TITLE
refactor(schema): consolidate layout data into single YAML file

### DIFF
--- a/.claude/rules/yaml-format.md
+++ b/.claude/rules/yaml-format.md
@@ -6,29 +6,42 @@ The `.threatforge.yaml` format is the product's primary moat. Treat it with extr
 - NEVER make breaking changes to the schema without a version bump and migration path.
 - New fields must be optional with sensible defaults to maintain backward compatibility.
 - The `version` field is always the first field under root. Currently `"1.0"`.
+- Unknown fields are tolerated (no `deny_unknown_fields`) for forward compatibility.
 
 ## Structure
-```
-.threatforge.yaml          # Main threat model (elements, flows, boundaries, threats, metadata)
-.threatforge/
-  layouts/
-    {diagram-id}.json      # Canvas layout data (positions, zoom, viewport)
-```
+
+All data lives in a single `.threatforge.yaml` file — no sidecar files needed.
+
+Layout data (positions, sizes, viewport, colors) is stored inline on each entity:
+- `elements[].position` — `{x, y}` canvas position
+- `trust_boundaries[].position` — `{x, y}` canvas position
+- `trust_boundaries[].size` — `{width, height}` boundary dimensions
+- `trust_boundaries[].fill_color`, `stroke_color`, `fill_opacity`, `stroke_opacity` — visual styling
+- `data_flows[].label_offset` — `{x, y}` dragged label offset
+- `diagrams[].viewport` — `{x, y, zoom}` canvas viewport
+
+### Legacy sidecar format (deprecated)
+Old models may still reference `.threatforge/layouts/*.json` via `diagrams[].layout_file`.
+The Rust backend auto-migrates on open: reads the sidecar JSON and merges positions inline.
+New saves always use inline positions and omit `layout_file`.
 
 ## Design Principles
-- Layout data (x/y positions, zoom, viewport) goes in `.threatforge/layouts/`, NOT in the YAML.
+- Everything about an entity lives in one place (inline positions, not a separate section).
 - Each threat is a discrete YAML block — adding/removing threats produces clean diffs.
 - Element IDs are kebab-case slugs: `api-gateway`, `payment-db`.
 - Use YAML block scalars (`|`) for multi-line descriptions, not escaped strings.
 - Order: `version` -> `metadata` -> `elements` -> `data_flows` -> `trust_boundaries` -> `threats` -> `diagrams`.
+- All layout/visual fields are `Option<T>` — omitted when not set, keeping the YAML minimal.
 
 ## Validation
-- Schema validation runs on every file load via serde strict deserialization.
+- Schema validation runs on every file load via serde deserialization.
 - All `element` and `flow` references in threats must point to existing IDs.
 - All `contains` references in trust boundaries must point to existing element IDs.
 - Reject files with duplicate IDs within any section.
+- Version check on load — reject unsupported versions with clear errors.
 
 ## Testing
 - Every schema change needs a round-trip test: YAML -> Rust struct -> YAML -> assert equal.
 - Maintain a set of sample `.threatforge.yaml` files in `tests/fixtures/` for regression testing.
 - Test that git diffs for common operations (add element, add threat, reorder) are clean and minimal.
+- Test backward compatibility: old YAML files without new fields must still parse correctly.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -3,3 +3,60 @@
 Shared execution plan for humans and LLM agents. Update this file before, during, and after every work session.
 
 ---
+
+## 2026-03-01 — WS1: YAML Format Consolidation
+
+Consolidate layout data from separate `.threatforge/layouts/*.json` sidecar files into inline fields within `.threatforge.yaml`. Adds position/size/color/viewport fields directly on each entity.
+
+### Plan
+- [x] Step 1: Rust model changes (`threat_model.rs`)
+  - [x] Add `Position` and `Size` structs
+  - [x] Remove `deny_unknown_fields` from all 8 structs
+  - [x] Add optional position/size/color fields to Element, TrustBoundary, DataFlow, Diagram
+  - [x] Change `Diagram.layout_file` from `String` to `Option<String>`
+  - [x] Add `viewport: Option<Viewport>` to Diagram
+  - [x] Update `ThreatModel::new()` constructor
+  - [x] Validate: `cargo test` + `cargo clippy`
+- [x] Step 2: Rust test updates (`threat_model.rs` tests)
+  - [x] Remove `test_rejects_unknown_fields`
+  - [x] Add `test_inline_position_round_trip`
+  - [x] Add `test_old_yaml_without_positions_parses`
+  - [x] Add `test_unknown_fields_are_tolerated`
+  - [x] Verify `test_sample_yaml_deserialization` still passes
+  - [x] Validate: `cargo test`
+- [x] Step 3: Rust migration logic (`reader.rs`)
+  - [x] Add `merge_layout_into_model()` function
+  - [x] Add `test_merge_layout_into_model` test
+  - [x] Add `test_merge_layout_skips_when_no_layout_file` test
+  - [x] Validate: `cargo test` + `cargo clippy`
+- [x] Step 4: Rust command update (`file_commands.rs`)
+  - [x] Call migration in `open_threat_model`
+  - [x] Validate: `cargo test`
+- [x] Step 5: TypeScript type updates (`threat-model.ts`)
+  - [x] Add `Position` and `Size` interfaces
+  - [x] Add optional fields to Element, TrustBoundary, DataFlow, Diagram
+- [x] Step 6: Canvas store updates (`canvas-store.ts`)
+  - [x] Update `boundaryToNode` to read colors from model
+  - [x] Update `boundaryToNode` to read size from model
+  - [x] Update `flowToEdge` to read `label_offset`
+- [x] Step 7: File operations rewrite (`use-file-operations.ts`)
+  - [x] Add `captureCanvasIntoModel()`
+  - [x] Add `buildLayoutFromModel()`
+  - [x] Update `saveModel`/`saveModelAs` to use `captureCanvasIntoModel`
+  - [x] Update `openModel` to use `buildLayoutFromModel` with sidecar fallback
+- [x] Step 8: Browser adapter update
+  - [x] Update `createNewModel` diagram shape (remove `layout_file`)
+- [x] Step 9: Test updates
+  - [x] Update `model-store.test.ts` mock diagram (remove `layout_file`)
+  - [x] Add canvas-store test: inline position restoration
+  - [x] Add canvas-store test: boundary colors from model
+  - [x] Add canvas-store test: label offset from data flow
+- [x] Step 10: Update `.claude/rules/yaml-format.md`
+- [x] Final validation: `npm run ci:local` — ALL PASSED
+
+### Notes
+- All new fields are `Option<T>` with `serde(default, skip_serializing_if)` for backward compat
+- Migration reads old sidecar JSON and merges into model in memory on open
+- Layout IPC commands (`open_layout`/`save_layout`) stay registered but become unused
+- Also fixed struct constructors in `ai/prompt.rs` and `stride/mod.rs` for new fields
+- 37 Rust tests, 95 frontend tests — all passing

--- a/src-tauri/src/ai/prompt.rs
+++ b/src-tauri/src/ai/prompt.rs
@@ -153,6 +153,7 @@ mod tests {
             technologies: vec!["nginx".to_string()],
             stores: None,
             encryption: None,
+            position: None,
         });
 
         let prompt = build_system_prompt(&model);
@@ -178,6 +179,7 @@ mod tests {
             protocol: "HTTPS".to_string(),
             data: vec!["user_input".to_string()],
             authenticated: true,
+            label_offset: None,
         });
 
         let prompt = build_system_prompt(&model);

--- a/src-tauri/src/commands/file_commands.rs
+++ b/src-tauri/src/commands/file_commands.rs
@@ -10,7 +10,9 @@ pub fn create_new_model(title: String, author: String) -> Result<ThreatModel, St
 #[tauri::command]
 pub fn open_threat_model(path: String) -> Result<ThreatModel, String> {
     let path = PathBuf::from(path);
-    file_io::read_threat_model(&path).map_err(|e| e.to_string())
+    let mut model = file_io::read_threat_model(&path).map_err(|e| e.to_string())?;
+    file_io::merge_layout_into_model(&mut model, &path);
+    Ok(model)
 }
 
 #[tauri::command]

--- a/src-tauri/src/file_io/reader.rs
+++ b/src-tauri/src/file_io/reader.rs
@@ -1,5 +1,6 @@
 use crate::errors::ThreatForgeError;
-use crate::models::{DiagramLayout, ThreatModel};
+use crate::models::{DiagramLayout, Position, Size, ThreatModel, Viewport};
+use std::collections::HashMap;
 use std::path::Path;
 
 /// Read and parse a `.threatforge.yaml` file
@@ -35,6 +36,68 @@ pub fn read_layout(path: &Path) -> Result<DiagramLayout, ThreatForgeError> {
         })?;
 
     Ok(layout)
+}
+
+/// Migrate old-format models that use sidecar layout JSON files.
+///
+/// Detects diagrams with `layout_file: Some(...)` and `viewport: None`,
+/// reads the sidecar JSON, and merges positions into inline model fields.
+/// Failures are non-fatal — missing layout files are silently skipped.
+pub fn merge_layout_into_model(model: &mut ThreatModel, model_path: &Path) {
+    let model_dir = match model_path.parent() {
+        Some(dir) => dir,
+        None => return,
+    };
+
+    for diagram in &mut model.diagrams {
+        // Only migrate if there's a layout_file but no inline viewport yet
+        let layout_file = match (&diagram.layout_file, &diagram.viewport) {
+            (Some(lf), None) => lf.clone(),
+            _ => continue,
+        };
+
+        let layout_path = model_dir.join(&layout_file);
+        let layout = match read_layout(&layout_path) {
+            Ok(l) => l,
+            Err(_) => continue, // Non-fatal: layout file may not exist
+        };
+
+        // Build lookup from node ID to position data
+        let positions: HashMap<&str, _> = layout.nodes.iter().map(|n| (n.id.as_str(), n)).collect();
+
+        // Merge positions into elements
+        for element in &mut model.elements {
+            if let Some(np) = positions.get(element.id.as_str()) {
+                if element.position.is_none() {
+                    element.position = Some(Position { x: np.x, y: np.y });
+                }
+            }
+        }
+
+        // Merge positions and sizes into trust boundaries
+        for boundary in &mut model.trust_boundaries {
+            if let Some(np) = positions.get(boundary.id.as_str()) {
+                if boundary.position.is_none() {
+                    boundary.position = Some(Position { x: np.x, y: np.y });
+                }
+                if boundary.size.is_none() {
+                    if let (Some(w), Some(h)) = (np.width, np.height) {
+                        boundary.size = Some(Size {
+                            width: w,
+                            height: h,
+                        });
+                    }
+                }
+            }
+        }
+
+        // Set diagram viewport from layout
+        diagram.viewport = Some(Viewport {
+            x: layout.viewport.x,
+            y: layout.viewport.y,
+            zoom: layout.viewport.zoom,
+        });
+    }
 }
 
 /// Validate the schema version is supported
@@ -135,7 +198,7 @@ fn validate_references(model: &ThreatModel) -> Result<(), ThreatForgeError> {
 mod tests {
     use super::*;
     use std::io::Write;
-    use tempfile::NamedTempFile;
+    use tempfile::{NamedTempFile, TempDir};
 
     fn write_temp_yaml(content: &str) -> NamedTempFile {
         let mut file = NamedTempFile::new().unwrap();
@@ -210,6 +273,130 @@ elements:
         let result = read_threat_model(file.path());
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Duplicate"));
+    }
+
+    #[test]
+    fn test_merge_layout_into_model() {
+        let dir = TempDir::new().unwrap();
+        let model_path = dir.path().join("test.threatforge.yaml");
+        let layout_dir = dir.path().join(".threatforge/layouts");
+        std::fs::create_dir_all(&layout_dir).unwrap();
+
+        // Write a YAML model with old-style layout_file reference
+        let yaml = r#"
+version: "1.0"
+metadata:
+  title: "Migration Test"
+  author: "Test"
+  created: 2026-03-15
+  modified: 2026-03-15
+elements:
+  - id: web-app
+    type: process
+    name: "Web App"
+  - id: db
+    type: data_store
+    name: "Database"
+trust_boundaries:
+  - id: boundary-1
+    name: "Internal"
+    contains: [web-app, db]
+diagrams:
+  - id: main-dfd
+    name: "Level 0 DFD"
+    layout_file: ".threatforge/layouts/main-dfd.json"
+"#;
+        std::fs::write(&model_path, yaml).unwrap();
+
+        // Write matching layout JSON
+        let layout_json = r#"{
+  "diagram_id": "main-dfd",
+  "viewport": { "x": 10.0, "y": 20.0, "zoom": 1.5 },
+  "nodes": [
+    { "id": "web-app", "x": 100.0, "y": 200.0 },
+    { "id": "db", "x": 300.0, "y": 400.0 },
+    { "id": "boundary-1", "x": 50.0, "y": 50.0, "width": 600.0, "height": 500.0 }
+  ]
+}"#;
+        std::fs::write(layout_dir.join("main-dfd.json"), layout_json).unwrap();
+
+        let mut model = read_threat_model(&model_path).unwrap();
+        merge_layout_into_model(&mut model, &model_path);
+
+        // Verify element positions were merged
+        assert_eq!(
+            model.elements[0].position,
+            Some(Position { x: 100.0, y: 200.0 }),
+            "web-app position should be merged from layout"
+        );
+        assert_eq!(
+            model.elements[1].position,
+            Some(Position { x: 300.0, y: 400.0 }),
+            "db position should be merged from layout"
+        );
+
+        // Verify boundary position and size
+        assert_eq!(
+            model.trust_boundaries[0].position,
+            Some(Position { x: 50.0, y: 50.0 })
+        );
+        assert_eq!(
+            model.trust_boundaries[0].size,
+            Some(Size {
+                width: 600.0,
+                height: 500.0
+            })
+        );
+
+        // Verify viewport was set on diagram
+        assert_eq!(
+            model.diagrams[0].viewport,
+            Some(Viewport {
+                x: 10.0,
+                y: 20.0,
+                zoom: 1.5
+            })
+        );
+    }
+
+    #[test]
+    fn test_merge_layout_skips_when_no_layout_file() {
+        let dir = TempDir::new().unwrap();
+        let model_path = dir.path().join("test.threatforge.yaml");
+
+        // Write a model without layout_file (new format)
+        let yaml = r#"
+version: "1.0"
+metadata:
+  title: "New Format"
+  author: "Test"
+  created: 2026-03-15
+  modified: 2026-03-15
+elements:
+  - id: app
+    type: process
+    name: "App"
+    position:
+      x: 50.0
+      y: 60.0
+diagrams:
+  - id: main-dfd
+    name: "Level 0 DFD"
+    viewport:
+      x: 0.0
+      y: 0.0
+      zoom: 1.0
+"#;
+        std::fs::write(&model_path, yaml).unwrap();
+
+        let mut model = read_threat_model(&model_path).unwrap();
+        merge_layout_into_model(&mut model, &model_path);
+
+        // Position should remain unchanged (not overwritten)
+        assert_eq!(
+            model.elements[0].position,
+            Some(Position { x: 50.0, y: 60.0 })
+        );
     }
 
     #[test]

--- a/src-tauri/src/models/threat_model.rs
+++ b/src-tauri/src/models/threat_model.rs
@@ -4,7 +4,6 @@ use uuid::Uuid;
 
 /// Root threat model document — maps to `.threatforge.yaml`
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(deny_unknown_fields)]
 pub struct ThreatModel {
     pub version: String,
     pub metadata: Metadata,
@@ -39,14 +38,14 @@ impl ThreatModel {
             diagrams: vec![Diagram {
                 id: "main-dfd".to_string(),
                 name: "Level 0 DFD".to_string(),
-                layout_file: ".threatforge/layouts/main-dfd.json".to_string(),
+                layout_file: None,
+                viewport: None,
             }],
         }
     }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(deny_unknown_fields)]
 pub struct Metadata {
     pub title: String,
     pub author: String,
@@ -66,7 +65,6 @@ pub enum ElementType {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(deny_unknown_fields)]
 pub struct Element {
     pub id: String,
     #[serde(rename = "type")]
@@ -84,10 +82,11 @@ pub struct Element {
     pub stores: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub encryption: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub position: Option<Position>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(deny_unknown_fields)]
 pub struct DataFlow {
     pub id: String,
     #[serde(default)]
@@ -100,15 +99,28 @@ pub struct DataFlow {
     pub data: Vec<String>,
     #[serde(default)]
     pub authenticated: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label_offset: Option<Position>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(deny_unknown_fields)]
 pub struct TrustBoundary {
     pub id: String,
     pub name: String,
     #[serde(default)]
     pub contains: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub position: Option<Position>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size: Option<Size>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fill_color: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stroke_color: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fill_opacity: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stroke_opacity: Option<f64>,
 }
 
 /// STRIDE threat categories
@@ -146,7 +158,6 @@ pub enum MitigationStatus {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(deny_unknown_fields)]
 pub struct Mitigation {
     pub status: MitigationStatus,
     #[serde(default)]
@@ -154,7 +165,6 @@ pub struct Mitigation {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(deny_unknown_fields)]
 pub struct Threat {
     pub id: String,
     pub title: String,
@@ -171,11 +181,13 @@ pub struct Threat {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(deny_unknown_fields)]
 pub struct Diagram {
     pub id: String,
     pub name: String,
-    pub layout_file: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub layout_file: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub viewport: Option<Viewport>,
 }
 
 /// Layout data stored in `.threatforge/layouts/*.json`
@@ -192,6 +204,18 @@ pub struct Viewport {
     pub x: f64,
     pub y: f64,
     pub zoom: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Position {
+    pub x: f64,
+    pub y: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Size {
+    pub width: f64,
+    pub height: f64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -335,7 +359,132 @@ diagrams:
     }
 
     #[test]
-    fn test_rejects_unknown_fields() {
+    fn test_inline_position_round_trip() {
+        let yaml = r##"
+version: "1.0"
+metadata:
+  title: "Position Test"
+  author: "Test"
+  created: 2026-03-15
+  modified: 2026-03-15
+elements:
+  - id: web-app
+    type: process
+    name: "Web App"
+    position:
+      x: 100.0
+      y: 200.0
+trust_boundaries:
+  - id: boundary-1
+    name: "Internal"
+    contains: [web-app]
+    position:
+      x: 50.0
+      y: 50.0
+    size:
+      width: 500.0
+      height: 400.0
+    fill_color: "#3b82f6"
+    stroke_color: "#1e40af"
+    fill_opacity: 0.1
+    stroke_opacity: 0.6
+data_flows:
+  - id: flow-1
+    from: web-app
+    to: web-app
+    label_offset:
+      x: 10.0
+      y: -5.0
+diagrams:
+  - id: main-dfd
+    name: "Level 0 DFD"
+    viewport:
+      x: 0.0
+      y: 0.0
+      zoom: 1.5
+"##;
+        let model: ThreatModel = serde_yaml::from_str(yaml).expect("Failed to parse");
+        assert_eq!(
+            model.elements[0].position,
+            Some(Position { x: 100.0, y: 200.0 })
+        );
+        assert_eq!(
+            model.trust_boundaries[0].position,
+            Some(Position { x: 50.0, y: 50.0 })
+        );
+        assert_eq!(
+            model.trust_boundaries[0].size,
+            Some(Size {
+                width: 500.0,
+                height: 400.0
+            })
+        );
+        assert_eq!(
+            model.trust_boundaries[0].fill_color,
+            Some(String::from("#3b82f6"))
+        );
+        assert_eq!(model.trust_boundaries[0].fill_opacity, Some(0.1));
+        assert_eq!(
+            model.data_flows[0].label_offset,
+            Some(Position { x: 10.0, y: -5.0 })
+        );
+        assert_eq!(
+            model.diagrams[0].viewport,
+            Some(Viewport {
+                x: 0.0,
+                y: 0.0,
+                zoom: 1.5
+            })
+        );
+        assert!(model.diagrams[0].layout_file.is_none());
+
+        // Round-trip
+        let reserialized = serde_yaml::to_string(&model).expect("Failed to serialize");
+        let reparsed: ThreatModel = serde_yaml::from_str(&reserialized).expect("Failed to reparse");
+        assert_eq!(model, reparsed, "Round-trip should produce equal models");
+    }
+
+    #[test]
+    fn test_old_yaml_without_positions_parses() {
+        let yaml = r#"
+version: "1.0"
+metadata:
+  title: "Old Format"
+  author: "Test"
+  created: 2026-03-15
+  modified: 2026-03-15
+elements:
+  - id: app
+    type: process
+    name: "App"
+trust_boundaries:
+  - id: boundary-1
+    name: "Internal"
+    contains: [app]
+data_flows:
+  - id: flow-1
+    from: app
+    to: app
+diagrams:
+  - id: main-dfd
+    name: "Level 0 DFD"
+    layout_file: ".threatforge/layouts/main-dfd.json"
+"#;
+        let model: ThreatModel = serde_yaml::from_str(yaml).expect("Old format should parse");
+        assert!(model.elements[0].position.is_none());
+        assert!(model.trust_boundaries[0].position.is_none());
+        assert!(model.trust_boundaries[0].size.is_none());
+        assert!(model.trust_boundaries[0].fill_color.is_none());
+        assert!(model.data_flows[0].label_offset.is_none());
+        assert_eq!(
+            model.diagrams[0].layout_file,
+            Some(".threatforge/layouts/main-dfd.json".to_string())
+        );
+        assert!(model.diagrams[0].viewport.is_none());
+    }
+
+    #[test]
+    fn test_unknown_fields_are_tolerated() {
         let yaml = r#"
 version: "1.0"
 metadata:
@@ -343,10 +492,13 @@ metadata:
   author: "Test"
   created: 2026-03-15
   modified: 2026-03-15
-unknown_field: "should fail"
+unknown_field: "should be tolerated"
 "#;
         let result = serde_yaml::from_str::<ThreatModel>(yaml);
-        assert!(result.is_err(), "Should reject unknown top-level fields");
+        assert!(
+            result.is_ok(),
+            "Unknown fields should be tolerated for forward compatibility"
+        );
     }
 
     #[test]

--- a/src-tauri/src/stride/mod.rs
+++ b/src-tauri/src/stride/mod.rs
@@ -301,6 +301,7 @@ mod tests {
                     technologies: vec![],
                     stores: None,
                     encryption: None,
+                    position: None,
                 },
                 Element {
                     id: "db".to_string(),
@@ -312,6 +313,7 @@ mod tests {
                     technologies: vec!["PostgreSQL".to_string()],
                     stores: None,
                     encryption: None,
+                    position: None,
                 },
                 Element {
                     id: "user".to_string(),
@@ -323,6 +325,7 @@ mod tests {
                     technologies: vec![],
                     stores: None,
                     encryption: None,
+                    position: None,
                 },
             ],
             data_flows: vec![DataFlow {
@@ -333,11 +336,18 @@ mod tests {
                 protocol: "PostgreSQL/TLS".to_string(),
                 data: vec!["user_records".to_string()],
                 authenticated: true,
+                label_offset: None,
             }],
             trust_boundaries: vec![TrustBoundary {
                 id: "boundary-1".to_string(),
                 name: "Internal Network".to_string(),
                 contains: vec!["web-app".to_string(), "db".to_string()],
+                position: None,
+                size: None,
+                fill_color: None,
+                stroke_color: None,
+                fill_opacity: None,
+                stroke_opacity: None,
             }],
             threats: vec![],
             diagrams: vec![],
@@ -465,6 +475,7 @@ mod tests {
             protocol: "HTTPS".to_string(),
             data: vec!["response".to_string()],
             authenticated: false,
+            label_offset: None,
         });
 
         let threats = analyze(&model);

--- a/src/hooks/use-file-operations.ts
+++ b/src/hooks/use-file-operations.ts
@@ -1,35 +1,101 @@
 import { useCallback } from "react";
 import { getFileAdapter } from "@/lib/adapters/get-file-adapter";
+import type { DfdEdgeData } from "@/stores/canvas-store";
 import { useCanvasStore } from "@/stores/canvas-store";
 import { useModelStore } from "@/stores/model-store";
-import type { ThreatModel } from "@/types/threat-model";
+import type { DiagramLayout, ThreatModel } from "@/types/threat-model";
 
 function todayString(): string {
 	return new Date().toISOString().split("T")[0];
 }
 
-/** Build a DiagramLayout from current canvas state. */
-function captureLayout(diagramId: string) {
-	const { nodes, viewport } = useCanvasStore.getState();
-	return {
-		diagram_id: diagramId,
-		viewport,
-		nodes: nodes.map((n) => ({
-			id: n.id,
-			x: n.position.x,
-			y: n.position.y,
-			...(n.width != null ? { width: n.width } : {}),
-			...(n.height != null ? { height: n.height } : {}),
-		})),
-	};
+/** Write current canvas positions, boundary colors, and label offsets back into the model. */
+function captureCanvasIntoModel(model: ThreatModel): ThreatModel {
+	const { nodes, edges, viewport } = useCanvasStore.getState();
+
+	const nodeMap = new Map(nodes.map((n) => [n.id, n]));
+	const edgeMap = new Map(edges.map((e) => [e.id, e]));
+
+	const elements = model.elements.map((el) => {
+		const node = nodeMap.get(el.id);
+		if (!node) return el;
+		return { ...el, position: { x: node.position.x, y: node.position.y } };
+	});
+
+	const trust_boundaries = model.trust_boundaries.map((b) => {
+		const node = nodeMap.get(b.id);
+		if (!node) return b;
+		const w = node.width ?? (node.style as Record<string, number> | undefined)?.width ?? 400;
+		const h = node.height ?? (node.style as Record<string, number> | undefined)?.height ?? 300;
+		return {
+			...b,
+			position: { x: node.position.x, y: node.position.y },
+			size: { width: w, height: h },
+			fill_color: node.data.boundaryFillColor ?? b.fill_color,
+			stroke_color: node.data.boundaryStrokeColor ?? b.stroke_color,
+			fill_opacity: node.data.boundaryFillOpacity ?? b.fill_opacity,
+			stroke_opacity: node.data.boundaryStrokeOpacity ?? b.stroke_opacity,
+		};
+	});
+
+	const data_flows = model.data_flows.map((f) => {
+		const edge = edgeMap.get(f.id);
+		const edgeData = edge?.data as DfdEdgeData | undefined;
+		if (!edgeData) return f;
+		const hasOffset = edgeData.labelOffsetX != null || edgeData.labelOffsetY != null;
+		return {
+			...f,
+			label_offset: hasOffset
+				? { x: edgeData.labelOffsetX ?? 0, y: edgeData.labelOffsetY ?? 0 }
+				: f.label_offset,
+		};
+	});
+
+	const diagrams = model.diagrams.map((d) => ({
+		...d,
+		layout_file: undefined,
+		viewport: { ...viewport },
+	}));
+
+	return { ...model, elements, trust_boundaries, data_flows, diagrams };
 }
 
-/** Save layout alongside the model file. Failures are non-fatal. */
-async function persistLayout(modelPath: string, model: ThreatModel): Promise<void> {
-	if (model.diagrams.length === 0) return;
-	const adapter = await getFileAdapter();
-	const layout = captureLayout(model.diagrams[0].id);
-	await adapter.saveLayout(modelPath, model.diagrams[0].layout_file, layout);
+/** Build a DiagramLayout from inline model positions (for setPendingLayout). */
+function buildLayoutFromModel(model: ThreatModel): DiagramLayout | null {
+	if (model.diagrams.length === 0) return null;
+
+	const diagram = model.diagrams[0];
+
+	// Only build if there are inline positions to use
+	const hasInlinePositions =
+		model.elements.some((e) => e.position) || model.trust_boundaries.some((b) => b.position);
+
+	if (!hasInlinePositions && !diagram.viewport) return null;
+
+	const nodes = [
+		...model.elements
+			.filter((e) => e.position)
+			.map((e) => ({
+				id: e.id,
+				x: e.position?.x ?? 0,
+				y: e.position?.y ?? 0,
+			})),
+		...model.trust_boundaries
+			.filter((b) => b.position)
+			.map((b) => ({
+				id: b.id,
+				x: b.position?.x ?? 0,
+				y: b.position?.y ?? 0,
+				width: b.size?.width,
+				height: b.size?.height,
+			})),
+	];
+
+	return {
+		diagram_id: diagram.id,
+		viewport: diagram.viewport ?? { x: 0, y: 0, zoom: 1 },
+		nodes,
+	};
 }
 
 export function useFileOperations() {
@@ -67,8 +133,12 @@ export function useFileOperations() {
 
 		const { model: loaded, path } = result;
 
-		// Try to load the saved layout so positions are restored
-		if (loaded.diagrams.length > 0 && path) {
+		// Build layout from inline positions (new format) or try sidecar (old format)
+		const inlineLayout = buildLayoutFromModel(loaded);
+		if (inlineLayout) {
+			useCanvasStore.getState().setPendingLayout(inlineLayout);
+		} else if (loaded.diagrams.length > 0 && loaded.diagrams[0].layout_file && path) {
+			// Fallback: try loading old sidecar layout file
 			const layout = await adapter.openLayout(path, loaded.diagrams[0].layout_file);
 			useCanvasStore.getState().setPendingLayout(layout);
 		} else {
@@ -82,37 +152,31 @@ export function useFileOperations() {
 	const saveModel = useCallback(async () => {
 		if (!model) return;
 
-		const modelToSave: ThreatModel = {
+		const captured = captureCanvasIntoModel({
 			...model,
 			metadata: { ...model.metadata, modified: todayString() },
-		};
+		});
 
 		const adapter = await getFileAdapter();
-		const savedPath = await adapter.saveThreatModel(modelToSave, filePath);
+		const savedPath = await adapter.saveThreatModel(captured, filePath);
 		if (!savedPath) return;
 
-		// Save layout alongside model
-		await persistLayout(savedPath, modelToSave);
-
-		setModel(modelToSave, savedPath);
+		setModel(captured, savedPath);
 	}, [model, filePath, setModel]);
 
 	const saveModelAs = useCallback(async () => {
 		if (!model) return;
 
-		const modelToSave: ThreatModel = {
+		const captured = captureCanvasIntoModel({
 			...model,
 			metadata: { ...model.metadata, modified: todayString() },
-		};
+		});
 
 		const adapter = await getFileAdapter();
-		const savedPath = await adapter.saveThreatModel(modelToSave, null);
+		const savedPath = await adapter.saveThreatModel(captured, null);
 		if (!savedPath) return;
 
-		// Save layout alongside model
-		await persistLayout(savedPath, modelToSave);
-
-		setModel(modelToSave, savedPath);
+		setModel(captured, savedPath);
 	}, [model, setModel]);
 
 	const closeModel = useCallback(async () => {

--- a/src/lib/adapters/browser-file-adapter.ts
+++ b/src/lib/adapters/browser-file-adapter.ts
@@ -33,7 +33,6 @@ export class BrowserFileAdapter implements FileAdapter {
 				{
 					id: "main-dfd",
 					name: "Level 0 DFD",
-					layout_file: ".threatforge/layouts/main-dfd.json",
 				},
 			],
 		};

--- a/src/lib/adapters/file-adapter.ts
+++ b/src/lib/adapters/file-adapter.ts
@@ -13,9 +13,9 @@ export interface FileAdapter {
 	openThreatModel(): Promise<{ model: ThreatModel; path: string | null } | null>;
 	/** Save a threat model to YAML. If no path provided, show save dialog. */
 	saveThreatModel(model: ThreatModel, path: string | null): Promise<string | null>;
-	/** Load layout data for a diagram. */
+	/** @deprecated Layout data is now inline in the YAML. Kept for old-format fallback. */
 	openLayout(modelPath: string, layoutFile: string): Promise<DiagramLayout | null>;
-	/** Save layout data alongside the model. */
+	/** @deprecated Layout data is now inline in the YAML. Will be removed in a future release. */
 	saveLayout(modelPath: string, layoutFile: string, layout: DiagramLayout): Promise<void>;
 	/** Show a confirmation dialog for discarding unsaved changes. */
 	confirmDiscard(): Promise<boolean>;

--- a/src/stores/canvas-store.test.ts
+++ b/src/stores/canvas-store.test.ts
@@ -285,4 +285,81 @@ describe("canvas-store", () => {
 		const boundary = model?.trust_boundaries.find((b) => b.id === "boundary-1");
 		expect(boundary?.contains).toContain("process-2");
 	});
+
+	it("reads inline positions from model via pending layout", () => {
+		const model = createTestModel();
+		// Set inline positions on elements
+		model.elements[0].position = { x: 150, y: 250 };
+		model.elements[1].position = { x: 350, y: 450 };
+		model.trust_boundaries[0].position = { x: 20, y: 30 };
+		model.trust_boundaries[0].size = { width: 600, height: 500 };
+
+		// Build a layout from inline positions (simulating what openModel does)
+		const nodes = [
+			...model.elements
+				.filter((e) => e.position)
+				.map((e) => ({
+					id: e.id,
+					x: e.position?.x ?? 0,
+					y: e.position?.y ?? 0,
+				})),
+			...model.trust_boundaries
+				.filter((b) => b.position)
+				.map((b) => ({
+					id: b.id,
+					x: b.position?.x ?? 0,
+					y: b.position?.y ?? 0,
+					width: b.size?.width,
+					height: b.size?.height,
+				})),
+		];
+
+		useCanvasStore.getState().setPendingLayout({
+			diagram_id: "main-dfd",
+			viewport: { x: 0, y: 0, zoom: 1 },
+			nodes,
+		});
+		useModelStore.getState().setModel(model, null);
+		useCanvasStore.getState().syncFromModel();
+
+		const processNode = useCanvasStore.getState().nodes.find((n) => n.id === "process-1");
+		expect(processNode?.position).toEqual({ x: 150, y: 250 });
+
+		const dataStoreNode = useCanvasStore.getState().nodes.find((n) => n.id === "data-store-1");
+		expect(dataStoreNode?.position).toEqual({ x: 350, y: 450 });
+
+		const boundaryNode = useCanvasStore.getState().nodes.find((n) => n.id === "boundary-1");
+		expect(boundaryNode?.position).toEqual({ x: 20, y: 30 });
+		expect(boundaryNode?.width).toBe(600);
+		expect(boundaryNode?.height).toBe(500);
+	});
+
+	it("reads boundary colors from model fields", () => {
+		const model = createTestModel();
+		model.trust_boundaries[0].fill_color = "#3b82f6";
+		model.trust_boundaries[0].stroke_color = "#1e40af";
+		model.trust_boundaries[0].fill_opacity = 0.15;
+		model.trust_boundaries[0].stroke_opacity = 0.7;
+
+		useModelStore.getState().setModel(model, null);
+		useCanvasStore.getState().syncFromModel();
+
+		const boundaryNode = useCanvasStore.getState().nodes.find((n) => n.id === "boundary-1");
+		expect(boundaryNode?.data.boundaryFillColor).toBe("#3b82f6");
+		expect(boundaryNode?.data.boundaryStrokeColor).toBe("#1e40af");
+		expect(boundaryNode?.data.boundaryFillOpacity).toBe(0.15);
+		expect(boundaryNode?.data.boundaryStrokeOpacity).toBe(0.7);
+	});
+
+	it("reads label offset from data flow model fields", () => {
+		const model = createTestModel();
+		model.data_flows[0].label_offset = { x: 15, y: -10 };
+
+		useModelStore.getState().setModel(model, null);
+		useCanvasStore.getState().syncFromModel();
+
+		const edge = useCanvasStore.getState().edges.find((e) => e.id === "flow-1");
+		expect(edge?.data?.labelOffsetX).toBe(15);
+		expect(edge?.data?.labelOffsetY).toBe(-10);
+	});
 });

--- a/src/stores/canvas-store.ts
+++ b/src/stores/canvas-store.ts
@@ -134,16 +134,18 @@ function elementToNode(element: Element, position: { x: number; y: number }): Df
 }
 
 function boundaryToNode(boundary: TrustBoundary, position: { x: number; y: number }): DfdNode {
+	const w = boundary.size?.width ?? 400;
+	const h = boundary.size?.height ?? 300;
 	return {
 		id: boundary.id,
 		type: "trustBoundary",
 		position,
-		width: 400,
-		height: 300,
+		width: w,
+		height: h,
 		// pointerEvents:none on the ReactFlow wrapper so clicks inside the boundary
 		// pass through to child nodes and edges. The label and resize handle inside
 		// TrustBoundaryNode opt back in with pointer-events:auto.
-		style: { width: 400, height: 300, pointerEvents: "none" as const },
+		style: { width: w, height: h, pointerEvents: "none" as const },
 		data: {
 			label: boundary.name,
 			elementType: "process", // unused for boundaries
@@ -152,6 +154,10 @@ function boundaryToNode(boundary: TrustBoundary, position: { x: number; y: numbe
 			technologies: [],
 			isBoundary: true,
 			boundaryName: boundary.name,
+			boundaryFillColor: boundary.fill_color,
+			boundaryStrokeColor: boundary.stroke_color,
+			boundaryFillOpacity: boundary.fill_opacity,
+			boundaryStrokeOpacity: boundary.stroke_opacity,
 		},
 	};
 }
@@ -167,6 +173,8 @@ function flowToEdge(flow: DataFlow): DfdEdge {
 			protocol: flow.protocol,
 			data: flow.data,
 			authenticated: flow.authenticated,
+			labelOffsetX: flow.label_offset?.x,
+			labelOffsetY: flow.label_offset?.y,
 		},
 	};
 }

--- a/src/stores/model-store.test.ts
+++ b/src/stores/model-store.test.ts
@@ -32,7 +32,6 @@ const mockModel: ThreatModel = {
 		{
 			id: "main-dfd",
 			name: "Level 0 DFD",
-			layout_file: ".threatforge/layouts/main-dfd.json",
 		},
 	],
 };

--- a/src/types/threat-model.ts
+++ b/src/types/threat-model.ts
@@ -30,6 +30,16 @@ export interface Metadata {
 	description: string;
 }
 
+export interface Position {
+	x: number;
+	y: number;
+}
+
+export interface Size {
+	width: number;
+	height: number;
+}
+
 export interface Element {
 	id: string;
 	type: ElementType;
@@ -40,6 +50,7 @@ export interface Element {
 	technologies: string[];
 	stores?: string[];
 	encryption?: string;
+	position?: Position;
 }
 
 export interface DataFlow {
@@ -50,12 +61,19 @@ export interface DataFlow {
 	protocol: string;
 	data: string[];
 	authenticated: boolean;
+	label_offset?: Position;
 }
 
 export interface TrustBoundary {
 	id: string;
 	name: string;
 	contains: string[];
+	position?: Position;
+	size?: Size;
+	fill_color?: string;
+	stroke_color?: string;
+	fill_opacity?: number;
+	stroke_opacity?: number;
 }
 
 export interface Mitigation {
@@ -77,7 +95,8 @@ export interface Threat {
 export interface Diagram {
 	id: string;
 	name: string;
-	layout_file: string;
+	layout_file?: string;
+	viewport?: Viewport;
 }
 
 export interface ThreatModel {


### PR DESCRIPTION
## Summary

- **Inline positions**: Element, TrustBoundary, DataFlow, and Diagram now carry optional position/size/color/viewport fields directly in `.threatforge.yaml` — no more sidecar `.threatforge/layouts/*.json` files needed
- **Auto-migration**: `open_threat_model` detects old-format models with `layout_file` references, reads the sidecar JSON, and merges positions into the model in memory
- **Forward compatibility**: Removed `deny_unknown_fields` from all 8 serde structs so older app versions tolerate new fields gracefully

## Details

| Area | Changes |
|------|---------|
| Rust models | Added `Position`/`Size` structs; optional inline fields on `Element`, `TrustBoundary`, `DataFlow`, `Diagram`; `layout_file` now `Option<String>` |
| Rust migration | `merge_layout_into_model()` in `reader.rs` handles old sidecar → inline conversion |
| TS types | Mirrored all Rust type changes in `threat-model.ts` |
| Canvas store | `boundaryToNode` reads colors/size from model; `flowToEdge` reads `label_offset` |
| File operations | Replaced `captureLayout`/`persistLayout` with `captureCanvasIntoModel`/`buildLayoutFromModel` |
| Tests | +3 Rust tests (round-trip, migration, backward compat), +3 TS tests (inline positions, colors, label offset) |

## Test plan

- [x] `npm run ci:local` passes (Biome, tsc, cargo fmt, clippy, 95 Vitest, 37 cargo test)
- [x] Manual: create model → add elements/boundaries → save → reopen → verify positions restored
- [x] Manual: open old-format model with sidecar layout → verify migration works
- [x] Manual: verify boundary colors and label offsets persist across save/reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)