### PR TITLE
feat(canvas): clipboard operations, multi-select, and E2E tests

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -4,6 +4,63 @@ Shared execution plan for humans and LLM agents. Update this file before, during
 
 ---
 
+## 2026-03-02 — Launch Readiness: Canvas Clipboard + E2E Tests
+
+Multi-select, clipboard operations (copy/cut/paste/select-all), and E2E test coverage for critical happy paths.
+
+### Plan
+- [x] Step 1: Export helpers from canvas-store.ts
+  - [x] Export generateElementId, generateFlowId, generateBoundaryId
+  - [x] Export elementToNode, boundaryToNode, flowToEdge
+- [x] Step 2: Create clipboard store (src/stores/clipboard-store.ts)
+  - [x] selectAll — set all nodes selected
+  - [x] copySelected — copy elements/boundaries/flows to clipboard
+  - [x] cutSelected — copy + delete
+  - [x] paste — clone with new IDs, offset positions, push history
+- [x] Step 3: Enable ReactFlow multi-select (dfd-canvas.tsx)
+  - [x] Add selectionKeyCode, multiSelectionKeyCode, selectionMode props
+- [x] Step 4: Fix multi-select deselection (canvas-store.ts)
+  - [x] Only clear model selection when zero nodes remain selected
+- [x] Step 5: Wire keyboard shortcuts (use-keyboard-shortcuts.ts)
+  - [x] Cmd+A → selectAll, Cmd+C → copy, Cmd+X → cut, Cmd+V → paste
+  - [x] Guard with isInputFocused
+- [x] Step 6: Update shortcuts list (settings.ts)
+  - [x] Add copy, cut, paste entries
+- [x] Step 7: Clipboard store unit tests (18 tests)
+- [x] Step 8: E2E test fixtures (e2e/fixtures.ts)
+- [x] Step 9: E2E tests (18 tests across 5 files)
+  - [x] app-launch.spec.ts (3 tests)
+  - [x] new-model.spec.ts (3 tests)
+  - [x] canvas-elements.spec.ts (5 tests)
+  - [x] keyboard-shortcuts.spec.ts (5 tests)
+  - [x] stride-analysis.spec.ts (2 tests)
+- [x] Step 10: Validation — biome, vitest, playwright, cargo test, ci:local
+
+### Code Review Fixes (post-implementation)
+- [x] Clipboard store: deep-clone mutable arrays (technologies, data, contains) on copy and paste
+- [x] Clipboard store: hoist `newElIds` Set outside `.filter()` callback (O(n²) → O(n))
+- [x] Clipboard store: insert pasted boundaries at front of nodes array (render behind elements)
+- [x] Clipboard store: set parentId/extent on pasted elements inside pasted boundaries
+- [x] dfd-canvas.tsx: remove `selectionKeyCode="Shift"` — was breaking free rubber-band select
+- [x] use-keyboard-shortcuts.ts: extend `isInputFocused` to cover `contentEditable` elements
+- [x] canvas-store.ts: fix `.find()` → `.filter()` for multi-select batch — use last selected node for properties panel
+- [x] stride-analysis E2E: strengthen assertion from `/\d+/` to `/[1-9]\d*/` (reject "0" threats)
+- [x] keyboard-shortcuts E2E: use bottom-right corner click position (avoids landing on auto-placed nodes)
+- [x] Validation — biome, vitest (158), playwright (36/36 with 2x repeat), tsc, ci:local — all passed
+
+### Notes
+- 158 frontend tests (up from 140), 40 Rust tests — all passing
+- 18 E2E tests across 5 files — all passing (36/36 with 2x repeat for flake detection)
+- Added data-testid="btn-stride-analyze" to threats-tab.tsx for E2E
+- Multi-select uses Shift+click for additive selection; rubber-band select works without modifier
+- Clipboard is in-memory only (not system clipboard) — simpler, no serialization
+- Paste offset cascades at 50px per paste (Figma pattern)
+- First paste adds "(copy)" suffix; subsequent pastes don't
+- Pasted boundary nodes go to front of array (render behind); element nodes go to end
+- Elements inside pasted boundaries get parentId/extent set for proper containment
+
+---
+
 ## 2026-03-01 — WS1: YAML Format Consolidation
 
 Consolidate layout data from separate `.threatforge/layouts/*.json` sidecar files into inline fields within `.threatforge.yaml`. Adds position/size/color/viewport fields directly on each entity.

--- a/e2e/app-launch.spec.ts
+++ b/e2e/app-launch.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "./fixtures";
+
+test.describe("App Launch", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto("/");
+	});
+
+	test("shows empty canvas state on launch", async ({ page }) => {
+		await expect(page.getByTestId("empty-canvas")).toBeVisible();
+		await expect(page.getByTestId("btn-empty-new")).toBeVisible();
+		await expect(page.getByTestId("btn-empty-open")).toBeVisible();
+	});
+
+	test("has top menu bar with controls", async ({ page }) => {
+		await expect(page.getByTestId("top-menu-bar")).toBeVisible();
+		await expect(page.getByTestId("btn-new")).toBeVisible();
+		await expect(page.getByTestId("btn-save")).toBeVisible();
+	});
+
+	test("has status bar at bottom", async ({ page }) => {
+		await expect(page.getByTestId("status-bar")).toBeVisible();
+	});
+});

