### PR TITLE
feat: add dev container with E0L workspace config mounting

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,63 @@
+{
+	"name": "ThreatForge",
+	"image": "mcr.microsoft.com/devcontainers/rust:1-1-bookworm",
+
+	"mounts": [
+		{
+			"source": "${localWorkspaceFolder}/../../.ai",
+			"target": "/workspace-config/.ai",
+			"type": "bind"
+		},
+		{
+			"source": "${localWorkspaceFolder}/../../.claude",
+			"target": "/workspace-config/.claude",
+			"type": "bind"
+		},
+		{
+			"source": "${localWorkspaceFolder}/../../.github",
+			"target": "/workspace-config/.github",
+			"type": "bind"
+		}
+	],
+
+	"postCreateCommand": "bash .devcontainer/on-create.sh",
+
+	"remoteEnv": {
+		"E0L_WORKSPACE_CONFIG": "/workspace-config"
+	},
+
+	"features": {
+		"ghcr.io/devcontainers/features/github-cli:1": {},
+		"ghcr.io/devcontainers/features/node:1": {
+			"version": "22"
+		}
+	},
+
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"biomejs.biome",
+				"bradlc.vscode-tailwindcss",
+				"rust-lang.rust-analyzer",
+				"tauri-apps.tauri-vscode",
+				"ms-playwright.playwright",
+				"vitest.explorer",
+				"github.copilot",
+				"github.copilot-chat"
+			],
+			"settings": {
+				"editor.formatOnSave": true,
+				"editor.defaultFormatter": "biomejs.biome",
+				"[rust]": {
+					"editor.defaultFormatter": "rust-lang.rust-analyzer"
+				},
+				"editor.codeActionsOnSave": {
+					"quickfix.biome": "explicit",
+					"source.organizeImports.biome": "explicit"
+				},
+				"typescript.preferences.importModuleSpecifier": "non-relative",
+				"terminal.integrated.defaultProfile.linux": "bash"
+			}
+		}
+	}
+}

--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -e
+
+WORKSPACE_CONFIG="/workspace-config"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+echo "🔧 Setting up ThreatForge dev environment..."
+
+# ─────────────────────────────────────────────
+# 1. Workspace config — mount or clone
+# ─────────────────────────────────────────────
+if [ -z "$(ls -A ${WORKSPACE_CONFIG}/.ai 2>/dev/null)" ]; then
+  echo "  ↳ Workspace config not mounted — cloning from GitHub..."
+
+  git clone --depth=1 --quiet \
+    https://github.com/exit-zero-labs/root-e0l-ai.git \
+    "${WORKSPACE_CONFIG}/.ai"
+
+  git clone --depth=1 --quiet \
+    https://github.com/exit-zero-labs/root-e0l-claude.git \
+    "${WORKSPACE_CONFIG}/.claude"
+
+  git clone --depth=1 --quiet \
+    https://github.com/exit-zero-labs/root-e0l-github.git \
+    "${WORKSPACE_CONFIG}/.github-workspace"
+
+  echo "  ✓ Workspace config cloned from GitHub"
+else
+  echo "  ✓ Workspace config mounted from host"
+fi
+
+# ─────────────────────────────────────────────
+# 2. Symlink — .e0l → /workspace-config
+# ─────────────────────────────────────────────
+ln -sfn "${WORKSPACE_CONFIG}" "${REPO_ROOT}/.e0l"
+echo "  ✓ Symlink: .e0l → ${WORKSPACE_CONFIG}"
+
+# ─────────────────────────────────────────────
+# 3. System deps for Tauri (Linux build)
+# ─────────────────────────────────────────────
+echo "  ↳ Installing Tauri system dependencies..."
+sudo apt-get update -qq
+sudo apt-get install -y -qq \
+  libwebkit2gtk-4.1-dev \
+  libappindicator3-dev \
+  librsvg2-dev \
+  patchelf \
+  libssl-dev \
+  libgtk-3-dev \
+  libsoup-3.0-dev \
+  libjavascriptcoregtk-4.1-dev \
+  > /dev/null 2>&1
+
+# ─────────────────────────────────────────────
+# 4. Install Node + Rust dependencies
+# ─────────────────────────────────────────────
+echo "  ↳ Installing npm dependencies..."
+npm ci
+
+echo "  ↳ Building Rust backend (first build may take a few minutes)..."
+cd src-tauri && cargo build 2>&1 | tail -5 && cd ..
+
+echo ""
+echo "✅ ThreatForge dev environment ready"
+echo ""
+echo "   Workspace config: ${WORKSPACE_CONFIG}"
+echo "   Symlink: ${REPO_ROOT}/.e0l"
+echo ""
+echo "   Start dev server:"
+echo "   $ npm run dev        (Tauri + Vite, port 1420)"
+echo "   $ npm run dev:web    (web-only mode, port 3000)"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Misc
 temp/
 
+# E0L workspace config symlink (created by .devcontainer/on-create.sh)
+.e0l
+
 # Logs
 logs
 *.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,10 @@
 # ThreatForge
 
+<!-- E0L company-wide context (agent personas, architecture decisions, git workflow).
+     Available inside dev container via the .e0l symlink → /workspace-config.
+     Silently skipped if not present (e.g., opening the repo natively without devcontainer). -->
+@./.e0l/.ai/AI.md
+
 Open-source, AI-enhanced, cross-platform desktop threat modeling application.
 
 Fills the gap between Microsoft's legacy TMT (free but Windows-only, binary `.tm7` files) and enterprise platforms like ThreatModeler/IriusRisk ($20K+/year). Produces human-readable, git-diffable YAML files with integrated AI assistance.


### PR DESCRIPTION
## Summary

Adds `.devcontainer/` so the threat-forge repo can be opened in VS Code or Codespaces while retaining access to E0L workspace config.

## How it works

| Scenario | What happens |
|----------|-------------|
| **Open from E0L workspace** | bind-mounts `../../.ai`, `../../.claude`, `../../.github` → `/workspace-config/` |
| **Standalone clone** | `on-create.sh` detects empty mount, clones config repos from GitHub |

In both cases: `.e0l` symlink → `/workspace-config/`, `CLAUDE.md` `@`-includes `.e0l/.ai/AI.md`.

## Customizations

- **Rust base image** (`devcontainers/rust:1-1-bookworm`) — Tauri backend needs Rust toolchain
- **Tauri system deps** — webkit2gtk, libsoup-3.0, etc. installed in on-create.sh
- **Extensions** — rust-analyzer, tauri-vscode alongside Biome/Copilot
- `cargo build` runs during on-create for faster first dev start

## Changes

- `.devcontainer/devcontainer.json` — Container config
- `.devcontainer/on-create.sh` — Setup script (ports 1420/3000)
- `.gitignore` — Added `.e0l`
- `CLAUDE.md` — Added workspace context include