### PR TITLE
feat(stores): add document registry and route the lifecycle through it

### DIFF
--- a/src/components/canvas/canvas.tsx
+++ b/src/components/canvas/canvas.tsx
@@ -16,8 +16,7 @@ import { buildLayoutFromModel } from "@/lib/model-layout-utils";
 import { openExternalUrl } from "@/lib/platform";
 import { loadTemplate, TEMPLATES, type TemplateInfo } from "@/lib/templates";
 import { TIPS } from "@/lib/tips";
-import { useCanvasStore } from "@/stores/canvas-store";
-import { useHistoryStore } from "@/stores/history-store";
+import { useDocumentRegistry } from "@/stores/document-registry";
 import { useModelStore } from "@/stores/model-store";
 import { useSettingsStore } from "@/stores/settings-store";
 
@@ -47,20 +46,16 @@ export function Canvas() {
 
 function EmptyCanvas() {
 	const { newModel, openModel } = useFileOperations();
-	const setModel = useModelStore((s) => s.setModel);
 
-	const openTemplate = useCallback(
-		(id: string) => {
-			const model = loadTemplate(id);
-			if (!model) return;
-			const layout = buildLayoutFromModel(model);
-			useCanvasStore.getState().setPendingLayout(layout);
-			setModel(model, null);
-			useHistoryStore.getState().clear();
-			useSettingsStore.getState().clearFileSettings();
-		},
-		[setModel],
-	);
+	const openTemplate = useCallback((id: string) => {
+		const model = loadTemplate(id);
+		if (!model) return;
+		const pendingLayout = buildLayoutFromModel(model);
+		const registry = useDocumentRegistry.getState();
+		if (registry.activeDocumentId) registry.closeDocument(registry.activeDocumentId);
+		registry.createDocument({ model, filePath: null, pendingLayout });
+		useSettingsStore.getState().clearFileSettings();
+	}, []);
 
 	return (
 		<div

--- a/src/hooks/use-file-operations.test.ts
+++ b/src/hooks/use-file-operations.test.ts
@@ -1,0 +1,208 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useCanvasStore } from "@/stores/canvas-store";
+import { useDocumentRegistry } from "@/stores/document-registry";
+import { createDocumentStores, setActiveStores } from "@/stores/document-stores";
+import { useHistoryStore } from "@/stores/history-store";
+import { useModelStore } from "@/stores/model-store";
+import type { ThreatModel } from "@/types/threat-model";
+
+// A single controllable fake file adapter. Each test configures what it returns.
+const adapter = vi.hoisted(() => ({
+	createNewModel: vi.fn(),
+	openThreatModel: vi.fn(),
+	importThreatModel: vi.fn(),
+	saveThreatModel: vi.fn(),
+	openLayout: vi.fn(),
+	saveLayout: vi.fn(),
+	exportAsHtml: vi.fn(),
+	confirmDiscard: vi.fn(),
+}));
+
+vi.mock("@/lib/adapters/get-file-adapter", () => ({
+	getFileAdapter: () => Promise.resolve(adapter),
+}));
+
+const { useFileOperations } = await import("@/hooks/use-file-operations");
+
+function makeModel(title: string): ThreatModel {
+	return {
+		version: "1.0",
+		metadata: {
+			title,
+			author: "Test",
+			created: "2026-01-01",
+			modified: "2026-01-01",
+			description: "",
+		},
+		elements: [],
+		data_flows: [],
+		trust_boundaries: [],
+		threats: [],
+		diagrams: [],
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	useDocumentRegistry.setState({
+		documents: {},
+		openDocumentIds: [],
+		activeDocumentId: null,
+	});
+	setActiveStores(createDocumentStores());
+	adapter.confirmDiscard.mockResolvedValue(true);
+	adapter.openLayout.mockResolvedValue(null);
+});
+
+describe("useFileOperations lifecycle through the document registry", () => {
+	it("New opens an active registry document with a clean history and no file path", async () => {
+		adapter.createNewModel.mockResolvedValue(makeModel("Untitled Threat Model"));
+		const { result } = renderHook(() => useFileOperations());
+
+		await act(async () => {
+			await result.current.newModel();
+		});
+
+		const registry = useDocumentRegistry.getState();
+		expect(registry.activeDocumentId).not.toBeNull();
+		expect(registry.openDocumentIds).toHaveLength(1);
+		expect(useModelStore.getState().model?.metadata.title).toBe("Untitled Threat Model");
+		expect(useModelStore.getState().filePath).toBeNull();
+		expect(useHistoryStore.getState().past).toEqual([]);
+	});
+
+	it("Save As to two different paths keeps the same document id and preserves undo depth", async () => {
+		adapter.createNewModel.mockResolvedValue(makeModel("Doc"));
+		const { result } = renderHook(() => useFileOperations());
+
+		await act(async () => {
+			await result.current.newModel();
+		});
+		const id = useDocumentRegistry.getState().openDocumentIds[0];
+
+		// One history-pushing edit gives the document a non-empty undo stack.
+		act(() => {
+			useCanvasStore.getState().addElement("web_server", { x: 0, y: 0 });
+		});
+		expect(useHistoryStore.getState().past).toHaveLength(1);
+
+		adapter.saveThreatModel.mockResolvedValueOnce("/a.thf");
+		await act(async () => {
+			await result.current.saveModelAs();
+		});
+		expect(useDocumentRegistry.getState().activeDocumentId).toBe(id);
+		expect(useModelStore.getState().filePath).toBe("/a.thf");
+		expect(useHistoryStore.getState().past).toHaveLength(1);
+
+		adapter.saveThreatModel.mockResolvedValueOnce("/b.thf");
+		await act(async () => {
+			await result.current.saveModelAs();
+		});
+		expect(useDocumentRegistry.getState().activeDocumentId).toBe(id);
+		expect(useDocumentRegistry.getState().openDocumentIds).toEqual([id]);
+		expect(useModelStore.getState().filePath).toBe("/b.thf");
+		expect(useHistoryStore.getState().past).toHaveLength(1);
+	});
+
+	it("Open after an edit starts a fresh document, dropping the previous canvas and history", async () => {
+		adapter.createNewModel.mockResolvedValue(makeModel("First"));
+		const { result } = renderHook(() => useFileOperations());
+
+		await act(async () => {
+			await result.current.newModel();
+		});
+		const firstId = useDocumentRegistry.getState().openDocumentIds[0];
+		act(() => {
+			useCanvasStore.getState().addElement("web_server", { x: 0, y: 0 });
+		});
+		expect(useCanvasStore.getState().nodes.map((n) => n.id)).toContain("comp-1");
+		expect(useHistoryStore.getState().past).toHaveLength(1);
+
+		adapter.openThreatModel.mockResolvedValue({ model: makeModel("Second"), path: "/second.thf" });
+		await act(async () => {
+			await result.current.openModel();
+		});
+
+		const registry = useDocumentRegistry.getState();
+		expect(registry.activeDocumentId).not.toBe(firstId);
+		expect(registry.documents[firstId]).toBeUndefined();
+		expect(useModelStore.getState().model?.metadata.title).toBe("Second");
+		expect(useModelStore.getState().filePath).toBe("/second.thf");
+		expect(useHistoryStore.getState().past).toEqual([]);
+		// The new document's canvas cannot contain the previous document's node.
+		expect(useCanvasStore.getState().nodes.map((n) => n.id)).not.toContain("comp-1");
+		expect(useCanvasStore.getState().nodes).toEqual([]);
+	});
+
+	it("Import starts a fresh unsaved document and disposes the previous one", async () => {
+		adapter.createNewModel.mockResolvedValue(makeModel("First"));
+		const { result } = renderHook(() => useFileOperations());
+
+		await act(async () => {
+			await result.current.newModel();
+		});
+		const firstId = useDocumentRegistry.getState().openDocumentIds[0];
+
+		adapter.importThreatModel.mockResolvedValue({ model: makeModel("Imported") });
+		await act(async () => {
+			await result.current.importModel();
+		});
+
+		const registry = useDocumentRegistry.getState();
+		expect(registry.documents[firstId]).toBeUndefined();
+		expect(registry.openDocumentIds).toHaveLength(1);
+		expect(useModelStore.getState().model?.metadata.title).toBe("Imported");
+		expect(useModelStore.getState().filePath).toBeNull();
+	});
+
+	it("Close disposes the active document and returns to an empty scratch view", async () => {
+		adapter.createNewModel.mockResolvedValue(makeModel("Doc"));
+		const { result } = renderHook(() => useFileOperations());
+
+		await act(async () => {
+			await result.current.newModel();
+		});
+		act(() => {
+			useCanvasStore.getState().addElement("web_server", { x: 0, y: 0 });
+		});
+
+		await act(async () => {
+			await result.current.closeModel();
+		});
+
+		const registry = useDocumentRegistry.getState();
+		expect(registry.activeDocumentId).toBeNull();
+		expect(registry.openDocumentIds).toEqual([]);
+		expect(registry.documents).toEqual({});
+		expect(useModelStore.getState().model).toBeNull();
+		expect(useCanvasStore.getState().nodes).toEqual([]);
+		expect(useHistoryStore.getState().past).toEqual([]);
+	});
+
+	it("New keeps the current document when the discard confirmation is declined", async () => {
+		adapter.createNewModel.mockResolvedValue(makeModel("First"));
+		const { result } = renderHook(() => useFileOperations());
+
+		await act(async () => {
+			await result.current.newModel();
+		});
+		const firstId = useDocumentRegistry.getState().openDocumentIds[0];
+		// Make the document dirty so the discard guard is exercised.
+		act(() => {
+			useCanvasStore.getState().addElement("web_server", { x: 0, y: 0 });
+		});
+
+		adapter.confirmDiscard.mockResolvedValue(false);
+		adapter.createNewModel.mockResolvedValue(makeModel("Second"));
+		await act(async () => {
+			await result.current.newModel();
+		});
+
+		const registry = useDocumentRegistry.getState();
+		expect(registry.openDocumentIds).toEqual([firstId]);
+		expect(registry.activeDocumentId).toBe(firstId);
+		expect(useModelStore.getState().model?.metadata.title).toBe("First");
+		expect(adapter.createNewModel).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/hooks/use-file-operations.ts
+++ b/src/hooks/use-file-operations.ts
@@ -4,10 +4,10 @@ import { generateHtmlReport } from "@/lib/export/export-html";
 import { buildLayoutFromModel } from "@/lib/model-layout-utils";
 import type { DfdEdgeData } from "@/stores/canvas-store";
 import { useCanvasStore } from "@/stores/canvas-store";
-import { useHistoryStore } from "@/stores/history-store";
+import { useDocumentRegistry } from "@/stores/document-registry";
 import { useModelStore } from "@/stores/model-store";
 import { useSettingsStore } from "@/stores/settings-store";
-import type { ThreatModel } from "@/types/threat-model";
+import type { DiagramLayout, ThreatModel } from "@/types/threat-model";
 
 function todayString(): string {
 	return new Date().toISOString().split("T")[0];
@@ -89,7 +89,6 @@ export function useFileOperations() {
 	const filePath = useModelStore((s) => s.filePath);
 	const isDirty = useModelStore((s) => s.isDirty);
 	const setModel = useModelStore((s) => s.setModel);
-	const clearModel = useModelStore((s) => s.clearModel);
 
 	const newModel = useCallback(async () => {
 		if (isDirty) {
@@ -106,13 +105,14 @@ export function useFileOperations() {
 		if (identity) {
 			created.metadata.created_by = identity;
 		}
-		// No pending layout for new models — use default positions
-		useCanvasStore.getState().setPendingLayout(null);
-		setModel(created, null);
-		useHistoryStore.getState().clear();
+
+		const registry = useDocumentRegistry.getState();
+		if (registry.activeDocumentId) registry.closeDocument(registry.activeDocumentId);
+		// New models use default positions, so there is no pending layout to apply.
+		registry.createDocument({ model: created, filePath: null, pendingLayout: null });
 		useSettingsStore.getState().clearFileSettings();
-		// syncFromModel is called by the useEffect in DfdCanvas when model changes
-	}, [isDirty, setModel]);
+		// syncFromModel runs from the DfdCanvas effect once the new bundle is active.
+	}, [isDirty]);
 
 	const openModel = useCallback(async () => {
 		if (isDirty) {
@@ -127,23 +127,24 @@ export function useFileOperations() {
 
 		const { model: loaded, path } = result;
 
-		// Build layout from inline positions (new format) or try sidecar (old format)
+		// Build layout from inline positions (new format) or try sidecar (old format).
+		let pendingLayout: DiagramLayout | null;
 		const inlineLayout = buildLayoutFromModel(loaded);
 		if (inlineLayout) {
-			useCanvasStore.getState().setPendingLayout(inlineLayout);
+			pendingLayout = inlineLayout;
 		} else if (loaded.diagrams.length > 0 && loaded.diagrams[0].layout_file && path) {
 			// Fallback: try loading old sidecar layout file
-			const layout = await adapter.openLayout(path, loaded.diagrams[0].layout_file);
-			useCanvasStore.getState().setPendingLayout(layout);
+			pendingLayout = await adapter.openLayout(path, loaded.diagrams[0].layout_file);
 		} else {
-			useCanvasStore.getState().setPendingLayout(null);
+			pendingLayout = null;
 		}
 
-		setModel(loaded, path);
-		useHistoryStore.getState().clear();
+		const registry = useDocumentRegistry.getState();
+		if (registry.activeDocumentId) registry.closeDocument(registry.activeDocumentId);
+		registry.createDocument({ model: loaded, filePath: path, pendingLayout });
 		useSettingsStore.getState().loadFileSettings(loaded.metadata.settings);
-		// syncFromModel is called by the useEffect in DfdCanvas when model changes
-	}, [isDirty, setModel]);
+		// syncFromModel runs from the DfdCanvas effect once the new bundle is active.
+	}, [isDirty]);
 
 	const saveModel = useCallback(async () => {
 		if (!model) return;
@@ -193,12 +194,12 @@ export function useFileOperations() {
 			const discard = await adapter.confirmDiscard();
 			if (!discard) return;
 		}
-		clearModel();
-		useHistoryStore.getState().clear();
+		const registry = useDocumentRegistry.getState();
+		if (registry.activeDocumentId) registry.closeDocument(registry.activeDocumentId);
+		// With no active document the facades resolve to a fresh scratch bundle, so the canvas
+		// is empty by construction — no explicit syncFromModel needed.
 		useSettingsStore.getState().clearFileSettings();
-		// DfdCanvas unmounts when model is null, so useEffect won't fire — clear canvas directly
-		useCanvasStore.getState().syncFromModel();
-	}, [isDirty, clearModel]);
+	}, [isDirty]);
 
 	const importModel = useCallback(async () => {
 		if (isDirty) {
@@ -220,20 +221,16 @@ export function useFileOperations() {
 
 		const { model: imported } = result;
 
-		// Build layout from inline positions
-		const inlineLayout = buildLayoutFromModel(imported);
-		if (inlineLayout) {
-			useCanvasStore.getState().setPendingLayout(inlineLayout);
-		} else {
-			useCanvasStore.getState().setPendingLayout(null);
-		}
+		// Build layout from inline positions (imported models carry no sidecar reference).
+		const pendingLayout = buildLayoutFromModel(imported);
 
-		// Imported models have no file path — user must Save As to create a .thf file
-		setModel(imported, null);
-		useHistoryStore.getState().clear();
-		// TM7 imports have no ThreatForge file settings — clear to defaults
+		const registry = useDocumentRegistry.getState();
+		if (registry.activeDocumentId) registry.closeDocument(registry.activeDocumentId);
+		// Imported models have no file path — user must Save As to create a .thf file.
+		registry.createDocument({ model: imported, filePath: null, pendingLayout });
+		// TM7 imports have no ThreatForge file settings — clear to defaults.
 		useSettingsStore.getState().clearFileSettings();
-	}, [isDirty, setModel]);
+	}, [isDirty]);
 
 	const exportAsHtml = useCallback(async () => {
 		if (!model) return;

--- a/src/hooks/use-native-menu.ts
+++ b/src/hooks/use-native-menu.ts
@@ -4,6 +4,7 @@ import { isTauri } from "@/lib/platform";
 import { useCanvasInstanceStore } from "@/stores/canvas-instance-store";
 import { useCanvasStore } from "@/stores/canvas-store";
 import { useClipboardStore } from "@/stores/clipboard-store";
+import { useDocumentRegistry } from "@/stores/document-registry";
 import { useHistoryStore } from "@/stores/history-store";
 import { useModelStore } from "@/stores/model-store";
 import { useSettingsStore } from "@/stores/settings-store";
@@ -20,10 +21,10 @@ async function openFileByPath(filePath: string) {
 		path: filePath,
 	});
 
-	const layout = buildLayoutFromModel(model);
-	if (layout) useCanvasStore.getState().setPendingLayout(layout);
-	useModelStore.getState().setModel(model, filePath);
-	useHistoryStore.getState().clear();
+	const pendingLayout = buildLayoutFromModel(model);
+	const registry = useDocumentRegistry.getState();
+	if (registry.activeDocumentId) registry.closeDocument(registry.activeDocumentId);
+	registry.createDocument({ model, filePath, pendingLayout });
 	useSettingsStore.getState().loadFileSettings(model.metadata.settings);
 }
 

--- a/src/stores/document-registry.test.ts
+++ b/src/stores/document-registry.test.ts
@@ -1,0 +1,320 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { DiagramLayout, FileSettings, ThreatModel } from "@/types/threat-model";
+import { useCanvasStore } from "./canvas-store";
+import { useDocumentRegistry } from "./document-registry";
+import { createDocumentStores, getActiveStores, setActiveStores } from "./document-stores";
+import { useHistoryStore } from "./history-store";
+import { useModelStore } from "./model-store";
+
+function createTestModel(title: string, settings?: FileSettings): ThreatModel {
+	return {
+		version: "1.0",
+		metadata: {
+			title,
+			author: "Test",
+			created: "2026-01-01",
+			modified: "2026-01-01",
+			description: "",
+			...(settings ? { settings } : {}),
+		},
+		elements: [],
+		data_flows: [],
+		trust_boundaries: [],
+		threats: [],
+		diagrams: [],
+	};
+}
+
+/** Reset the registry and install a clean scratch bundle so each test starts isolated. */
+beforeEach(() => {
+	useDocumentRegistry.setState({
+		documents: {},
+		openDocumentIds: [],
+		activeDocumentId: null,
+	});
+	setActiveStores(createDocumentStores());
+});
+
+describe("document registry lifecycle", () => {
+	it("registers a document, points the facades at its bundle, and returns a fresh id", () => {
+		const registry = useDocumentRegistry.getState();
+		const id = registry.createDocument({
+			model: createTestModel("Alpha"),
+			filePath: "/alpha.thf",
+			pendingLayout: null,
+		});
+
+		const state = useDocumentRegistry.getState();
+		expect(state.activeDocumentId).toBe(id);
+		expect(state.openDocumentIds).toEqual([id]);
+		expect(state.documents[id]).toBeDefined();
+		// The facade now resolves the new document's own bundle.
+		expect(getActiveStores()).toBe(registry.getDocumentStores(id));
+		expect(useModelStore.getState().model?.metadata.title).toBe("Alpha");
+		expect(useModelStore.getState().filePath).toBe("/alpha.thf");
+	});
+
+	it("gives every document its own store instances", () => {
+		const registry = useDocumentRegistry.getState();
+		const a = registry.createDocument({
+			model: createTestModel("A"),
+			filePath: null,
+			pendingLayout: null,
+		});
+		const b = registry.createDocument({
+			model: createTestModel("B"),
+			filePath: null,
+			pendingLayout: null,
+		});
+
+		expect(a).not.toBe(b);
+		const storesA = registry.getDocumentStores(a);
+		const storesB = registry.getDocumentStores(b);
+		expect(storesA?.model).not.toBe(storesB?.model);
+		expect(storesA?.canvas).not.toBe(storesB?.canvas);
+		expect(storesA?.history).not.toBe(storesB?.history);
+		// Creating a second document leaves it active and appends to the open order.
+		expect(useDocumentRegistry.getState().activeDocumentId).toBe(b);
+		expect(useDocumentRegistry.getState().openDocumentIds).toEqual([a, b]);
+	});
+
+	it("seeds the pending layout onto the new bundle, not the outgoing active one", () => {
+		const layout: DiagramLayout = {
+			diagram_id: "diagram-1",
+			nodes: [{ id: "comp-1", x: 10, y: 20 }],
+			viewport: { x: 5, y: 6, zoom: 2 },
+		};
+		const registry = useDocumentRegistry.getState();
+		const a = registry.createDocument({
+			model: createTestModel("A"),
+			filePath: null,
+			pendingLayout: null,
+		});
+		const b = registry.createDocument({
+			model: createTestModel("B"),
+			filePath: null,
+			pendingLayout: layout,
+		});
+
+		expect(registry.getDocumentStores(b)?.canvas.getState().pendingLayout).toEqual(layout);
+		// The previously active document must not have received the incoming layout.
+		expect(registry.getDocumentStores(a)?.canvas.getState().pendingLayout).toBeNull();
+	});
+
+	it("seeds fileSettings from model metadata, or null when the model carries none", () => {
+		const registry = useDocumentRegistry.getState();
+		const withSettings = registry.createDocument({
+			model: createTestModel("Configured", { grid_size: 24 }),
+			filePath: null,
+			pendingLayout: null,
+		});
+		const withoutSettings = registry.createDocument({
+			model: createTestModel("Plain"),
+			filePath: null,
+			pendingLayout: null,
+		});
+
+		expect(useDocumentRegistry.getState().documents[withSettings].fileSettings).toEqual({
+			grid_size: 24,
+		});
+		expect(useDocumentRegistry.getState().documents[withoutSettings].fileSettings).toBeNull();
+	});
+
+	it("activates a document by pointing the facades at its bundle", () => {
+		const registry = useDocumentRegistry.getState();
+		const a = registry.createDocument({
+			model: createTestModel("A"),
+			filePath: null,
+			pendingLayout: null,
+		});
+		registry.createDocument({
+			model: createTestModel("B"),
+			filePath: null,
+			pendingLayout: null,
+		});
+
+		expect(useModelStore.getState().model?.metadata.title).toBe("B");
+		registry.activateDocument(a);
+		expect(useDocumentRegistry.getState().activeDocumentId).toBe(a);
+		expect(getActiveStores()).toBe(registry.getDocumentStores(a));
+		expect(useModelStore.getState().model?.metadata.title).toBe("A");
+	});
+
+	it("ignores activation of an unknown id", () => {
+		const registry = useDocumentRegistry.getState();
+		const a = registry.createDocument({
+			model: createTestModel("A"),
+			filePath: null,
+			pendingLayout: null,
+		});
+		registry.activateDocument("doc-does-not-exist" as ReturnType<typeof registry.createDocument>);
+		expect(useDocumentRegistry.getState().activeDocumentId).toBe(a);
+		expect(getActiveStores()).toBe(registry.getDocumentStores(a));
+	});
+});
+
+describe("closing documents", () => {
+	it("leaves the active pointer unchanged when a non-active document closes", () => {
+		const registry = useDocumentRegistry.getState();
+		const a = registry.createDocument({
+			model: createTestModel("A"),
+			filePath: null,
+			pendingLayout: null,
+		});
+		const b = registry.createDocument({
+			model: createTestModel("B"),
+			filePath: null,
+			pendingLayout: null,
+		});
+
+		registry.closeDocument(a);
+
+		const state = useDocumentRegistry.getState();
+		expect(state.documents[a]).toBeUndefined();
+		expect(state.openDocumentIds).toEqual([b]);
+		expect(state.activeDocumentId).toBe(b);
+		expect(getActiveStores()).toBe(registry.getDocumentStores(b));
+	});
+
+	it("activates a remaining document when the active one closes", () => {
+		const registry = useDocumentRegistry.getState();
+		const a = registry.createDocument({
+			model: createTestModel("A"),
+			filePath: null,
+			pendingLayout: null,
+		});
+		const b = registry.createDocument({
+			model: createTestModel("B"),
+			filePath: null,
+			pendingLayout: null,
+		});
+		const c = registry.createDocument({
+			model: createTestModel("C"),
+			filePath: null,
+			pendingLayout: null,
+		});
+
+		registry.closeDocument(c);
+
+		const state = useDocumentRegistry.getState();
+		expect(state.documents[c]).toBeUndefined();
+		expect(state.openDocumentIds).toEqual([a, b]);
+		expect(state.activeDocumentId).toBe(b);
+		expect(useModelStore.getState().model?.metadata.title).toBe("B");
+	});
+
+	it("clears the pointer and installs a fresh scratch bundle when the last document closes", () => {
+		const registry = useDocumentRegistry.getState();
+		const a = registry.createDocument({
+			model: createTestModel("Only"),
+			filePath: "/only.thf",
+			pendingLayout: null,
+		});
+
+		const before = getActiveStores();
+		registry.closeDocument(a);
+
+		const state = useDocumentRegistry.getState();
+		expect(state.activeDocumentId).toBeNull();
+		expect(state.openDocumentIds).toEqual([]);
+		expect(state.documents).toEqual({});
+		// A brand-new scratch bundle so nothing written while no document is open can resurface.
+		const after = getActiveStores();
+		expect(after).not.toBe(before);
+		expect(after.model.getState().model).toBeNull();
+		expect(after.canvas.getState().nodes).toEqual([]);
+	});
+
+	it("ignores closing an unknown id", () => {
+		const registry = useDocumentRegistry.getState();
+		const a = registry.createDocument({
+			model: createTestModel("A"),
+			filePath: null,
+			pendingLayout: null,
+		});
+		const before = getActiveStores();
+
+		registry.closeDocument("doc-missing" as typeof a);
+
+		const state = useDocumentRegistry.getState();
+		expect(state.openDocumentIds).toEqual([a]);
+		expect(state.activeDocumentId).toBe(a);
+		expect(getActiveStores()).toBe(before);
+	});
+});
+
+describe("per-document session metadata", () => {
+	it("updates fileSettings and chat-session references on the addressed document only", () => {
+		const registry = useDocumentRegistry.getState();
+		const a = registry.createDocument({
+			model: createTestModel("A"),
+			filePath: null,
+			pendingLayout: null,
+		});
+		const b = registry.createDocument({
+			model: createTestModel("B"),
+			filePath: null,
+			pendingLayout: null,
+		});
+
+		registry.setDocumentFileSettings(a, { grid_size: 32 });
+		registry.setDocumentChatSessionId(a, "session-a");
+
+		const state = useDocumentRegistry.getState();
+		expect(state.documents[a].fileSettings).toEqual({ grid_size: 32 });
+		expect(state.documents[a].activeChatSessionId).toBe("session-a");
+		expect(state.documents[b].fileSettings).toBeNull();
+		expect(state.documents[b].activeChatSessionId).toBeNull();
+	});
+
+	it("ignores metadata updates for unknown ids", () => {
+		const registry = useDocumentRegistry.getState();
+		registry.setDocumentFileSettings("doc-missing" as ReturnType<typeof registry.createDocument>, {
+			grid_size: 8,
+		});
+		expect(useDocumentRegistry.getState().documents).toEqual({});
+	});
+});
+
+describe("document isolation", () => {
+	it("keeps a second document's edits out of the first and restores the first on return", () => {
+		const registry = useDocumentRegistry.getState();
+
+		// Document A: two elements and their history, seen through the live facades.
+		const a = registry.createDocument({
+			model: createTestModel("A"),
+			filePath: "/a.thf",
+			pendingLayout: null,
+		});
+		useCanvasStore.getState().addElement("web_server", { x: 0, y: 0 });
+		useCanvasStore.getState().addElement("web_server", { x: 10, y: 10 });
+
+		expect(useModelStore.getState().model?.elements.map((e) => e.id)).toEqual(["comp-1", "comp-2"]);
+		expect(useHistoryStore.getState().past).toHaveLength(2);
+
+		// Activating B must present B's own empty bundle, not A's populated one.
+		const b = registry.createDocument({
+			model: createTestModel("B"),
+			filePath: "/b.thf",
+			pendingLayout: null,
+		});
+		expect(useModelStore.getState().model?.elements).toEqual([]);
+		expect(useCanvasStore.getState().nodes).toEqual([]);
+		expect(useHistoryStore.getState().past).toEqual([]);
+		expect(useModelStore.getState().filePath).toBe("/b.thf");
+
+		// Editing B allocates ids from B's own counter and must not touch A's bundle.
+		useCanvasStore.getState().addElement("data_store", { x: 5, y: 5 });
+		expect(useModelStore.getState().model?.elements.map((e) => e.id)).toEqual(["comp-1"]);
+		expect(registry.getDocumentStores(a)?.model.getState().model?.elements).toHaveLength(2);
+
+		// Returning to A restores its canvas, ids, and undo depth byte-for-byte.
+		registry.activateDocument(a);
+		expect(useModelStore.getState().model?.metadata.title).toBe("A");
+		expect(useModelStore.getState().model?.elements.map((e) => e.id)).toEqual(["comp-1", "comp-2"]);
+		expect(useModelStore.getState().filePath).toBe("/a.thf");
+		expect(useHistoryStore.getState().past).toHaveLength(2);
+		// B remains intact with its single, independently numbered element.
+		expect(registry.getDocumentStores(b)?.model.getState().model?.elements).toHaveLength(1);
+	});
+});

--- a/src/stores/document-registry.ts
+++ b/src/stores/document-registry.ts
@@ -1,0 +1,151 @@
+import { create } from "zustand";
+import { createDocumentId } from "@/lib/document-id";
+import type { DocumentId, DocumentSession } from "@/types/document";
+import type { DiagramLayout, FileSettings, ThreatModel } from "@/types/threat-model";
+import { createDocumentStores, type DocumentStores, setActiveStores } from "./document-stores";
+
+/** Everything needed to seed a new document's bundle at creation time. */
+export interface CreateDocumentInput {
+	/** The loaded, imported, template, or newly created model. */
+	model: ThreatModel;
+	/** The file path the model was loaded from, or null for unsaved documents. */
+	filePath: string | null;
+	/**
+	 * Layout to apply on the new document's first canvas sync. Passed here — rather than set
+	 * on the canvas store by the caller — because the caller's `useCanvasStore` still resolves
+	 * the outgoing document's bundle until this document is activated.
+	 */
+	pendingLayout: DiagramLayout | null;
+}
+
+interface DocumentRegistryState {
+	/** All open documents, keyed by their stable identity. */
+	documents: Record<DocumentId, DocumentSession>;
+	/** Open document ids in the order they were created. */
+	openDocumentIds: DocumentId[];
+	/** The single active-document pointer, or null when no document is open. */
+	activeDocumentId: DocumentId | null;
+
+	/**
+	 * Create a fresh document from a model, activate it, and return its id. The new bundle is
+	 * seeded and wired in isolation; nothing is copied from any other document.
+	 */
+	createDocument: (input: CreateDocumentInput) => DocumentId;
+	/** Point the store facades at a document's own bundle and mark it active. No-op if unknown. */
+	activateDocument: (id: DocumentId) => void;
+	/**
+	 * Dispose a document and its bundle. If it was active, activate the last remaining open
+	 * document, or install a fresh scratch bundle when none remain so nothing written while no
+	 * document is open can surface in a later document.
+	 */
+	closeDocument: (id: DocumentId) => void;
+	/** Update a document's file-scoped settings. No-op if the id is unknown. */
+	setDocumentFileSettings: (id: DocumentId, fileSettings: FileSettings | null) => void;
+	/** Update a document's AI session reference. No-op if the id is unknown. */
+	setDocumentChatSessionId: (id: DocumentId, sessionId: string | null) => void;
+	/** Read a document's own store bundle without subscribing, or null if the id is unknown. */
+	getDocumentStores: (id: DocumentId) => DocumentStores | null;
+}
+
+/**
+ * The document registry. It owns document sessions, their open order, and the single active
+ * pointer. The registry is the only global document-selection state; per-document state lives
+ * entirely inside each session's `stores` bundle.
+ *
+ * No store facade module imports this file, keeping the module graph acyclic.
+ */
+export const useDocumentRegistry = create<DocumentRegistryState>((set, get) => ({
+	documents: {},
+	openDocumentIds: [],
+	activeDocumentId: null,
+
+	createDocument: ({ model, filePath, pendingLayout }) => {
+		const id = createDocumentId();
+		const stores = createDocumentStores();
+
+		// Seed the new bundle in isolation before it becomes active. `setModel` resets the
+		// document's selection and dirty flag; the pending layout is consumed on first sync.
+		stores.model.getState().setModel(model, filePath);
+		stores.canvas.setState({ pendingLayout });
+
+		const session: DocumentSession = {
+			id,
+			createdAt: new Date().toISOString(),
+			stores,
+			fileSettings: model.metadata.settings ?? null,
+			activeChatSessionId: null,
+		};
+
+		set((state) => ({
+			documents: { ...state.documents, [id]: session },
+			openDocumentIds: [...state.openDocumentIds, id],
+		}));
+
+		get().activateDocument(id);
+		return id;
+	},
+
+	activateDocument: (id) => {
+		const session = get().documents[id];
+		if (!session) return;
+		set({ activeDocumentId: id });
+		setActiveStores(session.stores);
+	},
+
+	closeDocument: (id) => {
+		const state = get();
+		if (!state.documents[id]) return;
+
+		const remainingIds = state.openDocumentIds.filter((docId) => docId !== id);
+		const nextDocuments = { ...state.documents };
+		// Dropping the session's reference releases its model, history snapshots, and canvas
+		// state to garbage collection so closed-document content is not retained behind an
+		// inactive pointer.
+		delete nextDocuments[id];
+
+		const wasActive = state.activeDocumentId === id;
+		set({
+			documents: nextDocuments,
+			openDocumentIds: remainingIds,
+			activeDocumentId: wasActive ? null : state.activeDocumentId,
+		});
+
+		if (!wasActive) return;
+
+		// The active document closed. Activation policy on close (which sibling becomes active)
+		// is owned by the tab UX in #54; here we deterministically fall back to the most
+		// recently created document still open.
+		const nextActiveId = remainingIds[remainingIds.length - 1];
+		if (nextActiveId !== undefined) {
+			get().activateDocument(nextActiveId);
+		} else {
+			setActiveStores(createDocumentStores());
+		}
+	},
+
+	setDocumentFileSettings: (id, fileSettings) =>
+		set((state) => {
+			const session = state.documents[id];
+			if (!session) return state;
+			return { documents: { ...state.documents, [id]: { ...session, fileSettings } } };
+		}),
+
+	setDocumentChatSessionId: (id, sessionId) =>
+		set((state) => {
+			const session = state.documents[id];
+			if (!session) return state;
+			return {
+				documents: { ...state.documents, [id]: { ...session, activeChatSessionId: sessionId } },
+			};
+		}),
+
+	getDocumentStores: (id) => get().documents[id]?.stores ?? null,
+}));
+
+/**
+ * Subscribe to a document's own store bundle. `#54` uses this to render a per-tab title and
+ * dirty indicator from each document's stores without activating it.
+ */
+export function useDocumentStores(id: DocumentId): DocumentStores | null {
+	return useDocumentRegistry((state) => state.documents[id]?.stores ?? null);
+}

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -1,3 +1,6 @@
+import type { DocumentStores } from "@/stores/document-stores";
+import type { FileSettings } from "@/types/threat-model";
+
 /**
  * Opaque workspace identity for an open document.
  *
@@ -9,3 +12,27 @@
  * from a file path, title, or model content, and are never written to a `.thf` file.
  */
 export type DocumentId = string & { readonly __brand: "DocumentId" };
+
+/**
+ * One open document owned by the registry. The registry keeps exactly one session per
+ * open document and never copies state between sessions: everything document-scoped lives
+ * inside `stores`, so activating another document cannot expose this document's canvas,
+ * history, or selection.
+ *
+ * `fileSettings` and `activeChatSessionId` are the two document-scoped values that do not
+ * yet live in a store bundle. `#53` step 6 moves `fileSettings` off the workspace settings
+ * store into this record; step 8 populates `activeChatSessionId`. Neither field holds
+ * credentials or AI conversation content.
+ */
+export interface DocumentSession {
+	/** Stable, path-independent identity that survives Save As, rename, and path changes. */
+	id: DocumentId;
+	/** ISO timestamp of when the document was opened, for ordering and diagnostics. */
+	createdAt: string;
+	/** The document's own isolated model, canvas, and history stores. */
+	stores: DocumentStores;
+	/** File-scoped settings from `metadata.settings`, or null when the model carries none. */
+	fileSettings: FileSettings | null;
+	/** Reference to the AI session this document last used, or null. Populated from step 8. */
+	activeChatSessionId: string | null;
+}


### PR DESCRIPTION
Implements **steps 4 and 5** of the committed plan for #53, building on the injected store factories from #113. No user-visible change: the app still shows exactly one document at a time — this PR makes the machinery underneath multi-document.

Refs #53. Does not close it (steps 6–9 remain).

## Step 4 — the registry

`useDocumentRegistry` owns document sessions keyed by `DocumentId`, the ordered open list, and the **single active pointer** the acceptance criteria require. `createDocument` seeds a fresh isolated bundle and activates it; `activateDocument` swaps which bundle the facades resolve via `setActiveStores`; `closeDocument` disposes the bundle and activates a remaining document or installs a fresh scratch bundle.

**Nothing is copied between documents.** Activation is a pointer swap — the plan's bundle-swap-never-copy invariant, which is what makes future fields impossible to forget.

## Step 5 — lifecycle routed through it

New/Open/Import/template/file-association/Close go through registry operations; Save and Save As keep the document id. Two workarounds became unnecessary and were removed rather than kept as dead defense: the three explicit history `clear()` calls and the `closeModel` `syncFromModel()` hack — a fresh bundle *is* the clear.

`pendingLayout` is computed before the close and passed at creation, so it lands on the **new** bundle rather than the outgoing one — an ordering bug the old imperative sequence invited.

## Tests — 19 new, zero existing tests modified

13 registry tests including: closing the last document installs a *different* scratch bundle (identity-checked), pending layout lands on the new bundle not the outgoing one, and a full isolation case proving document B's edits do not leak into A and that returning to A restores nodes, ids, and undo depth exactly.

6 lifecycle tests against a mocked adapter: Save As twice keeps the same id and history depth; Open-after-edit gets a fresh document with no leaked node; declined discard keeps the current document.

## Verification

```
npx tsc --noEmit             exit 0
npx biome check .            exit 0 (1 pre-existing warning)
npx vitest run               45 files / 541 tests passed
bash scripts/ci-local.sh     All checks passed
npx playwright test          46 passed, first run, no retries
```

## Plan imprecisions found (recorded, not blocking)

1. **`DocumentSession` creates a type-only `types → stores` import.** Acyclic and compiles cleanly, but an unusual layering direction worth knowing for #54.
2. **Sibling activation on close is under-specified in the plan.** Chosen: deterministic "last remaining open id", documented in-code as provisional — the real policy is #54's tab UX decision. Pinned by a test so #54 changes it deliberately.
3. **`session.fileSettings` is seeded but not yet read** — the settings store remains source of truth until step 6. Scaffolding by the plan's own decomposition, exercised by tests, flagged so the slop lane doesn't treat it as speculative.

## Owner validation

- Confirm the close-activation policy placeholder (last remaining id) is acceptable until #54 decides the real UX.
- `useDocumentStores(id)` and `setDocumentChatSessionId` are forward API for #54/#63 — same "scaffolding with a named consumer" trade as #113's `createDocumentId`.
- Steps 6 (fileSettings move), 7 (viewport restore on switch), 8 (AI session refs) are deliberately absent; nothing here pretends to cover them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
