### PR TITLE
feat(help): add keyboard shortcuts dialog

### DIFF
--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -137,6 +137,13 @@ pub fn build_menu(app: &App) -> Result<Menu<Wry>, Box<dyn std::error::Error>> {
     )?;
 
     // Help menu
+    let help_keyboard_shortcuts = MenuItem::with_id(
+        handle,
+        "help-keyboard-shortcuts",
+        "Keyboard Shortcuts",
+        true,
+        None::<&str>,
+    )?;
     let help_guides = MenuItem::with_id(handle, "help-guides", "Guided Tours", true, None::<&str>)?;
     let help_about = MenuItem::with_id(
         handle,
@@ -151,6 +158,8 @@ pub fn build_menu(app: &App) -> Result<Menu<Wry>, Box<dyn std::error::Error>> {
         "Help",
         true,
         &[
+			&help_keyboard_shortcuts,
+			&PredefinedMenuItem::separator(handle)?,
             &help_guides,
             &PredefinedMenuItem::separator(handle)?,
             &help_about,

--- a/src/components/layout/app-layout.tsx
+++ b/src/components/layout/app-layout.tsx
@@ -15,6 +15,7 @@ import { GuideProvider } from "../onboarding/guide-provider";
 
 import { WhatsNewOverlay } from "../onboarding/whats-new-overlay";
 import { ComponentPalette } from "../palette/component-palette";
+import { KeyboardShortcutsDialog } from "../panels/keyboard-shortcuts-dialog";
 import { RightPanel } from "../panels/right-panel";
 import { SettingsDialog } from "../panels/settings-dialog";
 import { ResizeHandle } from "../ui/resize-handle";
@@ -29,6 +30,7 @@ export function AppLayout() {
 	const rightPanelWidth = useUiStore((s) => s.rightPanelWidth);
 	const commandPaletteOpen = useUiStore((s) => s.commandPaletteOpen);
 	const closeCommandPalette = useUiStore((s) => s.closeCommandPalette);
+	const keyboardShortcutsDialogOpen = useUiStore((s) => s.keyboardShortcutsDialogOpen);
 	const settingsDialogOpen = useSettingsStore((s) => s.settingsDialogOpen);
 	useKeyboardShortcuts();
 	useNativeMenu();
@@ -101,6 +103,7 @@ export function AppLayout() {
 
 				{/* Dialogs */}
 				{settingsDialogOpen && <SettingsDialog />}
+				{keyboardShortcutsDialogOpen && <KeyboardShortcutsDialog />}
 				<CommandPalette open={commandPaletteOpen} onClose={closeCommandPalette} />
 				<GuideProvider />
 				<WhatsNewOverlay />

--- a/src/components/panels/keyboard-shortcuts-dialog.test.tsx
+++ b/src/components/panels/keyboard-shortcuts-dialog.test.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useUiStore } from "@/stores/ui-store";
+import { KeyboardShortcutsDialog } from "./keyboard-shortcuts-dialog";
+
+beforeEach(() => {
+	useUiStore.setState({ keyboardShortcutsDialogOpen: true });
+});
+
+describe("KeyboardShortcutsDialog", () => {
+	it("renders shortcuts grouped by category", () => {
+		render(<KeyboardShortcutsDialog />);
+
+		const dialog = screen.getByTestId("keyboard-shortcuts-dialog");
+		expect(dialog).toBeInTheDocument();
+		expect(within(dialog).getByText("Keyboard Shortcuts")).toBeInTheDocument();
+		expect(within(dialog).getByText("File")).toBeInTheDocument();
+		expect(within(dialog).getByText("View")).toBeInTheDocument();
+		expect(within(dialog).getByText("New Model")).toBeInTheDocument();
+		expect(within(dialog).getByText("Command Palette")).toBeInTheDocument();
+	});
+
+	it("filters shortcuts using the search box", () => {
+		render(<KeyboardShortcutsDialog />);
+
+		fireEvent.change(screen.getByTestId("keyboard-shortcuts-search"), {
+			target: { value: "save as" },
+		});
+
+		expect(screen.getByText("Save As")).toBeInTheDocument();
+		expect(screen.queryByText("New Model")).not.toBeInTheDocument();
+	});
+
+	it("closes on Escape", () => {
+		render(<KeyboardShortcutsDialog />);
+
+		fireEvent.keyDown(screen.getByTestId("keyboard-shortcuts-dialog"), { key: "Escape" });
+
+		expect(useUiStore.getState().keyboardShortcutsDialogOpen).toBe(false);
+	});
+});

--- a/src/components/panels/keyboard-shortcuts-dialog.tsx
+++ b/src/components/panels/keyboard-shortcuts-dialog.tsx
@@ -1,0 +1,145 @@
+import { Search, X } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useUiStore } from "@/stores/ui-store";
+import { KEYBOARD_SHORTCUTS, type KeyboardShortcut } from "@/types/settings";
+
+const CATEGORY_LABELS: Record<KeyboardShortcut["category"], string> = {
+	file: "File",
+	edit: "Edit",
+	view: "View",
+	canvas: "Canvas",
+};
+
+export function KeyboardShortcutsDialog() {
+	const closeKeyboardShortcutsDialog = useUiStore((s) => s.closeKeyboardShortcutsDialog);
+	const inputRef = useRef<HTMLInputElement>(null);
+	const [query, setQuery] = useState("");
+	const isMac = navigator.platform.includes("Mac");
+
+	useEffect(() => {
+		requestAnimationFrame(() => inputRef.current?.focus());
+	}, []);
+
+	const filteredShortcuts = useMemo(() => {
+		const normalizedQuery = query.trim().toLowerCase();
+		if (!normalizedQuery) return KEYBOARD_SHORTCUTS;
+
+		return KEYBOARD_SHORTCUTS.filter((shortcut) => {
+			const searchableText = [
+				shortcut.label,
+				shortcut.macKeys,
+				shortcut.winKeys,
+				CATEGORY_LABELS[shortcut.category],
+			]
+				.join(" ")
+				.toLowerCase();
+
+			return searchableText.includes(normalizedQuery);
+		});
+	}, [query]);
+
+	const groupedShortcuts = useMemo(() => {
+		return (Object.keys(CATEGORY_LABELS) as KeyboardShortcut["category"][])
+			.map((category) => ({
+				category,
+				shortcuts: filteredShortcuts.filter((shortcut) => shortcut.category === category),
+			}))
+			.filter((group) => group.shortcuts.length > 0);
+	}, [filteredShortcuts]);
+
+	function handleKeyDown(event: React.KeyboardEvent) {
+		if (event.key === "Escape") {
+			closeKeyboardShortcutsDialog();
+		}
+	}
+
+	return (
+		// biome-ignore lint/a11y/useKeyWithClickEvents: overlay click to close is a convenience
+		<div
+			className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+			onClick={(event) => {
+				if (event.target === event.currentTarget) closeKeyboardShortcutsDialog();
+			}}
+		>
+			<div
+				data-testid="keyboard-shortcuts-dialog"
+				className="flex h-[620px] w-full max-w-3xl flex-col overflow-hidden rounded-lg border border-border bg-background shadow-lg"
+				onKeyDown={handleKeyDown}
+			>
+				<div className="flex items-center justify-between border-b border-border px-4 py-3">
+					<div>
+						<h2 className="text-sm font-medium text-foreground">Keyboard Shortcuts</h2>
+						<p className="mt-1 text-xs text-muted-foreground">
+							Search by action, key combo, or category. Press Escape to close.
+						</p>
+					</div>
+					<button
+						type="button"
+						onClick={closeKeyboardShortcutsDialog}
+						className="rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+					>
+						<X className="h-4 w-4" />
+					</button>
+				</div>
+
+				<div className="border-b border-border px-4 py-3">
+					<div className="flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2">
+						<Search className="h-4 w-4 text-muted-foreground" />
+						<input
+							ref={inputRef}
+							data-testid="keyboard-shortcuts-search"
+							type="text"
+							value={query}
+							onChange={(event) => setQuery(event.target.value)}
+							placeholder="Search shortcuts…"
+							className="w-full bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+						/>
+					</div>
+				</div>
+
+				<div className="flex-1 overflow-y-auto px-4 py-4">
+					{groupedShortcuts.length === 0 ? (
+						<div className="rounded-md border border-dashed border-border px-4 py-10 text-center text-sm text-muted-foreground">
+							No shortcuts match your search.
+						</div>
+					) : (
+						<div className="space-y-6">
+							{groupedShortcuts.map((group) => (
+								<section key={group.category}>
+									<h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+										{CATEGORY_LABELS[group.category]}
+									</h3>
+									<div className="overflow-hidden rounded-md border border-border">
+										{group.shortcuts.map((shortcut) => {
+											const primaryKeys = isMac ? shortcut.macKeys : shortcut.winKeys;
+											const secondaryKeys = isMac ? shortcut.winKeys : shortcut.macKeys;
+
+											return (
+												<div
+													key={shortcut.id}
+													className="flex items-center justify-between gap-4 border-b border-border bg-card px-4 py-3 last:border-b-0"
+												>
+													<div className="min-w-0">
+														<div className="text-sm font-medium text-foreground">
+															{shortcut.label}
+														</div>
+														<div className="mt-1 text-xs text-muted-foreground">
+															Also: {secondaryKeys}
+														</div>
+													</div>
+													<kbd className="shrink-0 rounded border border-border bg-background px-2 py-1 text-xs font-medium text-foreground">
+														{primaryKeys}
+													</kbd>
+												</div>
+											);
+										})}
+									</div>
+								</section>
+							))}
+						</div>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/hooks/use-keyboard-shortcuts.test.tsx
+++ b/src/hooks/use-keyboard-shortcuts.test.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSettingsStore } from "@/stores/settings-store";
+import { useUiStore } from "@/stores/ui-store";
+
+vi.mock("@/hooks/use-file-operations", () => ({
+	useFileOperations: () => ({
+		newModel: vi.fn(),
+		openModel: vi.fn(),
+		saveModel: vi.fn(),
+		saveModelAs: vi.fn(),
+		exportAsHtml: vi.fn(),
+	}),
+}));
+
+const { useKeyboardShortcuts } = await import("./use-keyboard-shortcuts");
+
+describe("useKeyboardShortcuts", () => {
+	beforeEach(() => {
+		useUiStore.setState({ keyboardShortcutsDialogOpen: false });
+		useSettingsStore.setState({ settingsDialogOpen: false, settingsDialogInitialTab: null });
+	});
+
+	it("opens the keyboard shortcuts dialog with ?", () => {
+		renderHook(() => useKeyboardShortcuts());
+
+		fireEvent.keyDown(window, { key: "?", shiftKey: true });
+
+		expect(useUiStore.getState().keyboardShortcutsDialogOpen).toBe(true);
+	});
+
+	it("closes the keyboard shortcuts dialog with Escape before other Escape behavior", () => {
+		useUiStore.setState({ keyboardShortcutsDialogOpen: true });
+
+		renderHook(() => useKeyboardShortcuts());
+
+		fireEvent.keyDown(window, { key: "Escape" });
+
+		expect(useUiStore.getState().keyboardShortcutsDialogOpen).toBe(false);
+	});
+});

--- a/src/hooks/use-keyboard-shortcuts.ts
+++ b/src/hooks/use-keyboard-shortcuts.ts
@@ -27,6 +27,10 @@ export function useKeyboardShortcuts() {
 
 			if (!isInputFocused && !mod) {
 				switch (e.key) {
+					case "?":
+						e.preventDefault();
+						useUiStore.getState().openKeyboardShortcutsDialog();
+						return;
 					case "Delete":
 					case "Backspace":
 						e.preventDefault();
@@ -49,7 +53,9 @@ export function useKeyboardShortcuts() {
 						return;
 					case "Escape":
 						// Close dialogs first, then deselect
-						if (useSettingsStore.getState().settingsDialogOpen) {
+						if (useUiStore.getState().keyboardShortcutsDialogOpen) {
+							useUiStore.getState().closeKeyboardShortcutsDialog();
+						} else if (useSettingsStore.getState().settingsDialogOpen) {
 							useSettingsStore.getState().closeSettingsDialog();
 						} else {
 							useModelStore.getState().setSelectedElement(null);

--- a/src/hooks/use-native-menu.ts
+++ b/src/hooks/use-native-menu.ts
@@ -168,6 +168,9 @@ export function useNativeMenu() {
 						break;
 
 					// Help
+					case "help-keyboard-shortcuts":
+						useUiStore.getState().openKeyboardShortcutsDialog();
+						break;
 					case "help-guides":
 						// Handled via a frontend event — guide picker is a React component
 						window.dispatchEvent(new CustomEvent("open-guide-picker"));

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -63,6 +63,8 @@ interface UiState extends ThemeState {
 	canvasLocked: boolean;
 	/** Whether the command palette (Cmd+K) is open */
 	commandPaletteOpen: boolean;
+	/** Whether the keyboard shortcuts dialog is open */
+	keyboardShortcutsDialogOpen: boolean;
 
 	// Actions
 	toggleLeftPanel: () => void;
@@ -76,6 +78,8 @@ interface UiState extends ThemeState {
 	toggleCanvasLock: () => void;
 	openCommandPalette: () => void;
 	closeCommandPalette: () => void;
+	openKeyboardShortcutsDialog: () => void;
+	closeKeyboardShortcutsDialog: () => void;
 }
 
 function loadPersistedTheme(): ThemeState {
@@ -167,6 +171,7 @@ export const useUiStore = create<UiState>((set, get) => ({
 	rightPanelTab: "properties",
 	canvasLocked: false,
 	commandPaletteOpen: false,
+	keyboardShortcutsDialogOpen: false,
 	themeMode: initialTheme.themeMode,
 	lightPresetId: initialTheme.lightPresetId,
 	darkPresetId: initialTheme.darkPresetId,
@@ -187,6 +192,8 @@ export const useUiStore = create<UiState>((set, get) => ({
 	toggleCanvasLock: () => set((state) => ({ canvasLocked: !state.canvasLocked })),
 	openCommandPalette: () => set({ commandPaletteOpen: true }),
 	closeCommandPalette: () => set({ commandPaletteOpen: false }),
+	openKeyboardShortcutsDialog: () => set({ keyboardShortcutsDialogOpen: true }),
+	closeKeyboardShortcutsDialog: () => set({ keyboardShortcutsDialogOpen: false }),
 
 	setTheme: (mode, presetId) => {
 		const current = get();


### PR DESCRIPTION
## Summary
- add a searchable keyboard shortcuts dialog backed by the existing shortcut registry
- open it from the Help menu and with the ? shortcut
- add focused tests for the dialog and keyboard hook behavior

Closes #36

## Testing
- npx vitest run src/components/panels/keyboard-shortcuts-dialog.test.tsx src/hooks/use-keyboard-shortcuts.test.tsx
- npx biome check src/components/layout/app-layout.tsx src/components/panels/keyboard-shortcuts-dialog.tsx src/components/panels/keyboard-shortcuts-dialog.test.tsx src/hooks/use-keyboard-shortcuts.ts src/hooks/use-keyboard-shortcuts.test.tsx src/hooks/use-native-menu.ts src/stores/ui-store.ts