--- a/e2e/canvas-elements.spec.ts
+++ b/e2e/canvas-elements.spec.ts
@@ -1,0 +1,50 @@
+import { addPaletteItem, createModel, expect, modKey, test } from "./fixtures";
+
+test.describe("Canvas Elements", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto("/");
+		await createModel(page);
+	});
+
+	test("adds element via double-click on palette item", async ({ page }) => {
+		await addPaletteItem(page, "palette-item-generic");
+		// Node should appear on canvas
+		const node = page.locator("[data-testid^='node-']").first();
+		await expect(node).toBeVisible();
+	});
+
+	test("adds a typed component from the library", async ({ page }) => {
+		await addPaletteItem(page, "palette-item-web-server");
+		const node = page.locator("[data-testid^='node-']").first();
+		await expect(node).toBeVisible();
+		await expect(node).toContainText("Web Server");
+	});
+
+	test("adds multiple elements", async ({ page }) => {
+		await addPaletteItem(page, "palette-item-generic");
+		await addPaletteItem(page, "palette-item-web-server");
+		const nodes = page.locator("[data-testid^='node-']");
+		await expect(nodes).toHaveCount(2);
+	});
+
+	test("deletes element with Delete key", async ({ page }) => {
+		await addPaletteItem(page, "palette-item-generic");
+		// Click on the node to select it
+		const node = page.locator("[data-testid^='node-']").first();
+		await node.click();
+		// Press Delete
+		await page.keyboard.press("Delete");
+		// Node should be gone
+		await expect(page.locator("[data-testid^='node-']")).toHaveCount(0);
+	});
+
+	test("clicking element shows properties panel", async ({ page }) => {
+		await addPaletteItem(page, "palette-item-web-server");
+		const node = page.locator("[data-testid^='node-']").first();
+		await node.click();
+		// Properties tab should be active and show element info
+		await expect(page.getByTestId("tab-properties")).toBeVisible();
+		// The right panel should contain the element name
+		await expect(page.getByTestId("right-panel")).toContainText("Web Server");
+	});
+});

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,18 @@
+import { type Page, test as base } from "@playwright/test";
+
+/** Platform-aware modifier key: Meta on macOS, Control elsewhere */
+export const modKey = process.platform === "darwin" ? "Meta" : "Control";
+
+/** Click the "New Model" button from the empty canvas state and wait for the canvas to load */
+export async function createModel(page: Page) {
+	await page.getByTestId("btn-empty-new").click();
+	await page.getByTestId("component-palette").waitFor({ state: "visible" });
+}
+
+/** Double-click a palette item to add it to the canvas */
+export async function addPaletteItem(page: Page, testId: string) {
+	await page.getByTestId(testId).dblclick();
+}
+
+export const test = base;
+export { expect } from "@playwright/test";

--- a/e2e/keyboard-shortcuts.spec.ts
+++ b/e2e/keyboard-shortcuts.spec.ts
@@ -1,0 +1,60 @@
+import { addPaletteItem, createModel, expect, modKey, test } from "./fixtures";
+
+test.describe("Keyboard Shortcuts", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto("/");
+	});
+
+	test("Cmd+Z undoes last action", async ({ page }) => {
+		await createModel(page);
+		await addPaletteItem(page, "palette-item-generic");
+		await expect(page.locator("[data-testid^='node-']")).toHaveCount(1);
+
+		// Click an empty area of the canvas to ensure focus (far from default node position)
+		const canvas = page.getByTestId("canvas-area");
+		const box = await canvas.boundingBox();
+		await canvas.click({
+			position: { x: (box?.width ?? 800) - 20, y: (box?.height ?? 600) - 20 },
+		});
+		await page.keyboard.press(`${modKey}+z`);
+		await expect(page.locator("[data-testid^='node-']")).toHaveCount(0);
+	});
+
+	test("Cmd+Shift+Z redoes undone action", async ({ page }) => {
+		await createModel(page);
+		await addPaletteItem(page, "palette-item-generic");
+
+		const canvas = page.getByTestId("canvas-area");
+		const box = await canvas.boundingBox();
+		await canvas.click({
+			position: { x: (box?.width ?? 800) - 20, y: (box?.height ?? 600) - 20 },
+		});
+		await page.keyboard.press(`${modKey}+z`);
+		await expect(page.locator("[data-testid^='node-']")).toHaveCount(0);
+
+		// Redo
+		await page.keyboard.press(`${modKey}+Shift+z`);
+		await expect(page.locator("[data-testid^='node-']")).toHaveCount(1);
+	});
+
+	test("Cmd+/ opens shortcuts dialog", async ({ page }) => {
+		// Click body to ensure page has keyboard focus
+		await page.locator("body").click();
+		await page.keyboard.press(`${modKey}+/`);
+		await expect(page.getByTestId("shortcuts-dialog")).toBeVisible();
+	});
+
+	test("Cmd+, opens settings dialog", async ({ page }) => {
+		await page.locator("body").click();
+		await page.keyboard.press(`${modKey}+,`);
+		await expect(page.getByTestId("settings-dialog")).toBeVisible();
+	});
+
+	test("Escape closes dialog", async ({ page }) => {
+		await page.locator("body").click();
+		await page.keyboard.press(`${modKey}+/`);
+		await expect(page.getByTestId("shortcuts-dialog")).toBeVisible();
+		await page.keyboard.press("Escape");
+		await expect(page.getByTestId("shortcuts-dialog")).not.toBeVisible();
+	});
+});

