### PR TITLE
fix(build): add explicit [[bin]] for main binary

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -12,6 +12,10 @@ name = "threat_forge_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [[bin]]
+name = "threat-forge"
+path = "src/main.rs"
+
+[[bin]]
 name = "threatforge-mcp"
 path = "src/bin/threatforge-mcp.rs"
 


### PR DESCRIPTION
## Summary
- Adds explicit `[[bin]]` entry for `threat-forge` (the main Tauri binary) in `Cargo.toml`
- Fixes "failed to find main binary" error that broke CI builds on all 3 platforms since PR #22

## Root Cause
When a `[[bin]]` entry was added for `threatforge-mcp` in PR #22, Cargo stopped auto-discovering `src/main.rs` as the `threat-forge` binary target. The `default-run` field only affects `cargo run` — it doesn't register the binary target. Tauri's build tooling needs an explicit target to find the main binary.

## Test plan
- [x] `cargo check` resolves both binary targets
- [x] `cargo metadata` lists `threat-forge` and `threatforge-mcp`
- [x] `npm run ci:local` passes (318/318 tests, clippy, biome, tsc)
- [ ] CI build step passes on all 3 platforms (GitHub Actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)