### PR TITLE
feat(stores): move file settings, viewport, and AI session ownership into the document session

### DIFF
--- a/src/components/canvas/canvas.tsx
+++ b/src/components/canvas/canvas.tsx
@@ -53,8 +53,8 @@ function EmptyCanvas() {
 		const pendingLayout = buildLayoutFromModel(model);
 		const registry = useDocumentRegistry.getState();
 		if (registry.activeDocumentId) registry.closeDocument(registry.activeDocumentId);
+		// Templates carry no file settings; createDocument seeds fileSettings to null.
 		registry.createDocument({ model, filePath: null, pendingLayout });
-		useSettingsStore.getState().clearFileSettings();
 	}, []);
 
 	return (

--- a/src/components/canvas/dfd-canvas.tsx
+++ b/src/components/canvas/dfd-canvas.tsx
@@ -79,15 +79,18 @@ export function DfdCanvas() {
 		[getReactFlowViewport, setReactFlowViewport],
 	);
 
-	// Expose ReactFlow actions to the canvas instance store so keyboard shortcuts can use them
+	// Expose ReactFlow actions to the canvas instance store so keyboard shortcuts and document
+	// activation (viewport restore/flush on switch) can drive the mounted instance.
 	useEffect(() => {
 		useCanvasInstanceStore.getState().setReactFlowActions({
 			fitView: () => fitViewFn(),
 			zoomIn: () => zoomInFn(),
 			zoomOut: () => zoomOutFn(),
 			panBy: (delta) => panByFn(delta),
+			setViewport: (viewport) => setReactFlowViewport(viewport),
+			getViewport: () => getReactFlowViewport(),
 		});
-	}, [fitViewFn, zoomInFn, zoomOutFn, panByFn]);
+	}, [fitViewFn, zoomInFn, zoomOutFn, panByFn, setReactFlowViewport, getReactFlowViewport]);
 
 	// Context menu state
 	const [contextMenu, setContextMenu] = useState<{

--- a/src/components/panels/ai-chat-tab.test.tsx
+++ b/src/components/panels/ai-chat-tab.test.tsx
@@ -1,0 +1,154 @@
+import { act, render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useChatStore } from "@/stores/chat-store";
+import { useDocumentRegistry } from "@/stores/document-registry";
+import { createDocumentStores, setActiveStores } from "@/stores/document-stores";
+import type { ThreatModel } from "@/types/threat-model";
+import { AiChatTab } from "./ai-chat-tab";
+
+// A controllable fake chat adapter. The abort test configures a stream that never resolves.
+const chatAdapter = vi.hoisted(() => ({ sendMessage: vi.fn() }));
+
+vi.mock("@/lib/adapters/get-chat-adapter", () => ({
+	getChatAdapter: () => Promise.resolve(chatAdapter),
+}));
+
+vi.mock("@/lib/adapters/get-keychain-adapter", () => ({
+	getKeychainAdapter: () => Promise.resolve({ hasKey: async () => false }),
+}));
+
+function makeModel(title: string): ThreatModel {
+	return {
+		version: "1.0",
+		metadata: {
+			title,
+			author: "Test",
+			created: "2026-01-01",
+			modified: "2026-01-01",
+			description: "",
+		},
+		elements: [],
+		data_flows: [],
+		trust_boundaries: [],
+		threats: [],
+		diagrams: [],
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	useDocumentRegistry.setState({
+		documents: {},
+		openDocumentIds: [],
+		activeDocumentId: null,
+	});
+	setActiveStores(createDocumentStores());
+	useChatStore.setState({
+		sessions: [],
+		activeSessionId: null,
+		sessionKey: null,
+		messages: [],
+		isStreaming: false,
+		error: null,
+	});
+});
+
+describe("AiChatTab session binding", () => {
+	it("re-binds chat sessions on a switch between two unsaved documents", async () => {
+		const registry = useDocumentRegistry.getState();
+		const a = registry.createDocument({
+			model: makeModel("A"),
+			filePath: null,
+			pendingLayout: null,
+		});
+		const b = registry.createDocument({
+			model: makeModel("B"),
+			filePath: null,
+			pendingLayout: null,
+		});
+		registry.activateDocument(a);
+
+		// Spy on the session loader while keeping its real behavior.
+		const realLoad = useChatStore.getState().loadSessionsForFile;
+		const loadSpy = vi.fn(realLoad);
+		useChatStore.setState({ loadSessionsForFile: loadSpy });
+
+		await act(async () => {
+			render(<AiChatTab />);
+		});
+		const initialCalls = loadSpy.mock.calls.length;
+		expect(initialCalls).toBeGreaterThan(0);
+
+		// Both documents are unsaved (filePath === null), so only the activeDocumentId dependency
+		// can re-run the binding effect. A build that keys the effect on filePath alone fails here.
+		await act(async () => {
+			registry.activateDocument(b);
+		});
+		expect(loadSpy.mock.calls.length).toBeGreaterThan(initialCalls);
+	});
+});
+
+describe("AiChatTab stream cancellation on document switch", () => {
+	it("aborts an in-flight AI stream on switch, leaving isStreaming false and dropping later chunks", async () => {
+		let capturedOnChunk: ((text: string) => void) | undefined;
+		chatAdapter.sendMessage.mockImplementation(
+			(
+				_provider: unknown,
+				_messages: unknown,
+				_model: unknown,
+				callbacks: { onChunk: (text: string) => void },
+			) => {
+				capturedOnChunk = callbacks.onChunk;
+				// Never resolves: the stream stays in-flight until it is aborted.
+				return new Promise<void>(() => {});
+			},
+		);
+
+		const registry = useDocumentRegistry.getState();
+		const a = registry.createDocument({
+			model: makeModel("A"),
+			filePath: null,
+			pendingLayout: null,
+		});
+		const b = registry.createDocument({
+			model: makeModel("B"),
+			filePath: null,
+			pendingLayout: null,
+		});
+		registry.activateDocument(a);
+
+		// A session must exist for the chat store to accept a message.
+		useChatStore.setState({
+			sessions: [{ id: "s1", title: "s1", messages: [], createdAt: "t", updatedAt: "t" }],
+			activeSessionId: "s1",
+			sessionKey: "threatforge-chat-sessions:unsaved",
+			messages: [],
+		});
+
+		await act(async () => {
+			void useChatStore.getState().sendMessage("hello", makeModel("A"));
+			// Let sendMessage reach the adapter call and register the abort controller.
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+
+		expect(useChatStore.getState().isStreaming).toBe(true);
+		expect(capturedOnChunk).toBeDefined();
+		const transcriptBefore = useChatStore.getState().messages;
+
+		// Switching documents cancels the in-flight stream.
+		act(() => {
+			registry.activateDocument(b);
+		});
+		expect(useChatStore.getState().isStreaming).toBe(false);
+
+		// A chunk that arrives after the abort must not append to the transcript.
+		act(() => {
+			capturedOnChunk?.("leaked text");
+		});
+		expect(useChatStore.getState().messages).toEqual(transcriptBefore);
+		expect(useChatStore.getState().messages.some((m) => m.content.includes("leaked text"))).toBe(
+			false,
+		);
+	});
+});

--- a/src/components/panels/ai-chat-tab.tsx
+++ b/src/components/panels/ai-chat-tab.tsx
@@ -21,6 +21,7 @@ import { extractThreats, suggestionToThreat } from "@/lib/ai-utils";
 import { cn } from "@/lib/utils";
 import { useCanvasStore } from "@/stores/canvas-store";
 import { type ChatMessage, useChatStore } from "@/stores/chat-store";
+import { useDocumentRegistry } from "@/stores/document-registry";
 import { useModelStore } from "@/stores/model-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import type { Threat } from "@/types/threat-model";
@@ -29,6 +30,7 @@ import { MarkdownContent } from "./markdown-content";
 export function AiChatTab() {
 	const model = useModelStore((s) => s.model);
 	const filePath = useModelStore((s) => s.filePath);
+	const activeDocumentId = useDocumentRegistry((s) => s.activeDocumentId);
 	const hasApiKey = useChatStore((s) => s.hasApiKey);
 	const checkApiKey = useChatStore((s) => s.checkApiKey);
 	const loadSessionsForFile = useChatStore((s) => s.loadSessionsForFile);
@@ -41,7 +43,10 @@ export function AiChatTab() {
 		void checkApiKey();
 	}, [checkApiKey]);
 
-	// Load sessions when file path changes; migrate on Save As
+	// Load sessions when the active document changes; migrate on Save As. `activeDocumentId` is
+	// a dependency so a switch between two unsaved documents (both `filePath === null`) still
+	// re-binds the panel instead of leaving it on the previous document's sessions.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: activeDocumentId re-binds sessions on document switch
 	useEffect(() => {
 		const prev = prevFilePathRef.current;
 		// Migrate sessions when transitioning from unsaved/old path to a new path
@@ -50,7 +55,7 @@ export function AiChatTab() {
 		}
 		loadSessionsForFile(filePath);
 		prevFilePathRef.current = filePath;
-	}, [filePath, loadSessionsForFile, migrateSessionKey]);
+	}, [activeDocumentId, filePath, loadSessionsForFile, migrateSessionKey]);
 
 	if (!model) {
 		return (

--- a/src/hooks/use-file-operations.ts
+++ b/src/hooks/use-file-operations.ts
@@ -29,6 +29,18 @@ function getAuthorIdentity(): string {
 	return "";
 }
 
+/**
+ * Keep the active document's file-scoped settings in sync with a just-saved model. The
+ * document session owns `fileSettings`; `setModel` refreshes the model but not the cached
+ * settings, so a save that rewrites metadata refreshes the session's copy here.
+ */
+function syncActiveFileSettings(model: ThreatModel): void {
+	const registry = useDocumentRegistry.getState();
+	const activeId = registry.activeDocumentId;
+	if (!activeId) return;
+	registry.setDocumentFileSettings(activeId, model.metadata.settings ?? null);
+}
+
 /** Write current canvas positions, boundary colors, and label offsets back into the model. */
 function captureCanvasIntoModel(model: ThreatModel): ThreatModel {
 	const { nodes, edges, viewport } = useCanvasStore.getState();
@@ -109,8 +121,8 @@ export function useFileOperations() {
 		const registry = useDocumentRegistry.getState();
 		if (registry.activeDocumentId) registry.closeDocument(registry.activeDocumentId);
 		// New models use default positions, so there is no pending layout to apply.
+		// The new document owns its own file settings (seeded from metadata by createDocument).
 		registry.createDocument({ model: created, filePath: null, pendingLayout: null });
-		useSettingsStore.getState().clearFileSettings();
 		// syncFromModel runs from the DfdCanvas effect once the new bundle is active.
 	}, [isDirty]);
 
@@ -150,8 +162,8 @@ export function useFileOperations() {
 
 		const registry = useDocumentRegistry.getState();
 		if (registry.activeDocumentId) registry.closeDocument(registry.activeDocumentId);
+		// createDocument seeds the new document's fileSettings from loaded.metadata.settings.
 		registry.createDocument({ model: loaded, filePath: path, pendingLayout });
-		useSettingsStore.getState().loadFileSettings(loaded.metadata.settings);
 		// syncFromModel runs from the DfdCanvas effect once the new bundle is active.
 	}, [isDirty]);
 
@@ -174,6 +186,7 @@ export function useFileOperations() {
 		if (!savedPath) return;
 
 		setModel(captured, savedPath);
+		syncActiveFileSettings(captured);
 	}, [model, filePath, setModel]);
 
 	const saveModelAs = useCallback(async () => {
@@ -195,6 +208,7 @@ export function useFileOperations() {
 		if (!savedPath) return;
 
 		setModel(captured, savedPath);
+		syncActiveFileSettings(captured);
 	}, [model, setModel]);
 
 	const closeModel = useCallback(async () => {
@@ -206,8 +220,8 @@ export function useFileOperations() {
 		const registry = useDocumentRegistry.getState();
 		if (registry.activeDocumentId) registry.closeDocument(registry.activeDocumentId);
 		// With no active document the facades resolve to a fresh scratch bundle, so the canvas
-		// is empty by construction — no explicit syncFromModel needed.
-		useSettingsStore.getState().clearFileSettings();
+		// is empty by construction — no explicit syncFromModel needed. File settings are disposed
+		// with the closed document's session.
 	}, [isDirty]);
 
 	const importModel = useCallback(async () => {
@@ -236,9 +250,9 @@ export function useFileOperations() {
 		const registry = useDocumentRegistry.getState();
 		if (registry.activeDocumentId) registry.closeDocument(registry.activeDocumentId);
 		// Imported models have no file path — user must Save As to create a .thf file.
+		// TM7 imports carry no ThreatForge file settings; createDocument seeds fileSettings to
+		// null from the absent metadata.settings.
 		registry.createDocument({ model: imported, filePath: null, pendingLayout });
-		// TM7 imports have no ThreatForge file settings — clear to defaults.
-		useSettingsStore.getState().clearFileSettings();
 	}, [isDirty]);
 
 	const exportAsHtml = useCallback(async () => {

--- a/src/hooks/use-native-menu.ts
+++ b/src/hooks/use-native-menu.ts
@@ -7,7 +7,6 @@ import { useClipboardStore } from "@/stores/clipboard-store";
 import { useDocumentRegistry } from "@/stores/document-registry";
 import { useHistoryStore } from "@/stores/history-store";
 import { useModelStore } from "@/stores/model-store";
-import { useSettingsStore } from "@/stores/settings-store";
 import { useUiStore } from "@/stores/ui-store";
 import { useFileOperations } from "./use-file-operations";
 
@@ -24,8 +23,8 @@ async function openFileByPath(filePath: string) {
 	const pendingLayout = buildLayoutFromModel(model);
 	const registry = useDocumentRegistry.getState();
 	if (registry.activeDocumentId) registry.closeDocument(registry.activeDocumentId);
+	// createDocument seeds the new document's fileSettings from model.metadata.settings.
 	registry.createDocument({ model, filePath, pendingLayout });
-	useSettingsStore.getState().loadFileSettings(model.metadata.settings);
 }
 
 /**

--- a/src/stores/canvas-instance-store.ts
+++ b/src/stores/canvas-instance-store.ts
@@ -1,3 +1,4 @@
+import type { Viewport } from "@xyflow/react";
 import { create } from "zustand";
 
 /**
@@ -14,11 +15,17 @@ interface CanvasInstanceState {
 	rfZoomIn: (() => void) | null;
 	rfZoomOut: (() => void) | null;
 	rfPanBy: ((delta: { x: number; y: number }) => void) | null;
+	/** Push a viewport (pan/zoom) into the mounted ReactFlow instance. */
+	rfSetViewport: ((viewport: Viewport) => void) | null;
+	/** Read the mounted ReactFlow instance's live viewport (pan/zoom). */
+	rfGetViewport: (() => Viewport) | null;
 	setReactFlowActions: (actions: {
 		fitView: () => void;
 		zoomIn: () => void;
 		zoomOut: () => void;
 		panBy: (delta: { x: number; y: number }) => void;
+		setViewport?: (viewport: Viewport) => void;
+		getViewport?: () => Viewport;
 	}) => void;
 
 	/** Element type currently being dragged from palette (workaround for WKWebView dataTransfer issues) */
@@ -52,12 +59,16 @@ export const useCanvasInstanceStore = create<CanvasInstanceState>((set) => ({
 	rfZoomIn: null,
 	rfZoomOut: null,
 	rfPanBy: null,
+	rfSetViewport: null,
+	rfGetViewport: null,
 	setReactFlowActions: (actions) =>
 		set({
 			rfFitView: actions.fitView,
 			rfZoomIn: actions.zoomIn,
 			rfZoomOut: actions.zoomOut,
 			rfPanBy: actions.panBy,
+			rfSetViewport: actions.setViewport ?? null,
+			rfGetViewport: actions.getViewport ?? null,
 		}),
 
 	draggedType: null,

--- a/src/stores/document-registry.test.ts
+++ b/src/stores/document-registry.test.ts
@@ -1,10 +1,14 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatSession } from "@/types/chat-session";
 import type { DiagramLayout, FileSettings, ThreatModel } from "@/types/threat-model";
+import { useCanvasInstanceStore } from "./canvas-instance-store";
 import { useCanvasStore } from "./canvas-store";
+import { useChatStore } from "./chat-store";
 import { useDocumentRegistry } from "./document-registry";
 import { createDocumentStores, getActiveStores, setActiveStores } from "./document-stores";
 import { useHistoryStore } from "./history-store";
 import { useModelStore } from "./model-store";
+import { useUiStore } from "./ui-store";
 
 function createTestModel(title: string, settings?: FileSettings): ThreatModel {
 	return {
@@ -316,5 +320,276 @@ describe("document isolation", () => {
 		expect(useHistoryStore.getState().past).toHaveLength(2);
 		// B remains intact with its single, independently numbered element.
 		expect(registry.getDocumentStores(b)?.model.getState().model?.elements).toHaveLength(1);
+	});
+});
+
+// Coverage for the file-scoped settings that #53 step 6 moved off the workspace settings
+// store and onto the per-document session. The corresponding cases previously lived in
+// `settings-store.test.ts`.
+describe("document-owned file settings", () => {
+	it("seeds fileSettings from every provided metadata settings field", () => {
+		const registry = useDocumentRegistry.getState();
+		const id = registry.createDocument({
+			model: createTestModel("Configured", {
+				grid_size: 24,
+				default_element_fill: "#3b82f6",
+			}),
+			filePath: null,
+			pendingLayout: null,
+		});
+
+		const { fileSettings } = useDocumentRegistry.getState().documents[id];
+		expect(fileSettings).not.toBeNull();
+		expect(fileSettings?.grid_size).toBe(24);
+		expect(fileSettings?.default_element_fill).toBe("#3b82f6");
+	});
+
+	it("disposes fileSettings when the document is closed", () => {
+		const registry = useDocumentRegistry.getState();
+		const id = registry.createDocument({
+			model: createTestModel("Configured", { grid_size: 24 }),
+			filePath: "/only.thf",
+			pendingLayout: null,
+		});
+		expect(useDocumentRegistry.getState().documents[id].fileSettings).toEqual({ grid_size: 24 });
+
+		registry.closeDocument(id);
+		// The session — and with it the file settings — is gone entirely, not merely blanked.
+		expect(useDocumentRegistry.getState().documents[id]).toBeUndefined();
+	});
+
+	it("replaces fileSettings wholesale, dropping fields absent from the new value", () => {
+		const registry = useDocumentRegistry.getState();
+		const id = registry.createDocument({
+			model: createTestModel("Configured", {
+				grid_size: 24,
+				default_element_fill: "#3b82f6",
+			}),
+			filePath: null,
+			pendingLayout: null,
+		});
+
+		registry.setDocumentFileSettings(id, { grid_size: 32, default_boundary_fill: "#22c55e" });
+
+		const { fileSettings } = useDocumentRegistry.getState().documents[id];
+		expect(fileSettings?.grid_size).toBe(32);
+		expect(fileSettings?.default_boundary_fill).toBe("#22c55e");
+		// The field only present in the previous value must not survive the replacement.
+		expect(fileSettings?.default_element_fill).toBeUndefined();
+	});
+
+	it("isolates fileSettings between two open documents", () => {
+		const registry = useDocumentRegistry.getState();
+		const configured = registry.createDocument({
+			model: createTestModel("Configured", { grid_size: 24 }),
+			filePath: "/configured.thf",
+			pendingLayout: null,
+		});
+		// A second document whose model carries no settings must not inherit the first's.
+		const plain = registry.createDocument({
+			model: createTestModel("Plain"),
+			filePath: "/plain.thf",
+			pendingLayout: null,
+		});
+
+		expect(useDocumentRegistry.getState().documents[plain].fileSettings).toBeNull();
+		expect(useDocumentRegistry.getState().documents[configured].fileSettings).toEqual({
+			grid_size: 24,
+		});
+
+		// Mutating one document's settings leaves the other untouched.
+		registry.setDocumentFileSettings(plain, { grid_size: 8 });
+		expect(useDocumentRegistry.getState().documents[configured].fileSettings).toEqual({
+			grid_size: 24,
+		});
+	});
+});
+
+describe("canvas viewport on document switch", () => {
+	let live = { x: 0, y: 0, zoom: 1 };
+	const rfSetViewport = vi.fn((viewport: typeof live) => {
+		live = viewport;
+	});
+	const rfGetViewport = vi.fn(() => live);
+	const rfFitView = vi.fn();
+
+	beforeEach(() => {
+		live = { x: 0, y: 0, zoom: 1 };
+		rfSetViewport.mockClear();
+		rfGetViewport.mockClear();
+		rfFitView.mockClear();
+		// Stand in for the mounted ReactFlow instance registered by DfdCanvas.
+		useCanvasInstanceStore.setState({ rfSetViewport, rfGetViewport, rfFitView });
+	});
+
+	afterEach(() => {
+		useCanvasInstanceStore.setState({
+			rfSetViewport: null,
+			rfGetViewport: null,
+			rfFitView: null,
+		});
+		useUiStore.getState().setRightPanelTab("properties");
+	});
+
+	it("flushes the outgoing viewport and restores the incoming one on a real switch", () => {
+		const registry = useDocumentRegistry.getState();
+		const a = registry.createDocument({
+			model: createTestModel("A"),
+			filePath: "/a.thf",
+			pendingLayout: null,
+		});
+		// Give A a laid-out node so its restore pushes a viewport instead of fitting.
+		useCanvasStore.getState().addElement("web_server", { x: 0, y: 0 });
+		// Simulate the user having panned and zoomed A on screen.
+		live = { x: 120, y: -40, zoom: 2 };
+
+		// Creating B switches away from A, flushing A's live viewport into A's own canvas store.
+		const b = registry.createDocument({
+			model: createTestModel("B"),
+			filePath: "/b.thf",
+			pendingLayout: null,
+		});
+		expect(registry.getDocumentStores(a)?.canvas.getState().viewport).toEqual({
+			x: 120,
+			y: -40,
+			zoom: 2,
+		});
+		// B has no nodes yet, so activation fits the view rather than pushing a viewport.
+		expect(rfFitView).toHaveBeenCalled();
+
+		// Work in B and simulate a distinct on-screen viewport for it.
+		useCanvasStore.getState().addElement("data_store", { x: 5, y: 5 });
+		live = { x: 7, y: 8, zoom: 3 };
+
+		// Returning to A flushes B's viewport and restores A's saved pan/zoom exactly.
+		registry.activateDocument(a);
+		expect(registry.getDocumentStores(b)?.canvas.getState().viewport).toEqual({
+			x: 7,
+			y: 8,
+			zoom: 3,
+		});
+		expect(rfSetViewport).toHaveBeenLastCalledWith({ x: 120, y: -40, zoom: 2 });
+	});
+
+	it("fits the view when returning to a document that has no laid-out nodes", () => {
+		const registry = useDocumentRegistry.getState();
+		const a = registry.createDocument({
+			model: createTestModel("A"),
+			filePath: null,
+			pendingLayout: null,
+		});
+		registry.createDocument({
+			model: createTestModel("B"),
+			filePath: null,
+			pendingLayout: null,
+		});
+
+		rfFitView.mockClear();
+		rfSetViewport.mockClear();
+		registry.activateDocument(a);
+
+		// A never received a node, so switching back fits rather than restoring a stored viewport.
+		expect(rfFitView).toHaveBeenCalledTimes(1);
+		expect(rfSetViewport).not.toHaveBeenCalled();
+	});
+
+	it("keeps workspace UI state across a document switch (negative control)", () => {
+		// Workspace-scoped UI state must survive a switch; only document state is per-document.
+		useUiStore.getState().setRightPanelTab("threats");
+
+		const registry = useDocumentRegistry.getState();
+		const a = registry.createDocument({
+			model: createTestModel("A"),
+			filePath: null,
+			pendingLayout: null,
+		});
+		registry.createDocument({
+			model: createTestModel("B"),
+			filePath: null,
+			pendingLayout: null,
+		});
+		registry.activateDocument(a);
+
+		expect(useUiStore.getState().rightPanelTab).toBe("threats");
+	});
+});
+
+describe("AI session references on document switch", () => {
+	function makeSession(id: string): ChatSession {
+		return { id, title: id, messages: [], createdAt: "t", updatedAt: "t" };
+	}
+
+	beforeEach(() => {
+		// Reset the workspace chat store so session state does not leak between tests.
+		useChatStore.setState({
+			sessions: [],
+			activeSessionId: null,
+			sessionKey: null,
+			messages: [],
+			isStreaming: false,
+			error: null,
+		});
+	});
+
+	it("remembers each document's active chat session and restores it on return", () => {
+		useChatStore.setState({
+			sessions: [makeSession("sess-a"), makeSession("sess-b")],
+			activeSessionId: "sess-a",
+			sessionKey: "threatforge-chat-sessions:unsaved",
+			messages: [],
+		});
+
+		const registry = useDocumentRegistry.getState();
+		const a = registry.createDocument({
+			model: createTestModel("A"),
+			filePath: null,
+			pendingLayout: null,
+		});
+		// Creating B switches away from A, recording A's active session reference.
+		const b = registry.createDocument({
+			model: createTestModel("B"),
+			filePath: null,
+			pendingLayout: null,
+		});
+		expect(useDocumentRegistry.getState().documents[a].activeChatSessionId).toBe("sess-a");
+
+		// The user selects a different session while B is active.
+		useChatStore.getState().switchSession("sess-b");
+		expect(useChatStore.getState().activeSessionId).toBe("sess-b");
+
+		// Returning to A records B's session and restores A's remembered one.
+		registry.activateDocument(a);
+		expect(useDocumentRegistry.getState().documents[b].activeChatSessionId).toBe("sess-b");
+		expect(useChatStore.getState().activeSessionId).toBe("sess-a");
+	});
+
+	it("does not restore a chat session that no longer exists", () => {
+		useChatStore.setState({
+			sessions: [makeSession("sess-x"), makeSession("sess-y")],
+			activeSessionId: "sess-x",
+			sessionKey: "threatforge-chat-sessions:unsaved",
+			messages: [],
+		});
+
+		const registry = useDocumentRegistry.getState();
+		const a = registry.createDocument({
+			model: createTestModel("A"),
+			filePath: null,
+			pendingLayout: null,
+		});
+		// Leaving A records its active session (sess-x).
+		registry.createDocument({
+			model: createTestModel("B"),
+			filePath: null,
+			pendingLayout: null,
+		});
+		// The user moves to sess-y in B and sess-x is later deleted from the workspace store.
+		useChatStore.getState().switchSession("sess-y");
+		useChatStore.setState({ sessions: [makeSession("sess-y")], activeSessionId: "sess-y" });
+
+		// Returning to A tries to restore sess-x, which no longer exists: switchSession no-ops
+		// and the active session is left as-is rather than cleared.
+		registry.activateDocument(a);
+		expect(useChatStore.getState().activeSessionId).toBe("sess-y");
 	});
 });

--- a/src/stores/document-registry.ts
+++ b/src/stores/document-registry.ts
@@ -2,6 +2,8 @@ import { create } from "zustand";
 import { createDocumentId } from "@/lib/document-id";
 import type { DocumentId, DocumentSession } from "@/types/document";
 import type { DiagramLayout, FileSettings, ThreatModel } from "@/types/threat-model";
+import { useCanvasInstanceStore } from "./canvas-instance-store";
+import { useChatStore } from "./chat-store";
 import { createDocumentStores, type DocumentStores, setActiveStores } from "./document-stores";
 
 /** Everything needed to seed a new document's bundle at creation time. */
@@ -86,10 +88,66 @@ export const useDocumentRegistry = create<DocumentRegistryState>((set, get) => (
 	},
 
 	activateDocument: (id) => {
-		const session = get().documents[id];
+		const state = get();
+		const session = state.documents[id];
 		if (!session) return;
+
+		const prevActiveId = state.activeDocumentId;
+		// A real switch moves between two live documents. Creation flows (New, Open, Import,
+		// template) reach here with `prevActiveId === null` because they close the previous
+		// document first, so their viewport/session behavior is left to the DfdCanvas mount
+		// and stays pixel-identical to the single-document path.
+		const isSwitch = prevActiveId !== null && prevActiveId !== id;
+		const instance = useCanvasInstanceStore.getState();
+		const chat = useChatStore.getState();
+
+		// Leaving a document cancels any in-flight AI stream so a response started under the
+		// outgoing document cannot append into the newly visible one. chat-store's abort clears
+		// `isStreaming` and drops later chunks; #53 owns only this call, not the chat internals.
+		chat.stopGenerating();
+
+		if (isSwitch) {
+			const outgoing = state.documents[prevActiveId];
+			if (outgoing) {
+				// Flush the live viewport into the outgoing document's own canvas store before the
+				// swap. onMoveEnd only fires at the end of a user gesture, so a programmatic zoom
+				// immediately before switching would otherwise be lost.
+				if (instance.rfGetViewport) {
+					outgoing.stores.canvas.setState({ viewport: instance.rfGetViewport() });
+				}
+				// Remember which AI session the outgoing document was on so returning restores it.
+				set((s) => {
+					const current = s.documents[prevActiveId];
+					if (!current) return s;
+					return {
+						documents: {
+							...s.documents,
+							[prevActiveId]: { ...current, activeChatSessionId: chat.activeSessionId },
+						},
+					};
+				});
+			}
+		}
+
 		set({ activeDocumentId: id });
 		setActiveStores(session.stores);
+
+		if (isSwitch) {
+			// Restore the incoming document's on-screen viewport. A document that has never been
+			// laid out (no nodes yet) keeps the existing fit-to-view behavior.
+			const incoming = session.stores.canvas.getState();
+			if (incoming.nodes.length > 0) {
+				instance.rfSetViewport?.(incoming.viewport);
+			} else {
+				instance.rfFitView?.();
+			}
+		}
+
+		// Restore the incoming document's last AI session when it still exists. switchSession
+		// no-ops for an unknown id, so this fails safe when that session was deleted.
+		if (session.activeChatSessionId) {
+			chat.switchSession(session.activeChatSessionId);
+		}
 	},
 
 	closeDocument: (id) => {

--- a/src/stores/settings-store.test.ts
+++ b/src/stores/settings-store.test.ts
@@ -7,7 +7,6 @@ describe("useSettingsStore", () => {
 		// Reset store to defaults before each test
 		useSettingsStore.setState({
 			settings: { ...DEFAULT_USER_SETTINGS },
-			fileSettings: null,
 			settingsDialogOpen: false,
 		});
 	});
@@ -66,45 +65,7 @@ describe("useSettingsStore", () => {
 		expect(useSettingsStore.getState().settings.keytipsVisible).toBe(true);
 	});
 
-	it("starts with null fileSettings", () => {
-		expect(useSettingsStore.getState().fileSettings).toBeNull();
-	});
-
-	it("loads file settings from model metadata", () => {
-		useSettingsStore.getState().loadFileSettings({
-			grid_size: 24,
-			default_element_fill: "#3b82f6",
-		});
-		const { fileSettings } = useSettingsStore.getState();
-		expect(fileSettings).not.toBeNull();
-		expect(fileSettings?.grid_size).toBe(24);
-		expect(fileSettings?.default_element_fill).toBe("#3b82f6");
-	});
-
-	it("clears file settings on closeModel", () => {
-		useSettingsStore.getState().loadFileSettings({ grid_size: 24 });
-		expect(useSettingsStore.getState().fileSettings).not.toBeNull();
-
-		useSettingsStore.getState().clearFileSettings();
-		expect(useSettingsStore.getState().fileSettings).toBeNull();
-	});
-
-	it("handles undefined file settings gracefully", () => {
-		useSettingsStore.getState().loadFileSettings(undefined);
-		expect(useSettingsStore.getState().fileSettings).toBeNull();
-	});
-
-	it("replaces previous file settings on new load", () => {
-		useSettingsStore.getState().loadFileSettings({ grid_size: 24 });
-		useSettingsStore.getState().loadFileSettings({
-			grid_size: 32,
-			default_boundary_fill: "#22c55e",
-		});
-
-		const { fileSettings } = useSettingsStore.getState();
-		expect(fileSettings?.grid_size).toBe(32);
-		expect(fileSettings?.default_boundary_fill).toBe("#22c55e");
-		// Previous field not in new load should be absent
-		expect(fileSettings?.default_element_fill).toBeUndefined();
-	});
+	// File-scoped settings (`fileSettings`) moved out of this workspace store and into the
+	// per-document session in #53 step 6. Their coverage now lives in
+	// `document-registry.test.ts` under "document-owned file settings".
 });

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -2,16 +2,12 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import type { UserSettings } from "@/types/settings";
 import { DEFAULT_USER_SETTINGS } from "@/types/settings";
-import type { FileSettings } from "@/types/threat-model";
 
 export type SettingsTab = "general" | "appearance" | "ai" | "updates" | "support";
 
 interface SettingsState {
 	/** User-level settings persisted to localStorage */
 	settings: UserSettings;
-
-	/** File-scoped settings loaded from the current threat model (not persisted to localStorage) */
-	fileSettings: FileSettings | null;
 
 	/** Whether the settings dialog is open */
 	settingsDialogOpen: boolean;
@@ -22,8 +18,6 @@ interface SettingsState {
 	// Actions
 	updateSetting: <K extends keyof UserSettings>(key: K, value: UserSettings[K]) => void;
 	resetToDefaults: () => void;
-	loadFileSettings: (fileSettings: FileSettings | undefined) => void;
-	clearFileSettings: () => void;
 	openSettingsDialog: () => void;
 	openSettingsDialogAtTab: (tab: SettingsTab) => void;
 	closeSettingsDialog: () => void;
@@ -33,7 +27,6 @@ export const useSettingsStore = create<SettingsState>()(
 	persist(
 		(set) => ({
 			settings: { ...DEFAULT_USER_SETTINGS },
-			fileSettings: null,
 			settingsDialogOpen: false,
 			settingsDialogInitialTab: null,
 
@@ -43,10 +36,6 @@ export const useSettingsStore = create<SettingsState>()(
 				})),
 
 			resetToDefaults: () => set({ settings: { ...DEFAULT_USER_SETTINGS } }),
-
-			loadFileSettings: (fileSettings) => set({ fileSettings: fileSettings ?? null }),
-
-			clearFileSettings: () => set({ fileSettings: null }),
 
 			openSettingsDialog: () => set({ settingsDialogOpen: true, settingsDialogInitialTab: null }),
 			openSettingsDialogAtTab: (tab) =>


### PR DESCRIPTION
Implements **steps 6–8** of the committed plan for #53, on top of the registry core from #122.

Refs #53. Does not close it — step 9 (the full ten-case isolation suite) and step 10 (docs) are the final PR.

## Step 6 — fileSettings ownership moves to the document session

`fileSettings`, `loadFileSettings`, and `clearFileSettings` leave the settings store; the session copy `createDocument` already seeded becomes authoritative, and `saveModel`/`saveModelAs` sync it after a save rewrites metadata. Workspace-level preferences (theme, autosave, author, grid) stay put.

The plan said "delete the five call sites" — there were **six** (its own evidence table listed six writers). All six removed.

## Step 7 — activation restores the visible canvas

On a real switch, `activateDocument` flushes the outgoing document's live viewport into its own canvas store **before** the bundle swap, then restores the incoming viewport (or fits when the document has no laid-out nodes). Creation flows arrive with no previous document and take no viewport action — the single-document mount/pending-layout path is pixel-identical.

**Deviation from the plan, disclosed:** the plan placed the restore in a `DfdCanvas` `requestAnimationFrame` effect. It is implemented in `activateDocument` via workspace-scoped viewport handles instead — one owner for the whole swap sequence, deterministically testable without stubbing a ReactFlow render. The plan itself sanctioned "an equivalent hook-level test if stubbing ReactFlow proves brittle"; that is the route taken. `DfdCanvas` only gained handle registration.

## Step 8 — AI stream isolation on switch

`activateDocument` aborts any in-flight stream (leaving `isStreaming === false` with post-abort chunks dropped — the exact contract the #61 plan asked this work to preserve), records the outgoing document's chat session id, restores the incoming one, and no-ops on unknown ids. `chat-store.ts` was **not modified** — the #61 seam stays clean.

**Known limitation, carried to #63 explicitly:** `ai-chat-tab`'s session-loading effect re-derives the active session from the `filePath`-keyed store and can override the registry's restore. Full per-document conversation restore is #63's re-keying work; the registry-level contract (record + fail-safe restore) is what ships and is what the tests prove.

## Tests

New coverage: fileSettings isolation across two documents, viewport flush/restore with the workspace-UI negative control, chat session remember/restore + unknown-id fail-safe, and a component test proving an in-flight stream aborted by a switch leaves no post-abort chunk in the transcript.

The five settings-store fileSettings tests **moved** with the behavior into the registry suite — mapping documented in the PR-linked report, none deleted.

## Verification

```
npx tsc --noEmit             exit 0
npx biome check src/         exit 0 (1 pre-existing warning)
npx vitest run               50 files / 601 tests passed
bash scripts/ci-local.sh     All checks passed
npx playwright test          46 passed
```

## Owner validation

- Confirm the step-7 relocation (registry-owned restore vs canvas-effect restore) — it is a deliberate architectural simplification over the plan's sketch.
- Confirm the step-8 limitation note: session *references* restore now; content restore is #63. If you want the tab's effect override closed sooner, say so and it becomes a small linked issue instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