--- a/e2e/new-model.spec.ts
+++ b/e2e/new-model.spec.ts
@@ -1,0 +1,26 @@
+import { createModel, expect, test } from "./fixtures";
+
+test.describe("New Model", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto("/");
+	});
+
+	test("creates new model via empty state button", async ({ page }) => {
+		await createModel(page);
+		// Canvas area should still be visible but no longer showing empty state
+		await expect(page.getByTestId("canvas-area")).toBeVisible();
+		await expect(page.getByTestId("empty-canvas")).not.toBeVisible();
+	});
+
+	test("creates new model via toolbar button", async ({ page }) => {
+		await page.getByTestId("btn-new").click();
+		await expect(page.getByTestId("component-palette")).toBeVisible();
+		await expect(page.getByTestId("empty-canvas")).not.toBeVisible();
+	});
+
+	test("shows palette and right panel after creation", async ({ page }) => {
+		await createModel(page);
+		await expect(page.getByTestId("component-palette")).toBeVisible();
+		await expect(page.getByTestId("right-panel")).toBeVisible();
+	});
+});

--- a/e2e/stride-analysis.spec.ts
+++ b/e2e/stride-analysis.spec.ts
@@ -1,0 +1,32 @@
+import { addPaletteItem, createModel, expect, test } from "./fixtures";
+
+test.describe("STRIDE Analysis", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto("/");
+		await createModel(page);
+	});
+
+	test("STRIDE button is disabled with no elements", async ({ page }) => {
+		// Switch to threats tab
+		await page.getByTestId("tab-threats").click();
+		const btn = page.getByTestId("btn-stride-analyze");
+		await expect(btn).toBeVisible();
+		await expect(btn).toBeDisabled();
+	});
+
+	test("generates threats after adding elements", async ({ page }) => {
+		// Add two elements so STRIDE rules can fire
+		await addPaletteItem(page, "palette-item-web-server");
+		await addPaletteItem(page, "palette-item-sql-database");
+
+		// Switch to threats tab and run analysis
+		await page.getByTestId("tab-threats").click();
+		const btn = page.getByTestId("btn-stride-analyze");
+		await expect(btn).toBeEnabled();
+		await btn.click();
+
+		// Wait for threats to appear (analysis is fast for local STRIDE rules).
+		// Assert at least 1 threat generated (match 1+ digit, not just "0").
+		await expect(page.getByTestId("tab-threats")).toContainText(/[1-9]\d*/);
+	});
+});

