### PR TITLE
style(menu): fix rustfmt drift in menu.rs

### DIFF
--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -158,8 +158,8 @@ pub fn build_menu(app: &App) -> Result<Menu<Wry>, Box<dyn std::error::Error>> {
         "Help",
         true,
         &[
-			&help_keyboard_shortcuts,
-			&PredefinedMenuItem::separator(handle)?,
+            &help_keyboard_shortcuts,
+            &PredefinedMenuItem::separator(handle)?,
             &help_guides,
             &PredefinedMenuItem::separator(handle)?,
             &help_about,


### PR DESCRIPTION
## Summary

- Applies `cargo fmt` to `src-tauri/src/menu.rs` (tabs → 4 spaces, 2 lines). Whitespace-only, no behavior change.

## Why

`main`'s CI has been red since #40 — the `Lint` job fails on `cargo fmt --check` due to this drift (likely a rustfmt version difference at merge time). This unblocks CI for the repo. Verified locally with `npm run ci:local`: Biome, tsc, cargo fmt, Clippy, Vitest (422), cargo test (73) all green.

## Test plan

- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml --check` passes
- [x] Full `npm run ci:local` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)