### PR TITLE
chore(repo): add CODEOWNERS to restrict approvals to maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Code owners for ThreatForge.
+#
+# Every change requires an approving review from one of these accounts before it
+# can be merged into `main` (enforced by the repository ruleset's
+# "require code owner review"). The public can still open PRs from forks — only
+# these owners can approve and merge them.
+
+* @Shreyasdbz @exitzerolabs-admin


### PR DESCRIPTION
Adds `.github/CODEOWNERS` (`* @Shreyasdbz @exitzerolabs-admin`). Pairs with enabling `require_code_owner_review` on the main ruleset so only these two accounts can give a merge-enabling review. Public fork PRs stay open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)