### PR TITLE
chore(repo): ignore agent worktrees so the local gate stays runnable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,9 @@ screenshots/
 
 # Local-only scratch (per-developer, never committed)
 *.local.md
+
+# Agent worktrees. Each is a full checkout containing its own biome.json, which
+# Biome discovers as a nested root configuration and errors on, breaking
+# `npm run ci:local` for anyone running a coding agent. Ignoring them also stops
+# a worktree being committed by accident.
+.claude/worktrees/


### PR DESCRIPTION
`npm run ci:local` fails for anyone with a coding-agent worktree checked out under `.claude/worktrees/`.

## Cause

Each worktree is a full copy of the repository, so it carries its own `biome.json`. Biome discovers that as a *nested root configuration* and exits before linting anything:

```
× Found a nested root configuration, but there's already a root configuration.
  i The other configuration was found in /Users/shreyas/Exit0Labs/Repos/threat-forge.
× Biome exited because the configuration resulted in errors.
```

The `files.includes` scoping already in `biome.json` (`src/**`, `scripts/*.mjs`, …) does not help — config discovery happens independently of which files get linted.

## Fix

Biome already runs with `useIgnoreFile: true`, so adding `.claude/worktrees/` to `.gitignore` resolves it without introducing a second ignore list to keep in sync.

Separately, the directory was **not ignored at all**, so an entire agent worktree could have been committed by accident.

## Verification

Run with two agent worktrees present — previously an immediate Biome failure:

```
bash scripts/ci-local.sh
  ✓ package-lock.json  ✓ Tauri versions  ✓ Cargo dependencies
  ✓ Biome              ✓ tsc             ✓ cargo fmt
  ✓ Clippy             ✓ Vitest          ✓ cargo test
  ✓ Web build          ✓ Cloudflare Worker
  All checks passed.
```

`git check-ignore -v .claude/worktrees/` confirms the rule matches.

## Origin

Hit three times while landing the current PR queue. CI on GitHub was never affected, since worktrees are never committed — this only breaks the local gate, which is exactly the check `AGENTS.md` asks contributors to run before handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)