--- a/src/components/canvas/dfd-canvas.tsx
+++ b/src/components/canvas/dfd-canvas.tsx
@@ -6,6 +6,7 @@ import {
 	MiniMap,
 	type OnConnectStart,
 	ReactFlow,
+	SelectionMode,
 	useReactFlow,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
@@ -304,6 +305,8 @@ export function DfdCanvas() {
 				fitView
 				snapToGrid
 				snapGrid={[16, 16]}
+				multiSelectionKeyCode="Shift"
+				selectionMode={SelectionMode.Partial}
 				deleteKeyCode={null}
 				className="bg-background"
 				proOptions={{ hideAttribution: true }}

--- a/src/components/panels/threats-tab.tsx
+++ b/src/components/panels/threats-tab.tsx
@@ -67,6 +67,7 @@ export function ThreatsTab() {
 			{/* Analyze button */}
 			<button
 				type="button"
+				data-testid="btn-stride-analyze"
 				disabled={!hasElements || isAnalyzing}
 				onClick={() => void analyzeThreats()}
 				className={cn(

--- a/src/hooks/use-keyboard-shortcuts.ts
+++ b/src/hooks/use-keyboard-shortcuts.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { buildLayoutFromModel } from "@/lib/model-layout-utils";
 import { useCanvasStore } from "@/stores/canvas-store";
+import { useClipboardStore } from "@/stores/clipboard-store";
 import { useHistoryStore } from "@/stores/history-store";
 import { useModelStore } from "@/stores/model-store";
 import { useSettingsStore } from "@/stores/settings-store";
@@ -16,9 +17,13 @@ export function useKeyboardShortcuts() {
 			const mod = e.metaKey || e.ctrlKey;
 
 			// Non-modifier shortcuts (only when not focused in an input)
-			const activeTag = document.activeElement?.tagName;
+			const active = document.activeElement;
+			const activeTag = active?.tagName;
 			const isInputFocused =
-				activeTag === "INPUT" || activeTag === "TEXTAREA" || activeTag === "SELECT";
+				activeTag === "INPUT" ||
+				activeTag === "TEXTAREA" ||
+				activeTag === "SELECT" ||
+				(active instanceof HTMLElement && active.isContentEditable);
 
 			if (!isInputFocused && !mod) {
 				switch (e.key) {
@@ -122,6 +127,30 @@ export function useKeyboardShortcuts() {
 				case "/":
 					e.preventDefault();
 					useSettingsStore.getState().openShortcutsDialog();
+					break;
+				case "a":
+					if (!isInputFocused) {
+						e.preventDefault();
+						useClipboardStore.getState().selectAll();
+					}
+					break;
+				case "c":
+					if (!isInputFocused) {
+						e.preventDefault();
+						useClipboardStore.getState().copySelected();
+					}
+					break;
+				case "x":
+					if (!isInputFocused) {
+						e.preventDefault();
+						useClipboardStore.getState().cutSelected();
+					}
+					break;
+				case "v":
+					if (!isInputFocused) {
+						e.preventDefault();
+						useClipboardStore.getState().paste();
+					}
 					break;
 			}
 		}

--- a/src/stores/canvas-store.ts
+++ b/src/stores/canvas-store.ts
@@ -147,22 +147,22 @@ let elementCounter = 0;
 let flowCounter = 0;
 let boundaryCounter = 0;
 
-function generateElementId(): string {
+export function generateElementId(): string {
 	elementCounter++;
 	return `comp-${elementCounter}`;
 }
 
-function generateFlowId(): string {
+export function generateFlowId(): string {
 	flowCounter++;
 	return `flow-${flowCounter}`;
 }
 
-function generateBoundaryId(): string {
+export function generateBoundaryId(): string {
 	boundaryCounter++;
 	return `boundary-${boundaryCounter}`;
 }
 
-function elementToNode(element: Element, position: { x: number; y: number }): DfdNode {
+export function elementToNode(element: Element, position: { x: number; y: number }): DfdNode {
 	return {
 		id: element.id,
 		type: "dfdElement",
@@ -183,7 +183,10 @@ function elementToNode(element: Element, position: { x: number; y: number }): Df
 	};
 }
 
-function boundaryToNode(boundary: TrustBoundary, position: { x: number; y: number }): DfdNode {
+export function boundaryToNode(
+	boundary: TrustBoundary,
+	position: { x: number; y: number },
+): DfdNode {
 	const w = boundary.size?.width ?? 400;
 	const h = boundary.size?.height ?? 300;
 	return {
@@ -212,7 +215,7 @@ function boundaryToNode(boundary: TrustBoundary, position: { x: number; y: numbe
 	};
 }
 
-function flowToEdge(flow: DataFlow): DfdEdge {
+export function flowToEdge(flow: DataFlow): DfdEdge {
 	return {
 		id: flow.id,
 		source: flow.from,
@@ -268,22 +271,30 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
 			}
 		}
 
-		// Handle selection changes
-		const selectionChange = changes.find((c) => c.type === "select" && c.selected);
-		if (selectionChange && selectionChange.type === "select") {
-			const node = get().nodes.find((n) => n.id === selectionChange.id);
-			if (node?.data.isBoundary) {
-				useModelStore.getState().setSelectedBoundary(selectionChange.id);
-			} else if (node && !node.data.isBoundary) {
-				useModelStore.getState().setSelectedElement(selectionChange.id);
+		// Handle selection changes — process the last selected node for model-store sync.
+		// In multi-select batches, multiple nodes may be selected at once; use the last
+		// one as the "active" selection for the properties panel.
+		const selectionChanges = changes.filter((c) => c.type === "select" && c.selected);
+		if (selectionChanges.length > 0) {
+			const lastChange = selectionChanges[selectionChanges.length - 1];
+			if (lastChange.type === "select") {
+				const node = get().nodes.find((n) => n.id === lastChange.id);
+				if (node?.data.isBoundary) {
+					useModelStore.getState().setSelectedBoundary(lastChange.id);
+				} else if (node && !node.data.isBoundary) {
+					useModelStore.getState().setSelectedElement(lastChange.id);
+				}
 			}
 		}
 
-		// Handle deselection
-		const deselection = changes.find((c) => c.type === "select" && !c.selected);
-		if (deselection && !changes.some((c) => c.type === "select" && c.selected)) {
-			useModelStore.getState().setSelectedElement(null);
-			useModelStore.getState().setSelectedBoundary(null);
+		// Handle deselection — only clear model selection when zero nodes remain selected
+		const hasDeselection = changes.some((c) => c.type === "select" && !c.selected);
+		if (hasDeselection && !changes.some((c) => c.type === "select" && c.selected)) {
+			const anyStillSelected = get().nodes.some((n) => n.selected);
+			if (!anyStillSelected) {
+				useModelStore.getState().setSelectedElement(null);
+				useModelStore.getState().setSelectedBoundary(null);
+			}
 		}
 	},
 

--- a/src/stores/clipboard-store.test.ts
+++ b/src/stores/clipboard-store.test.ts
@@ -1,0 +1,311 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { ThreatModel } from "@/types/threat-model";
+import { useCanvasStore } from "./canvas-store";
+import { useClipboardStore } from "./clipboard-store";
+import { useHistoryStore } from "./history-store";
+import { useModelStore } from "./model-store";
+
+function createTestModel(): ThreatModel {
+	return {
+		version: "1.0",
+		metadata: {
+			title: "Test Model",
+			author: "Test",
+			created: "2026-01-01",
+			modified: "2026-01-01",
+			description: "",
+		},
+		elements: [
+			{
+				id: "el-1",
+				type: "web_server",
+				name: "Web App",
+				trust_zone: "internal",
+				description: "",
+				technologies: [],
+				position: { x: 100, y: 100 },
+			},
+			{
+				id: "el-2",
+				type: "sql_database",
+				name: "Database",
+				trust_zone: "internal",
+				description: "",
+				technologies: ["PostgreSQL"],
+				position: { x: 300, y: 300 },
+			},
+			{
+				id: "el-3",
+				type: "api_gateway",
+				name: "API Gateway",
+				trust_zone: "dmz",
+				description: "",
+				technologies: [],
+				position: { x: 500, y: 100 },
+			},
+		],
+		data_flows: [
+			{
+				id: "flow-1",
+				name: "DB Query",
+				from: "el-1",
+				to: "el-2",
+				protocol: "PostgreSQL/TLS",
+				data: ["user_records"],
+				authenticated: true,
+			},
+			{
+				id: "flow-2",
+				name: "API Call",
+				from: "el-3",
+				to: "el-1",
+				protocol: "HTTPS",
+				data: ["requests"],
+				authenticated: true,
+			},
+		],
+		trust_boundaries: [
+			{
+				id: "boundary-1",
+				name: "Internal Network",
+				contains: ["el-1", "el-2"],
+				position: { x: 50, y: 50 },
+				size: { width: 400, height: 300 },
+			},
+		],
+		threats: [],
+		diagrams: [],
+	};
+}
+
+function setupCanvas() {
+	useModelStore.getState().setModel(createTestModel(), null);
+	useCanvasStore.getState().syncFromModel();
+}
+
+function selectNodes(...ids: string[]) {
+	const nodes = useCanvasStore.getState().nodes;
+	useCanvasStore.setState({
+		nodes: nodes.map((n) => ({ ...n, selected: ids.includes(n.id) })),
+	});
+}
+
+describe("clipboard-store", () => {
+	beforeEach(() => {
+		useCanvasStore.setState({
+			nodes: [],
+			edges: [],
+			viewport: { x: 0, y: 0, zoom: 1 },
+		});
+		useModelStore.setState({ model: null, filePath: null, isDirty: false });
+		useHistoryStore.setState({ past: [], future: [] });
+		useClipboardStore.setState({ clipboard: null, pasteCount: 0 });
+	});
+
+	describe("selectAll", () => {
+		it("marks all nodes as selected", () => {
+			setupCanvas();
+			useClipboardStore.getState().selectAll();
+			const nodes = useCanvasStore.getState().nodes;
+			expect(nodes.every((n) => n.selected)).toBe(true);
+		});
+
+		it("is a no-op when there are no nodes", () => {
+			useClipboardStore.getState().selectAll();
+			expect(useCanvasStore.getState().nodes).toHaveLength(0);
+		});
+	});
+
+	describe("copySelected", () => {
+		it("is a no-op with no selection", () => {
+			setupCanvas();
+			useClipboardStore.getState().copySelected();
+			expect(useClipboardStore.getState().clipboard).toBeNull();
+		});
+
+		it("copies a single selected element", () => {
+			setupCanvas();
+			selectNodes("el-1");
+			useClipboardStore.getState().copySelected();
+
+			const clipboard = useClipboardStore.getState().clipboard;
+			expect(clipboard).not.toBeNull();
+			expect(clipboard?.elements).toHaveLength(1);
+			expect(clipboard?.elements[0].id).toBe("el-1");
+			expect(clipboard?.flows).toHaveLength(0);
+			expect(clipboard?.boundaries).toHaveLength(0);
+		});
+
+		it("copies multiple selected elements", () => {
+			setupCanvas();
+			selectNodes("el-1", "el-2");
+			useClipboardStore.getState().copySelected();
+
+			const clipboard = useClipboardStore.getState().clipboard;
+			expect(clipboard?.elements).toHaveLength(2);
+		});
+
+		it("includes edges between selected nodes only", () => {
+			setupCanvas();
+			selectNodes("el-1", "el-2");
+			useClipboardStore.getState().copySelected();
+
+			const clipboard = useClipboardStore.getState().clipboard;
+			// flow-1 connects el-1 → el-2 (both selected) → included
+			// flow-2 connects el-3 → el-1 (el-3 not selected) → excluded
+			expect(clipboard?.flows).toHaveLength(1);
+			expect(clipboard?.flows[0].id).toBe("flow-1");
+		});
+
+		it("excludes edges where only one endpoint is selected", () => {
+			setupCanvas();
+			selectNodes("el-1");
+			useClipboardStore.getState().copySelected();
+
+			const clipboard = useClipboardStore.getState().clipboard;
+			expect(clipboard?.flows).toHaveLength(0);
+		});
+
+		it("copies a trust boundary", () => {
+			setupCanvas();
+			selectNodes("boundary-1");
+			useClipboardStore.getState().copySelected();
+
+			const clipboard = useClipboardStore.getState().clipboard;
+			expect(clipboard?.boundaries).toHaveLength(1);
+			expect(clipboard?.boundaries[0].id).toBe("boundary-1");
+			expect(clipboard?.elements).toHaveLength(0);
+		});
+
+		it("resets pasteCount on copy", () => {
+			setupCanvas();
+			selectNodes("el-1");
+			useClipboardStore.setState({ pasteCount: 3 });
+			useClipboardStore.getState().copySelected();
+			expect(useClipboardStore.getState().pasteCount).toBe(0);
+		});
+	});
+
+	describe("cutSelected", () => {
+		it("copies and then deletes selected nodes", () => {
+			setupCanvas();
+			selectNodes("el-1");
+			const initialCount = useCanvasStore.getState().nodes.length;
+
+			useClipboardStore.getState().cutSelected();
+
+			// Clipboard should have the cut element
+			const clipboard = useClipboardStore.getState().clipboard;
+			expect(clipboard?.elements).toHaveLength(1);
+
+			// Canvas should have fewer nodes
+			const nodes = useCanvasStore.getState().nodes;
+			expect(nodes.length).toBe(initialCount - 1);
+			expect(nodes.find((n) => n.id === "el-1")).toBeUndefined();
+
+			// Model should also be updated
+			const model = useModelStore.getState().model;
+			expect(model?.elements.find((e) => e.id === "el-1")).toBeUndefined();
+		});
+	});
+
+	describe("paste", () => {
+		it("is a no-op when clipboard is empty", () => {
+			setupCanvas();
+			useClipboardStore.getState().paste();
+			// No change
+			expect(useModelStore.getState().model?.elements).toHaveLength(3);
+		});
+
+		it("generates new IDs for pasted elements", () => {
+			setupCanvas();
+			selectNodes("el-1");
+			useClipboardStore.getState().copySelected();
+			useClipboardStore.getState().paste();
+
+			const model = useModelStore.getState().model;
+			expect(model?.elements).toHaveLength(4);
+			const ids = model?.elements.map((e) => e.id) ?? [];
+			// All IDs should be unique
+			expect(new Set(ids).size).toBe(4);
+		});
+
+		it("adds (copy) suffix on first paste", () => {
+			setupCanvas();
+			selectNodes("el-1");
+			useClipboardStore.getState().copySelected();
+			useClipboardStore.getState().paste();
+
+			const model = useModelStore.getState().model;
+			const pastedEl = model?.elements[model.elements.length - 1];
+			expect(pastedEl?.name).toBe("Web App (copy)");
+		});
+
+		it("offsets positions by 50*pasteCount", () => {
+			setupCanvas();
+			selectNodes("el-1");
+			useClipboardStore.getState().copySelected();
+			useClipboardStore.getState().paste();
+
+			const nodes = useCanvasStore.getState().nodes;
+			const pastedNode = nodes.find((n) => n.data.label === "Web App (copy)");
+			expect(pastedNode?.position).toEqual({ x: 150, y: 150 });
+		});
+
+		it("increments offset on multiple pastes", () => {
+			setupCanvas();
+			selectNodes("el-1");
+			useClipboardStore.getState().copySelected();
+
+			useClipboardStore.getState().paste(); // offset 50
+			useClipboardStore.getState().paste(); // offset 100
+
+			const nodes = useCanvasStore.getState().nodes;
+			// Second paste — name is NOT "(copy)" anymore
+			const secondPaste = nodes[nodes.length - 1];
+			expect(secondPaste.position).toEqual({ x: 200, y: 200 });
+		});
+
+		it("remaps edge source/target to new IDs", () => {
+			setupCanvas();
+			selectNodes("el-1", "el-2");
+			useClipboardStore.getState().copySelected();
+			useClipboardStore.getState().paste();
+
+			const model = useModelStore.getState().model;
+			// Original flow-1: el-1 → el-2, plus new flow with remapped IDs
+			expect(model?.data_flows).toHaveLength(3);
+
+			const newFlow = model?.data_flows[model.data_flows.length - 1];
+			// New flow should NOT reference original IDs
+			expect(newFlow?.from).not.toBe("el-1");
+			expect(newFlow?.to).not.toBe("el-2");
+			// But the new from/to should exist as new element IDs
+			const elementIds = new Set(model?.elements.map((e) => e.id));
+			expect(elementIds.has(newFlow?.from ?? "")).toBe(true);
+			expect(elementIds.has(newFlow?.to ?? "")).toBe(true);
+		});
+
+		it("pushes one history snapshot for undo", () => {
+			setupCanvas();
+			selectNodes("el-1", "el-2");
+			useClipboardStore.getState().copySelected();
+
+			expect(useHistoryStore.getState().past).toHaveLength(0);
+			useClipboardStore.getState().paste();
+			expect(useHistoryStore.getState().past).toHaveLength(1);
+		});
+
+		it("selects only pasted nodes after paste", () => {
+			setupCanvas();
+			selectNodes("el-1");
+			useClipboardStore.getState().copySelected();
+			useClipboardStore.getState().paste();
+
+			const nodes = useCanvasStore.getState().nodes;
+			const selectedNodes = nodes.filter((n) => n.selected);
+			expect(selectedNodes).toHaveLength(1);
+			expect(selectedNodes[0].data.label).toBe("Web App (copy)");
+		});
+	});
+});

--- a/src/stores/clipboard-store.ts
+++ b/src/stores/clipboard-store.ts
@@ -1,0 +1,216 @@
+import { create } from "zustand";
+import type { DataFlow, Element, TrustBoundary } from "@/types/threat-model";
+import {
+	boundaryToNode,
+	elementToNode,
+	flowToEdge,
+	generateBoundaryId,
+	generateElementId,
+	generateFlowId,
+	useCanvasStore,
+} from "./canvas-store";
+import { useHistoryStore } from "./history-store";
+import { useModelStore } from "./model-store";
+
+interface ClipboardEntry {
+	elements: Element[];
+	flows: DataFlow[];
+	boundaries: TrustBoundary[];
+	/** Centroid anchor point for offset calculation */
+	anchorX: number;
+	anchorY: number;
+}
+
+interface ClipboardState {
+	clipboard: ClipboardEntry | null;
+	pasteCount: number;
+
+	selectAll: () => void;
+	copySelected: () => void;
+	cutSelected: () => void;
+	paste: () => void;
+}
+
+export const useClipboardStore = create<ClipboardState>((set, get) => ({
+	clipboard: null,
+	pasteCount: 0,
+
+	selectAll: () => {
+		const nodes = useCanvasStore.getState().nodes;
+		if (nodes.length === 0) return;
+		const updated = nodes.map((n) => ({ ...n, selected: true }));
+		useCanvasStore.setState({ nodes: updated });
+	},
+
+	copySelected: () => {
+		const { nodes, edges } = useCanvasStore.getState();
+		const model = useModelStore.getState().model;
+		if (!model) return;
+
+		const selectedNodes = nodes.filter((n) => n.selected);
+		if (selectedNodes.length === 0) return;
+
+		const selectedIds = new Set(selectedNodes.map((n) => n.id));
+
+		// Look up model entities for selected nodes — deep-clone mutable arrays
+		const elements: Element[] = [];
+		const boundaries: TrustBoundary[] = [];
+
+		for (const node of selectedNodes) {
+			if (node.data.isBoundary) {
+				const boundary = model.trust_boundaries.find((b) => b.id === node.id);
+				if (boundary) {
+					boundaries.push({
+						...boundary,
+						contains: [...boundary.contains],
+						position: { x: node.position.x, y: node.position.y },
+						size: {
+							width: node.width ?? (node.style as Record<string, number> | undefined)?.width ?? 400,
+							height:
+								node.height ?? (node.style as Record<string, number> | undefined)?.height ?? 300,
+						},
+					});
+				}
+			} else {
+				const element = model.elements.find((e) => e.id === node.id);
+				if (element) {
+					elements.push({
+						...element,
+						technologies: element.technologies ? [...element.technologies] : [],
+						position: { x: node.position.x, y: node.position.y },
+					});
+				}
+			}
+		}
+
+		// Only include edges where both endpoints are selected — deep-clone mutable arrays
+		const flows: DataFlow[] = [];
+		for (const edge of edges) {
+			if (selectedIds.has(edge.source) && selectedIds.has(edge.target)) {
+				const flow = model.data_flows.find((f) => f.id === edge.id);
+				if (flow) flows.push({ ...flow, data: flow.data ? [...flow.data] : [] });
+			}
+		}
+
+		// Compute centroid from selected node positions
+		const allPositions = selectedNodes.map((n) => n.position);
+		const anchorX = allPositions.reduce((s, p) => s + p.x, 0) / allPositions.length;
+		const anchorY = allPositions.reduce((s, p) => s + p.y, 0) / allPositions.length;
+
+		set({
+			clipboard: { elements, flows, boundaries, anchorX, anchorY },
+			pasteCount: 0,
+		});
+	},
+
+	cutSelected: () => {
+		get().copySelected();
+		useCanvasStore.getState().deleteSelected();
+	},
+
+	paste: () => {
+		const { clipboard, pasteCount } = get();
+		if (!clipboard) return;
+
+		const model = useModelStore.getState().model;
+		if (!model) return;
+
+		const newCount = pasteCount + 1;
+		const offset = 50 * newCount;
+		const isFirstPaste = newCount === 1;
+
+		// Build old→new ID mapping
+		const idMap = new Map<string, string>();
+		for (const el of clipboard.elements) {
+			idMap.set(el.id, generateElementId());
+		}
+		for (const b of clipboard.boundaries) {
+			idMap.set(b.id, generateBoundaryId());
+		}
+		for (const f of clipboard.flows) {
+			idMap.set(f.id, generateFlowId());
+		}
+
+		// Clone elements with new IDs and offset positions — deep-clone mutable arrays
+		const newElements: Element[] = clipboard.elements.map((el) => ({
+			...el,
+			id: idMap.get(el.id) ?? el.id,
+			name: isFirstPaste ? `${el.name} (copy)` : el.name,
+			technologies: el.technologies ? [...el.technologies] : [],
+			position: el.position ? { x: el.position.x + offset, y: el.position.y + offset } : undefined,
+		}));
+
+		// Clone boundaries with new IDs, remapped contains, offset positions
+		const newElIds = new Set(newElements.map((e) => e.id));
+		const newBoundaries: TrustBoundary[] = clipboard.boundaries.map((b) => ({
+			...b,
+			id: idMap.get(b.id) ?? b.id,
+			name: isFirstPaste ? `${b.name} (copy)` : b.name,
+			contains: b.contains.map((c) => idMap.get(c) ?? c).filter((c) => newElIds.has(c)),
+			position: b.position ? { x: b.position.x + offset, y: b.position.y + offset } : undefined,
+		}));
+
+		// Clone flows with new IDs, remapped source/target — deep-clone mutable arrays
+		const newFlows: DataFlow[] = clipboard.flows.map((f) => ({
+			...f,
+			id: idMap.get(f.id) ?? f.id,
+			from: idMap.get(f.from) ?? f.from,
+			to: idMap.get(f.to) ?? f.to,
+			data: f.data ? [...f.data] : [],
+		}));
+
+		// Push one history snapshot for undo
+		useHistoryStore.getState().pushSnapshot(model);
+
+		// Update model store
+		useModelStore.setState({
+			model: {
+				...model,
+				elements: [...model.elements, ...newElements],
+				data_flows: [...model.data_flows, ...newFlows],
+				trust_boundaries: [...model.trust_boundaries, ...newBoundaries],
+			},
+			isDirty: true,
+		});
+
+		// Build canvas nodes for pasted items — boundaries first, then elements
+		const newBoundaryNodes = newBoundaries.map((b) => {
+			const node = boundaryToNode(b, b.position ?? { x: offset, y: offset });
+			return { ...node, selected: true };
+		});
+
+		const newElementNodes = newElements.map((el) => {
+			const node = elementToNode(el, el.position ?? { x: offset, y: offset });
+			// If this element belongs to a pasted boundary, set parentId
+			for (const nb of newBoundaries) {
+				if (nb.contains.includes(el.id)) {
+					node.parentId = nb.id;
+					node.extent = "parent";
+					// Adjust position to be relative to boundary
+					if (nb.position && el.position) {
+						node.position = {
+							x: el.position.x - nb.position.x,
+							y: el.position.y - nb.position.y,
+						};
+					}
+					break;
+				}
+			}
+			return { ...node, selected: true };
+		});
+
+		const newEdges = newFlows.map((f) => flowToEdge(f));
+
+		// Add to canvas: deselect old, insert boundaries at front (render behind),
+		// then existing nodes, then new element nodes at end
+		const canvasState = useCanvasStore.getState();
+		const deselectedOld = canvasState.nodes.map((n) => ({ ...n, selected: false }));
+
+		useCanvasStore.setState({
+			nodes: [...newBoundaryNodes, ...deselectedOld, ...newElementNodes],
+			edges: [...canvasState.edges, ...newEdges],
+		});
+
+		set({ pasteCount: newCount });
+	},
+}));

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -153,6 +153,27 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
 		category: "canvas",
 	},
 	{
+		id: "copy",
+		label: "Copy",
+		macKeys: "⌘C",
+		winKeys: "Ctrl+C",
+		category: "edit",
+	},
+	{
+		id: "cut",
+		label: "Cut",
+		macKeys: "⌘X",
+		winKeys: "Ctrl+X",
+		category: "edit",
+	},
+	{
+		id: "paste",
+		label: "Paste",
+		macKeys: "⌘V",
+		winKeys: "Ctrl+V",
+		category: "edit",
+	},
+	{
 		id: "select-all",
 		label: "Select All",
 		macKeys: "⌘A",


### PR DESCRIPTION
## Summary

- Add clipboard store with **copy/cut/paste/select-all** (in-memory clipboard, Figma-style cascading paste offset)
- Enable **ReactFlow multi-select** with Shift+click and rubber-band selection
- Wire **Cmd+A/C/X/V** keyboard shortcuts with `isInputFocused` + `contentEditable` guards
- Add **18 Playwright E2E tests** across 5 spec files covering app launch, model creation, canvas elements, keyboard shortcuts, and STRIDE analysis
- Deep-clone mutable arrays on copy/paste, correct boundary z-ordering, parentId for contained elements

## Test plan

- [x] `npx biome check .` — 86 files clean
- [x] `npx vitest --run` — 158 tests passing (up from 140)
- [x] `npx playwright test --repeat-each=2` — 36/36 (no flakes)
- [x] `npx tsc --noEmit` — clean
- [x] `cargo test` — 40 tests passing
- [x] `cargo clippy` — clean
- [x] `npm run ci:local` — all passed
- [ ] Manual: create model, add elements, Shift+click multi-select, Cmd+C → Cmd+V, verify paste offset and undo

🤖 Generated with [Claude Code](https://claude.com/claude-code)