### PR TITLE
chore(ci): auto-trigger CI on main and PRs, add release validation gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,11 @@
 name: CI
 
 on:
-  workflow_dispatch: # manual trigger only — use local CI for routine checks
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch: # can still trigger manually
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,13 +13,79 @@ permissions:
   contents: write
 
 jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: ".node-version"
+          cache: "npm"
+
+      - run: npm ci
+
+      - name: Biome lint + format check
+        run: npx biome check .
+
+      - name: TypeScript type check
+        run: npx tsc --noEmit
+
+      - name: Frontend tests
+        run: npx vitest --run
+
+      - name: Install Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libdbus-1-dev \
+            libssl-dev
+
+      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master 2026-02-13
+        with:
+          toolchain: stable
+          components: clippy, rustfmt
+
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            src-tauri/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Rust format check
+        run: cargo fmt --manifest-path src-tauri/Cargo.toml --check
+
+      - name: Clippy lint
+        run: cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
+
+      - name: Rust tests
+        run: cargo test --manifest-path src-tauri/Cargo.toml
+
   release:
-    name: Release (${{ matrix.platform }})
+    name: Release (${{ matrix.settings.platform }})
+    needs: [validate]
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.platform }}
+        settings:
+          - platform: ubuntu-latest
+            args: ""
+          - platform: macos-latest
+            args: "--target aarch64-apple-darwin"
+          - platform: macos-latest
+            args: "--target x86_64-apple-darwin"
+          - platform: windows-latest
+            args: ""
+    runs-on: ${{ matrix.settings.platform }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
@@ -33,6 +99,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master 2026-02-13
         with:
           toolchain: stable
+          targets: ${{ matrix.settings.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
@@ -59,9 +126,17 @@ jobs:
       - uses: tauri-apps/tauri-action@f650639e43adf15f35dd1023d248b3ecc3568b64 # action-v0.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # macOS code signing (set these in GitHub repo secrets when ready)
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           tagName: v__VERSION__
           releaseName: "ThreatForge v__VERSION__"
           releaseBody: "See the assets to download this version and install ThreatForge."
           releaseDraft: true
           prerelease: false
+          args: ${{ matrix.settings.args }}


### PR DESCRIPTION
- CI workflow now runs on push to main and pull requests (was manual-only)
- Release workflow gates builds behind a validate job (lint + test)
- Release builds macOS binaries for both ARM and x86 architectures
- Added Apple code signing env var placeholders for future setup

## Summary

<!-- What does this PR do? Keep it to 1-3 sentences. -->

## Changes

<!-- Bulleted list of what changed and why. -->

-

## Type

<!-- Check one. -->

- [ ] Feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Refactor (`refactor`)
- [ ] Chore (build, CI, deps)
- [ ] Documentation (`docs`)

## Checklist

- [ ] Code follows project conventions (named exports, strict TS, etc.)
- [ ] TypeScript linted: `npx biome check .`
- [ ] Rust linted: `cargo clippy -- -D warnings`
- [ ] Tests added/updated for changes
- [ ] Tests pass: `npx vitest --run` and `cargo test`
- [ ] App builds: `npm run tauri build`
- [ ] YAML schema changes are backward-compatible (if applicable)
- [ ] No secrets, API keys, or credentials in the diff

## Related Issues

<!-- Link issues: "Closes #123" or "Relates to #456" -->
