### PR TITLE
feat(ai): add the shared SSE decoder and provider stream mappers

### DIFF
--- a/src/lib/ai/protocol/errors.test.ts
+++ b/src/lib/ai/protocol/errors.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { redactProviderDetail } from "./errors";
+
+describe("redactProviderDetail", () => {
+	it("masks every key-shaped token, whichever prefix family it uses", () => {
+		const redacted = redactProviderDetail(
+			"Incorrect API key provided: sk-abc123DEF. Related keys sk-ant-xyz_789 and sk-proj-QQ-11.",
+		);
+		expect(redacted).toBe(
+			"Incorrect API key provided: [redacted-key]. Related keys [redacted-key] and [redacted-key].",
+		);
+	});
+
+	it("leaves short clean provider text untouched", () => {
+		expect(redactProviderDetail("overloaded_error: Overloaded")).toBe(
+			"overloaded_error: Overloaded",
+		);
+	});
+
+	it("masks key tokens whose casing a proxy or log formatter changed", () => {
+		expect(redactProviderDetail("Bad key SK-ABC123 and Sk-Ant-Xyz")).toBe(
+			"Bad key [redacted-key] and [redacted-key]",
+		);
+	});
+
+	it("does not mask hyphenated words that merely end in sk-", () => {
+		expect(redactProviderDetail("task-123 failed on desk-check")).toBe(
+			"task-123 failed on desk-check",
+		);
+	});
+
+	it("caps the detail at 200 characters and marks the cut", () => {
+		const redacted = redactProviderDetail("x".repeat(500));
+		expect(redacted).toHaveLength(201);
+		expect(redacted).toBe(`${"x".repeat(200)}…`);
+	});
+
+	it("masks before truncating so a cut cannot leave a recognizable key prefix", () => {
+		// The key starts just before the cap: truncating first would leave "sk-"
+		// and the opening of the key visible; masking first cannot.
+		const redacted = redactProviderDetail(`${"x".repeat(196)} sk-secret123456789`);
+		expect(redacted).not.toContain("sk-");
+		expect(redacted).toBe(`${"x".repeat(196)} [re…`);
+	});
+
+	it("never cuts inside a surrogate pair at the cap", () => {
+		// "😀" is one astral code point, two UTF-16 units; 199 x's put the cap
+		// boundary between them. A naive slice would keep a lone high surrogate.
+		const redacted = redactProviderDetail(`${"x".repeat(199)}😀${"y".repeat(50)}`);
+		expect(redacted).toBe(`${"x".repeat(199)}…`);
+		// No lone high surrogate survives anywhere in the result.
+		expect(/[\ud800-\udbff](?![\udc00-\udfff])/u.test(redacted)).toBe(false);
+	});
+});

--- a/src/lib/ai/protocol/errors.ts
+++ b/src/lib/ai/protocol/errors.ts
@@ -48,6 +48,38 @@ export interface ProtocolError {
 	providerDetail?: string;
 }
 
+/** Longest provider-supplied detail retained after redaction. */
+const PROVIDER_DETAIL_MAX_LENGTH = 200;
+
+/**
+ * Provider key tokens (`sk-...`, `sk-ant-...`, `sk-proj-...`). An OpenAI 401
+ * body echoes the submitted key back in its `message` field, so provider text
+ * must be assumed to contain key material until proven otherwise. The match is
+ * case-insensitive: real keys are lowercase, but a proxy or log formatter
+ * between here and the provider may not preserve casing.
+ */
+const KEY_TOKEN_PATTERN = /\bsk-[A-Za-z0-9_-]+/gi;
+
+/**
+ * Make provider-supplied text safe to carry as `providerDetail`.
+ *
+ * Key-shaped tokens are masked before truncation so a cut cannot leave a
+ * recognizable key prefix behind, and the result is length-capped so a provider
+ * cannot flood the UI or persisted error state. The desktop relay (issue #61
+ * step 8) must apply the same rule, in the same mask-then-truncate order, in
+ * Rust before frames cross the IPC boundary.
+ */
+export function redactProviderDetail(detail: string): string {
+	const masked = detail.replace(KEY_TOKEN_PATTERN, "[redacted-key]");
+	if (masked.length <= PROVIDER_DETAIL_MAX_LENGTH) return masked;
+	let end = PROVIDER_DETAIL_MAX_LENGTH;
+	const lastKeptCode = masked.charCodeAt(end - 1);
+	// Never cut inside a surrogate pair: the detail is documented as safe to
+	// persist and serialize, and a lone high surrogate is neither.
+	if (lastKeptCode >= 0xd800 && lastKeptCode <= 0xdbff) end -= 1;
+	return `${masked.slice(0, end)}…`;
+}
+
 /**
  * A thrown carrier for a {@link ProtocolError}.
  *

--- a/src/lib/ai/protocol/events.ts
+++ b/src/lib/ai/protocol/events.ts
@@ -82,7 +82,22 @@ export interface MessageStopEvent {
 	stopReason: StopReason;
 }
 
-/** The turn failed. Terminal. */
+/**
+ * A failure was detected. The terminality rule is exact: a `malformed_stream`
+ * error emitted by a mapper is a non-terminal notice scoped to the one piece
+ * of the stream it reports — an undecodable frame, an orphan argument
+ * fragment, or a dropped tool call — and the mapper keeps mapping the frames
+ * that follow. An error with any other code reports the turn itself and is
+ * terminal; provider-reported failures (`http_status`, `rate_limited`) end
+ * the turn because the provider closes the stream after sending them. A
+ * client must not treat a `malformed_stream` notice as the end of the turn
+ * (issue #61 step 6).
+ *
+ * A *thrown* `malformed_stream` `ProtocolException` — the SSE decoder's
+ * buffer-cap breach is one — is terminal on that channel and must not be
+ * re-emitted as a stream notice: the non-terminal reading above applies only
+ * to events a mapper emitted.
+ */
 export interface ErrorEvent {
 	type: "error";
 	error: ProtocolError;

--- a/src/lib/ai/protocol/request.ts
+++ b/src/lib/ai/protocol/request.ts
@@ -9,8 +9,28 @@
 
 import { type CapabilityResolution, resolveCapabilities } from "@/lib/ai-models";
 import { ProtocolException } from "./errors";
-import type { AiProvider } from "./messages";
-import type { ToolDescriptor } from "./tools";
+import type { AiProvider, ProtocolMessage } from "./messages";
+import type { AdvertisedTool, ToolDescriptor } from "./tools";
+
+/**
+ * Everything a provider mapper needs to build one streaming chat request.
+ *
+ * Provider-neutral by construction: the Anthropic and OpenAI request builders
+ * (`src/lib/ai/providers/`) each translate this one shape into their wire
+ * format, so nothing else in the stack assembles a provider-specific body. The
+ * system prompt is a separate field because the providers place it differently
+ * (a top-level `system` field versus a `system` message).
+ */
+export interface ProviderChatRequest {
+	modelId: string;
+	/** The composed system prompt for this turn. */
+	system: string;
+	messages: readonly ProtocolMessage[];
+	/** Tools advertised this turn. Empty means no tool fields are sent at all. */
+	tools: readonly AdvertisedTool[];
+	/** Cap on the model's answer, the same tokens the budgeter reserves. */
+	maxOutputTokens: number;
+}
 
 /** The parts of a chat request preflight needs to judge it. */
 export interface PreflightRequest {

--- a/src/lib/ai/protocol/tools.ts
+++ b/src/lib/ai/protocol/tools.ts
@@ -50,6 +50,18 @@ export interface ToolDescriptor {
 	readonly description: string;
 }
 
+/**
+ * A tool as advertised to a provider: identity plus the generated input schema.
+ *
+ * The provider mappers (`src/lib/ai/providers/`) consume this instead of
+ * `ToolDefinition` so a heterogeneous tool list can be advertised without the
+ * generic input shape, which only `parseInput` callers need. Every
+ * `ToolDefinition` satisfies it.
+ */
+export interface AdvertisedTool extends ToolDescriptor {
+	jsonSchema(): ToolInputJsonSchema;
+}
+
 export interface ToolDefinition<Shape extends z.ZodRawShape> extends ToolDescriptor {
 	/**
 	 * Exposed so related tools can be combined — the legacy action registry

--- a/src/lib/ai/providers/anthropic.test.ts
+++ b/src/lib/ai/providers/anthropic.test.ts
@@ -1,0 +1,425 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import type { StreamEvent } from "@/lib/ai/protocol/events";
+import type { ProtocolMessage } from "@/lib/ai/protocol/messages";
+import type { ProviderChatRequest } from "@/lib/ai/protocol/request";
+import { defineTool } from "@/lib/ai/protocol/tools";
+import {
+	type AnthropicStreamMapper,
+	buildAnthropicRequestBody,
+	createAnthropicStreamMapper,
+} from "./anthropic";
+import type { SseFrame } from "./sse";
+
+const addNoteTool = defineTool({
+	name: "add_note",
+	description: "Attach a note to the model.",
+	input: { text: z.string() },
+});
+
+const baseRequest: ProviderChatRequest = {
+	modelId: "claude-sonnet-4-20250514",
+	system: "You are a threat modeling assistant.",
+	messages: [{ role: "user", content: [{ type: "text", text: "Review the gateway." }] }],
+	tools: [],
+	maxOutputTokens: 4096,
+};
+
+/** Author one frame the way the decoder would deliver it. */
+function frame(event: string, payload: unknown): SseFrame {
+	return { event, data: JSON.stringify(payload) };
+}
+
+function mapAll(mapper: AnthropicStreamMapper, frames: SseFrame[]): StreamEvent[] {
+	const events: StreamEvent[] = [];
+	for (const f of frames) {
+		events.push(...mapper.mapFrame(f));
+	}
+	return events;
+}
+
+describe("buildAnthropicRequestBody", () => {
+	it("places the system prompt as a top-level field with streaming enabled", () => {
+		const body = buildAnthropicRequestBody(baseRequest);
+		expect(body.model).toBe("claude-sonnet-4-20250514");
+		expect(body.system).toBe("You are a threat modeling assistant.");
+		expect(body.max_tokens).toBe(4096);
+		expect(body.stream).toBe(true);
+		expect(body.messages).toEqual([
+			{ role: "user", content: [{ type: "text", text: "Review the gateway." }] },
+		]);
+	});
+
+	it("serializes tool calls and tool results as Anthropic content blocks", () => {
+		const messages: ProtocolMessage[] = [
+			{ role: "user", content: [{ type: "text", text: "Add a note." }] },
+			{
+				role: "assistant",
+				content: [
+					{ type: "text", text: "Adding it." },
+					{ type: "tool_call", id: "call_1", name: "add_note", input: { text: "hi" } },
+				],
+			},
+			{
+				role: "user",
+				content: [{ type: "tool_result", toolCallId: "call_1", content: "ok" }],
+			},
+		];
+		const body = buildAnthropicRequestBody({ ...baseRequest, messages });
+		expect(body.messages[1]).toEqual({
+			role: "assistant",
+			content: [
+				{ type: "text", text: "Adding it." },
+				{ type: "tool_use", id: "call_1", name: "add_note", input: { text: "hi" } },
+			],
+		});
+		// Anthropic's shape: the result is a tool_result block inside a user message.
+		expect(body.messages[2]).toEqual({
+			role: "user",
+			content: [{ type: "tool_result", tool_use_id: "call_1", content: "ok" }],
+		});
+		// is_error is omitted, not serialized as false, when the result succeeded.
+		expect(body.messages[2].content[0]).not.toHaveProperty("is_error");
+	});
+
+	it("carries is_error through for failed tool results", () => {
+		const body = buildAnthropicRequestBody({
+			...baseRequest,
+			messages: [
+				{
+					role: "user",
+					content: [{ type: "tool_result", toolCallId: "call_1", content: "boom", isError: true }],
+				},
+			],
+		});
+		expect(body.messages[0].content[0]).toEqual({
+			type: "tool_result",
+			tool_use_id: "call_1",
+			content: "boom",
+			is_error: true,
+		});
+	});
+
+	it("advertises tools with their generated input_schema and omits the field when empty", () => {
+		const withTools = buildAnthropicRequestBody({ ...baseRequest, tools: [addNoteTool] });
+		expect(withTools.tools).toEqual([
+			{
+				name: "add_note",
+				description: "Attach a note to the model.",
+				input_schema: addNoteTool.jsonSchema(),
+			},
+		]);
+
+		const withoutTools = buildAnthropicRequestBody(baseRequest);
+		expect(withoutTools).not.toHaveProperty("tools");
+	});
+});
+
+describe("createAnthropicStreamMapper", () => {
+	it("maps message_start to the echoed model", () => {
+		const mapper = createAnthropicStreamMapper();
+		const events = mapper.mapFrame(
+			frame("message_start", {
+				type: "message_start",
+				message: { model: "claude-sonnet-4-20250514", usage: { input_tokens: 42 } },
+			}),
+		);
+		expect(events).toEqual([{ type: "message_start", model: "claude-sonnet-4-20250514" }]);
+	});
+
+	it("maps text content blocks to text deltas and emits nothing for the empty opener", () => {
+		const mapper = createAnthropicStreamMapper();
+		expect(
+			mapper.mapFrame(
+				frame("content_block_start", { index: 0, content_block: { type: "text", text: "" } }),
+			),
+		).toEqual([]);
+		expect(
+			mapper.mapFrame(
+				frame("content_block_delta", { index: 0, delta: { type: "text_delta", text: "Hello" } }),
+			),
+		).toEqual([{ type: "text_delta", text: "Hello" }]);
+		expect(mapper.mapFrame(frame("content_block_stop", { index: 0 }))).toEqual([]);
+	});
+
+	it("maps a tool_use block through start, input deltas, and completion", () => {
+		const mapper = createAnthropicStreamMapper();
+		expect(
+			mapper.mapFrame(
+				frame("content_block_start", {
+					index: 1,
+					content_block: { type: "tool_use", id: "call_1", name: "add_note", input: {} },
+				}),
+			),
+		).toEqual([{ type: "tool_call_start", id: "call_1", name: "add_note" }]);
+		expect(
+			mapper.mapFrame(
+				frame("content_block_delta", {
+					index: 1,
+					delta: { type: "input_json_delta", partial_json: '{"text":"h' },
+				}),
+			),
+		).toEqual([{ type: "tool_call_input_delta", id: "call_1", partialJson: '{"text":"h' }]);
+		expect(
+			mapper.mapFrame(
+				frame("content_block_delta", {
+					index: 1,
+					delta: { type: "input_json_delta", partial_json: 'i"}' },
+				}),
+			),
+		).toEqual([{ type: "tool_call_input_delta", id: "call_1", partialJson: 'i"}' }]);
+		// The accumulated fragments are parsed exactly once, at content_block_stop.
+		expect(mapper.mapFrame(frame("content_block_stop", { index: 1 }))).toEqual([
+			{ type: "tool_call_complete", id: "call_1", name: "add_note", input: { text: "hi" } },
+		]);
+	});
+
+	it("completes a tool call that streamed no fragments with the empty input", () => {
+		const mapper = createAnthropicStreamMapper();
+		mapper.mapFrame(
+			frame("content_block_start", {
+				index: 0,
+				content_block: { type: "tool_use", id: "call_1", name: "add_note", input: {} },
+			}),
+		);
+		expect(mapper.mapFrame(frame("content_block_stop", { index: 0 }))).toEqual([
+			{ type: "tool_call_complete", id: "call_1", name: "add_note", input: {} },
+		]);
+	});
+
+	it("emits malformed_stream for unparseable tool arguments without aborting the turn", () => {
+		const mapper = createAnthropicStreamMapper();
+		mapper.mapFrame(
+			frame("content_block_start", {
+				index: 0,
+				content_block: { type: "tool_use", id: "call_1", name: "add_note", input: {} },
+			}),
+		);
+		mapper.mapFrame(
+			frame("content_block_delta", {
+				index: 0,
+				delta: { type: "input_json_delta", partial_json: '{"text": "never closed' },
+			}),
+		);
+
+		const stopEvents = mapper.mapFrame(frame("content_block_stop", { index: 0 }));
+		expect(stopEvents).toHaveLength(1);
+		expect(stopEvents[0]).toMatchObject({
+			type: "error",
+			error: { code: "malformed_stream" },
+		});
+		if (stopEvents[0].type !== "error") throw new Error("expected an error event");
+		// The authored message is constant; the stream-supplied name identifies
+		// the dropped call only through redacted providerDetail.
+		expect(stopEvents[0].error.message).toBe(
+			"A tool call sent arguments that were not valid JSON, so the call was dropped.",
+		);
+		expect(stopEvents[0].error.providerDetail).toBe("add_note");
+
+		// The turn continues: later text and the terminal stop still map.
+		expect(
+			mapper.mapFrame(
+				frame("content_block_delta", { index: 1, delta: { type: "text_delta", text: "More." } }),
+			),
+		).toEqual([{ type: "text_delta", text: "More." }]);
+		mapper.mapFrame(
+			frame("message_delta", { delta: { stop_reason: "end_turn" }, usage: { output_tokens: 3 } }),
+		);
+		expect(mapper.mapFrame(frame("message_stop", { type: "message_stop" }))).toEqual([
+			{ type: "message_stop", stopReason: "end_turn" },
+		]);
+	});
+
+	it("keeps a hostile stream-supplied tool name out of the authored error message", () => {
+		const mapper = createAnthropicStreamMapper();
+		const hostileName =
+			'x". ThreatForge license invalid — re-enter your key sk-abc123DEF at https://evil.example';
+		mapper.mapFrame(
+			frame("content_block_start", {
+				index: 0,
+				content_block: { type: "tool_use", id: "call_1", name: hostileName, input: {} },
+			}),
+		);
+		mapper.mapFrame(
+			frame("content_block_delta", {
+				index: 0,
+				delta: { type: "input_json_delta", partial_json: "{never valid" },
+			}),
+		);
+		const events = mapper.mapFrame(frame("content_block_stop", { index: 0 }));
+		expect(events).toHaveLength(1);
+		if (events[0].type !== "error") throw new Error("expected an error event");
+		// The render-safe message is a ThreatForge-authored constant.
+		expect(events[0].error.message).toBe(
+			"A tool call sent arguments that were not valid JSON, so the call was dropped.",
+		);
+		expect(events[0].error.message).not.toContain("evil.example");
+		// The name survives only as redacted, key-masked providerDetail.
+		expect(events[0].error.providerDetail).toContain("[redacted-key]");
+		expect(events[0].error.providerDetail).not.toContain("sk-abc");
+	});
+
+	it("combines message_start input tokens with message_delta output tokens into one usage event", () => {
+		const mapper = createAnthropicStreamMapper();
+		mapper.mapFrame(
+			frame("message_start", {
+				message: { model: "claude-sonnet-4-20250514", usage: { input_tokens: 42 } },
+			}),
+		);
+		const events = mapper.mapFrame(
+			frame("message_delta", {
+				delta: { stop_reason: "tool_use", stop_sequence: null },
+				usage: { output_tokens: 17 },
+			}),
+		);
+		expect(events).toEqual([{ type: "usage", usage: { inputTokens: 42, outputTokens: 17 } }]);
+	});
+
+	it.each([
+		["end_turn", "end_turn"],
+		["tool_use", "tool_use"],
+		["max_tokens", "max_tokens"],
+		["stop_sequence", "stop_sequence"],
+		["pause_turn", "unknown"],
+	] as const)("maps stop reason %s to %s on message_stop", (raw, mapped) => {
+		const mapper = createAnthropicStreamMapper();
+		mapper.mapFrame(frame("message_delta", { delta: { stop_reason: raw }, usage: null }));
+		expect(mapper.mapFrame(frame("message_stop", { type: "message_stop" }))).toEqual([
+			{ type: "message_stop", stopReason: mapped },
+		]);
+	});
+
+	it("reports unknown when the stream never named a stop reason", () => {
+		const mapper = createAnthropicStreamMapper();
+		expect(mapper.mapFrame(frame("message_stop", { type: "message_stop" }))).toEqual([
+			{ type: "message_stop", stopReason: "unknown" },
+		]);
+	});
+
+	it("maps a rate_limit_error stream error to rate_limited with redacted detail", () => {
+		const mapper = createAnthropicStreamMapper();
+		const events = mapper.mapFrame(
+			frame("error", {
+				type: "error",
+				error: { type: "rate_limit_error", message: "Limit hit for key sk-ant-abc123DEF456" },
+			}),
+		);
+		expect(events).toHaveLength(1);
+		if (events[0].type !== "error") throw new Error("expected an error event");
+		expect(events[0].error.code).toBe("rate_limited");
+		// The primary message is authored by ThreatForge, never provider text.
+		expect(events[0].error.message).toBe(
+			"Anthropic rate limit or quota exceeded — wait and try again.",
+		);
+		expect(events[0].error.providerDetail).toContain("[redacted-key]");
+		expect(events[0].error.providerDetail).not.toContain("sk-ant");
+		expect(events[0].error.providerDetail).not.toContain("abc123DEF456");
+	});
+
+	it("maps other provider stream errors to http_status", () => {
+		const mapper = createAnthropicStreamMapper();
+		const events = mapper.mapFrame(
+			frame("error", { type: "error", error: { type: "overloaded_error", message: "Overloaded" } }),
+		);
+		expect(events).toMatchObject([
+			{
+				type: "error",
+				error: { code: "http_status", providerDetail: "overloaded_error: Overloaded" },
+			},
+		]);
+	});
+
+	it("emits malformed_stream for invalid JSON on a known event type", () => {
+		const mapper = createAnthropicStreamMapper();
+		const events = mapper.mapFrame({ event: "content_block_delta", data: '{"index": 0, "de' });
+		expect(events).toMatchObject([{ type: "error", error: { code: "malformed_stream" } }]);
+	});
+
+	it("emits malformed_stream for an input fragment whose tool call never started", () => {
+		const mapper = createAnthropicStreamMapper();
+		const events = mapper.mapFrame(
+			frame("content_block_delta", {
+				index: 5,
+				delta: { type: "input_json_delta", partial_json: '{"a":1}' },
+			}),
+		);
+		expect(events).toMatchObject([{ type: "error", error: { code: "malformed_stream" } }]);
+	});
+
+	it("ignores ping and unknown event types", () => {
+		const mapper = createAnthropicStreamMapper();
+		expect(mapper.mapFrame(frame("ping", { type: "ping" }))).toEqual([]);
+		expect(mapper.mapFrame(frame("content_block_flourish", { anything: true }))).toEqual([]);
+	});
+
+	it("ignores unknown delta types inside content_block_delta", () => {
+		const mapper = createAnthropicStreamMapper();
+		const events = mapper.mapFrame(
+			frame("content_block_delta", {
+				index: 0,
+				delta: { type: "thinking_delta", thinking: "hmm" },
+			}),
+		);
+		expect(events).toEqual([]);
+	});
+
+	it("keeps two interleaved tool_use blocks separate by content-block index", () => {
+		const mapper = createAnthropicStreamMapper();
+		mapper.mapFrame(
+			frame("content_block_start", {
+				index: 0,
+				content_block: { type: "tool_use", id: "call_a", name: "add_note", input: {} },
+			}),
+		);
+		mapper.mapFrame(
+			frame("content_block_start", {
+				index: 1,
+				content_block: { type: "tool_use", id: "call_b", name: "add_note", input: {} },
+			}),
+		);
+		mapper.mapFrame(
+			frame("content_block_delta", {
+				index: 1,
+				delta: { type: "input_json_delta", partial_json: '{"text":"b"}' },
+			}),
+		);
+		mapper.mapFrame(
+			frame("content_block_delta", {
+				index: 0,
+				delta: { type: "input_json_delta", partial_json: '{"text":"a"}' },
+			}),
+		);
+		expect(mapper.mapFrame(frame("content_block_stop", { index: 0 }))).toEqual([
+			{ type: "tool_call_complete", id: "call_a", name: "add_note", input: { text: "a" } },
+		]);
+		expect(mapper.mapFrame(frame("content_block_stop", { index: 1 }))).toEqual([
+			{ type: "tool_call_complete", id: "call_b", name: "add_note", input: { text: "b" } },
+		]);
+	});
+});
+
+describe("full transcript", () => {
+	it("maps a complete documented event sequence in order", () => {
+		const mapper = createAnthropicStreamMapper();
+		const events = mapAll(mapper, [
+			frame("message_start", {
+				type: "message_start",
+				message: { model: "claude-sonnet-4-20250514", usage: { input_tokens: 10 } },
+			}),
+			frame("content_block_start", { index: 0, content_block: { type: "text", text: "" } }),
+			frame("content_block_delta", { index: 0, delta: { type: "text_delta", text: "Done. " } }),
+			frame("content_block_stop", { index: 0 }),
+			frame("message_delta", {
+				delta: { stop_reason: "end_turn", stop_sequence: null },
+				usage: { output_tokens: 4 },
+			}),
+			frame("message_stop", { type: "message_stop" }),
+		]);
+		expect(events).toEqual([
+			{ type: "message_start", model: "claude-sonnet-4-20250514" },
+			{ type: "text_delta", text: "Done. " },
+			{ type: "usage", usage: { inputTokens: 10, outputTokens: 4 } },
+			{ type: "message_stop", stopReason: "end_turn" },
+		]);
+	});
+});

--- a/src/lib/ai/providers/anthropic.ts
+++ b/src/lib/ai/providers/anthropic.ts
@@ -1,0 +1,350 @@
+/**
+ * Anthropic Messages API mapper: request building and stream-event decoding.
+ *
+ * This module and `./openai.ts` are the only places Anthropic's wire shapes may
+ * appear; everything downstream speaks the protocol types in
+ * `src/lib/ai/protocol/`. Two logically identical responses from the two
+ * providers must map to identical `StreamEvent` sequences — the cross-provider
+ * equality test in `./openai.test.ts` is the proof.
+ *
+ * Tool results serialize as `tool_result` blocks inside a `user` message,
+ * which is Anthropic's shape; OpenAI's `role: "tool"` divergence lives wholly
+ * in `./openai.ts`.
+ */
+
+import { z } from "zod";
+import { type ProtocolError, redactProviderDetail } from "@/lib/ai/protocol/errors";
+import type { StopReason, StreamEvent } from "@/lib/ai/protocol/events";
+import type { ContentBlock } from "@/lib/ai/protocol/messages";
+import type { ProviderChatRequest } from "@/lib/ai/protocol/request";
+import type { ToolInputJsonSchema } from "@/lib/ai/protocol/tools";
+import { finishPendingToolCall, malformedStreamError, type PendingToolCall } from "./mapper-events";
+import type { SseFrame } from "./sse";
+
+// ---------------------------------------------------------------------------
+// Request building
+// ---------------------------------------------------------------------------
+
+interface AnthropicTextBlock {
+	type: "text";
+	text: string;
+}
+
+interface AnthropicToolUseBlock {
+	type: "tool_use";
+	id: string;
+	name: string;
+	input: unknown;
+}
+
+interface AnthropicToolResultBlock {
+	type: "tool_result";
+	tool_use_id: string;
+	content: string;
+	is_error?: boolean;
+}
+
+type AnthropicContentBlock = AnthropicTextBlock | AnthropicToolUseBlock | AnthropicToolResultBlock;
+
+interface AnthropicRequestMessage {
+	role: "user" | "assistant";
+	content: AnthropicContentBlock[];
+}
+
+interface AnthropicToolPayload {
+	name: string;
+	description: string;
+	input_schema: ToolInputJsonSchema;
+}
+
+/** The body posted to `POST /v1/messages`. */
+export interface AnthropicRequestBody {
+	model: string;
+	max_tokens: number;
+	system: string;
+	messages: AnthropicRequestMessage[];
+	stream: true;
+	tools?: AnthropicToolPayload[];
+}
+
+/**
+ * Protocol blocks map one-to-one onto Anthropic blocks regardless of role:
+ * tool results already live inside `user` messages in the protocol model.
+ */
+function toAnthropicBlock(block: ContentBlock): AnthropicContentBlock {
+	switch (block.type) {
+		case "text":
+			return { type: "text", text: block.text };
+		case "tool_call":
+			return { type: "tool_use", id: block.id, name: block.name, input: block.input };
+		case "tool_result":
+			return {
+				type: "tool_result",
+				tool_use_id: block.toolCallId,
+				content: block.content,
+				...(block.isError === undefined ? {} : { is_error: block.isError }),
+			};
+	}
+}
+
+/**
+ * Build the streaming request body for the Anthropic Messages API.
+ *
+ * Tool-call/result pairing and block placement are the caller's contract,
+ * enforced upstream by `assertToolPairing` and the budgeter; a history that
+ * violates them serializes to whatever the provider makes of it. Only
+ * contract-conforming histories are guaranteed to serialize equivalently
+ * across the two builders.
+ */
+export function buildAnthropicRequestBody(request: ProviderChatRequest): AnthropicRequestBody {
+	const body: AnthropicRequestBody = {
+		model: request.modelId,
+		max_tokens: request.maxOutputTokens,
+		system: request.system,
+		messages: request.messages.map((message) => ({
+			role: message.role,
+			content: message.content.map(toAnthropicBlock),
+		})),
+		stream: true,
+	};
+	if (request.tools.length > 0) {
+		body.tools = request.tools.map((tool) => ({
+			name: tool.name,
+			description: tool.description,
+			input_schema: tool.jsonSchema(),
+		}));
+	}
+	return body;
+}
+
+// ---------------------------------------------------------------------------
+// Stream mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Frame payload schemas. Deliberately lenient: only the fields this mapper
+ * reads are declared, unknown keys are stripped, and unknown block or delta
+ * types fall through to "ignore" — Anthropic documents that clients must
+ * tolerate event shapes added after a client was written.
+ */
+const usageSchema = z.object({
+	input_tokens: z.number().nullish(),
+	output_tokens: z.number().nullish(),
+});
+
+const messageStartSchema = z.object({
+	message: z.object({
+		model: z.string(),
+		usage: usageSchema.nullish(),
+	}),
+});
+
+const contentBlockStartSchema = z.object({
+	index: z.number().int(),
+	content_block: z.object({
+		type: z.string(),
+		id: z.string().optional(),
+		name: z.string().optional(),
+		text: z.string().optional(),
+	}),
+});
+
+const contentBlockDeltaSchema = z.object({
+	index: z.number().int(),
+	delta: z.object({
+		type: z.string(),
+		text: z.string().optional(),
+		partial_json: z.string().optional(),
+	}),
+});
+
+const contentBlockStopSchema = z.object({
+	index: z.number().int(),
+});
+
+const messageDeltaSchema = z.object({
+	delta: z.object({ stop_reason: z.string().nullish() }).nullish(),
+	usage: usageSchema.nullish(),
+});
+
+const errorEventSchema = z.object({
+	error: z
+		.object({
+			type: z.string().nullish(),
+			message: z.string().nullish(),
+		})
+		.nullish(),
+});
+
+const STOP_REASONS = new Map<string, StopReason>([
+	["end_turn", "end_turn"],
+	["tool_use", "tool_use"],
+	["max_tokens", "max_tokens"],
+	["stop_sequence", "stop_sequence"],
+]);
+
+function mapStopReason(raw: string): StopReason {
+	return STOP_REASONS.get(raw) ?? "unknown";
+}
+
+/**
+ * JSON-parse a frame payload and validate the fields this mapper reads.
+ * `undefined` means the frame could not be decoded as its event type claims.
+ */
+function decodePayload<Schema extends z.ZodType>(
+	schema: Schema,
+	data: string,
+): z.infer<Schema> | undefined {
+	let payload: unknown;
+	try {
+		payload = JSON.parse(data);
+	} catch {
+		return undefined;
+	}
+	const parsed = schema.safeParse(payload);
+	return parsed.success ? parsed.data : undefined;
+}
+
+export interface AnthropicStreamMapper {
+	/** Map one decoded frame onto zero or more protocol events. */
+	mapFrame(frame: SseFrame): StreamEvent[];
+}
+
+/** Create a mapper holding the per-turn state of one Anthropic stream. */
+export function createAnthropicStreamMapper(): AnthropicStreamMapper {
+	/** `tool_use` blocks in flight, keyed by their content-block index. */
+	const pendingToolCalls = new Map<number, PendingToolCall>();
+	/** Input tokens arrive on `message_start`; the usage event fires later. */
+	let reportedInputTokens = 0;
+	let stopReason: StopReason | undefined;
+
+	function undecodableFrame(event: string, data: string): StreamEvent[] {
+		return malformedStreamError(
+			`The Anthropic stream sent a "${event}" event that could not be decoded.`,
+			data,
+		);
+	}
+
+	return {
+		mapFrame(frame: SseFrame): StreamEvent[] {
+			switch (frame.event) {
+				case "message_start": {
+					const payload = decodePayload(messageStartSchema, frame.data);
+					if (payload === undefined) return undecodableFrame(frame.event, frame.data);
+					reportedInputTokens = payload.message.usage?.input_tokens ?? 0;
+					return [{ type: "message_start", model: payload.message.model }];
+				}
+
+				case "content_block_start": {
+					const payload = decodePayload(contentBlockStartSchema, frame.data);
+					if (payload === undefined) return undecodableFrame(frame.event, frame.data);
+					const { index, content_block: block } = payload;
+					if (block.type === "tool_use") {
+						if (block.id === undefined || block.name === undefined) {
+							return undecodableFrame(frame.event, frame.data);
+						}
+						pendingToolCalls.set(index, { id: block.id, name: block.name, fragments: [] });
+						return [{ type: "tool_call_start", id: block.id, name: block.name }];
+					}
+					if (block.type === "text" && block.text !== undefined && block.text !== "") {
+						// The opening text is empty in every documented stream, but a
+						// non-empty one is answer text and dropping it would lose it.
+						return [{ type: "text_delta", text: block.text }];
+					}
+					return [];
+				}
+
+				case "content_block_delta": {
+					const payload = decodePayload(contentBlockDeltaSchema, frame.data);
+					if (payload === undefined) return undecodableFrame(frame.event, frame.data);
+					const { index, delta } = payload;
+					if (delta.type === "text_delta") {
+						if (delta.text === undefined || delta.text === "") return [];
+						return [{ type: "text_delta", text: delta.text }];
+					}
+					if (delta.type === "input_json_delta") {
+						if (delta.partial_json === undefined || delta.partial_json === "") return [];
+						const pending = pendingToolCalls.get(index);
+						if (pending === undefined) {
+							// A fragment with no open call means an argument was lost; saying
+							// so beats silently completing a truncated tool call later.
+							return malformedStreamError(
+								"The Anthropic stream sent tool arguments for a tool call that never started.",
+							);
+						}
+						pending.fragments.push(delta.partial_json);
+						return [
+							{ type: "tool_call_input_delta", id: pending.id, partialJson: delta.partial_json },
+						];
+					}
+					// `thinking_delta`, `signature_delta`, and future delta types.
+					return [];
+				}
+
+				case "content_block_stop": {
+					const payload = decodePayload(contentBlockStopSchema, frame.data);
+					if (payload === undefined) return undecodableFrame(frame.event, frame.data);
+					const pending = pendingToolCalls.get(payload.index);
+					// Text blocks are not tracked by index; only tool calls finish here.
+					if (pending === undefined) return [];
+					pendingToolCalls.delete(payload.index);
+					return finishPendingToolCall(pending);
+				}
+
+				case "message_delta": {
+					const payload = decodePayload(messageDeltaSchema, frame.data);
+					if (payload === undefined) return undecodableFrame(frame.event, frame.data);
+					const rawStopReason = payload.delta?.stop_reason;
+					if (typeof rawStopReason === "string") {
+						stopReason = mapStopReason(rawStopReason);
+					}
+					const usage = payload.usage;
+					if (!usage) return [];
+					return [
+						{
+							type: "usage",
+							usage: {
+								// `message_delta` usage carries output tokens only; input tokens
+								// were reported on `message_start`.
+								inputTokens: usage.input_tokens ?? reportedInputTokens,
+								outputTokens: usage.output_tokens ?? 0,
+							},
+						},
+					];
+				}
+
+				case "message_stop":
+					// Carries no payload this protocol reads. `message_delta` precedes it
+					// in the documented protocol; "unknown" covers a stream that never
+					// reported a stop reason.
+					return [{ type: "message_stop", stopReason: stopReason ?? "unknown" }];
+
+				case "error": {
+					const payload = decodePayload(errorEventSchema, frame.data);
+					if (payload === undefined) return undecodableFrame(frame.event, frame.data);
+					const providerType = payload.error?.type ?? "";
+					const providerMessage = payload.error?.message ?? "";
+					const detailParts = [providerType, providerMessage].filter((part) => part !== "");
+					const error: ProtocolError =
+						providerType === "rate_limit_error"
+							? {
+									code: "rate_limited",
+									message: "Anthropic rate limit or quota exceeded — wait and try again.",
+								}
+							: {
+									code: "http_status",
+									message: "Anthropic reported an error while streaming the response.",
+								};
+					if (detailParts.length > 0) {
+						error.providerDetail = redactProviderDetail(detailParts.join(": "));
+					}
+					return [{ type: "error", error }];
+				}
+
+				default:
+					// `ping` and any event type added after this mapper was written.
+					return [];
+			}
+		},
+	};
+}

--- a/src/lib/ai/providers/mapper-events.ts
+++ b/src/lib/ai/providers/mapper-events.ts
@@ -1,0 +1,61 @@
+/**
+ * Provider-neutral `StreamEvent` construction shared by the two mappers.
+ *
+ * Tool-call arguments stream as JSON fragments on both providers — Anthropic's
+ * `input_json_delta` and OpenAI's `tool_calls[].function.arguments` — and the
+ * protocol contract for finishing them is identical: parse the concatenation
+ * exactly once, and emit `malformed_stream` for a fragment set that never
+ * parses without aborting the turn. Keeping that logic here guarantees the two
+ * mappers cannot drift into provider-specific failure shapes, which the
+ * cross-provider equality test in `./openai.test.ts` depends on.
+ */
+
+import { type ProtocolError, redactProviderDetail } from "@/lib/ai/protocol/errors";
+import type { StreamEvent } from "@/lib/ai/protocol/events";
+
+/** A tool call whose JSON arguments are still streaming in. */
+export interface PendingToolCall {
+	id: string;
+	name: string;
+	fragments: string[];
+}
+
+/**
+ * Build the non-terminal `malformed_stream` error for one undecodable piece of
+ * a stream. `providerDetail`, when given, is provider-controlled text and is
+ * redacted here so no caller can forget to.
+ */
+export function malformedStreamError(message: string, providerDetail?: string): StreamEvent[] {
+	const error: ProtocolError = { code: "malformed_stream", message };
+	if (providerDetail !== undefined && providerDetail !== "") {
+		error.providerDetail = redactProviderDetail(providerDetail);
+	}
+	return [{ type: "error", error }];
+}
+
+/**
+ * Parse a finished tool call's accumulated fragments.
+ *
+ * Fragments are JSON-parsed exactly once, here. A fragment set that never
+ * parses emits `malformed_stream` for that call and the turn continues; a call
+ * that streamed no fragments has the empty input `{}`, which is how both
+ * providers represent a no-argument call.
+ *
+ * The failed call's name identifies which call was dropped, but it is
+ * stream-supplied text — a steered model can put arbitrary copy in a tool
+ * name — so it travels as redacted `providerDetail`, never inside the authored
+ * `message`.
+ */
+export function finishPendingToolCall(call: PendingToolCall): StreamEvent[] {
+	const raw = call.fragments.join("");
+	let input: unknown;
+	try {
+		input = JSON.parse(raw === "" ? "{}" : raw);
+	} catch {
+		return malformedStreamError(
+			"A tool call sent arguments that were not valid JSON, so the call was dropped.",
+			call.name,
+		);
+	}
+	return [{ type: "tool_call_complete", id: call.id, name: call.name, input }];
+}

--- a/src/lib/ai/providers/openai.test.ts
+++ b/src/lib/ai/providers/openai.test.ts
@@ -1,0 +1,470 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import type { StreamEvent } from "@/lib/ai/protocol/events";
+import type { ProtocolMessage } from "@/lib/ai/protocol/messages";
+import type { ProviderChatRequest } from "@/lib/ai/protocol/request";
+import { defineTool } from "@/lib/ai/protocol/tools";
+import { createAnthropicStreamMapper } from "./anthropic";
+import { buildOpenAiRequestBody, createOpenAiStreamMapper } from "./openai";
+import { createSseDecoder, type SseFrame } from "./sse";
+
+const addNoteTool = defineTool({
+	name: "add_note",
+	description: "Attach a note to the model.",
+	input: { text: z.string() },
+});
+
+const baseRequest: ProviderChatRequest = {
+	modelId: "gpt-4o",
+	system: "You are a threat modeling assistant.",
+	messages: [{ role: "user", content: [{ type: "text", text: "Review the gateway." }] }],
+	tools: [],
+	maxOutputTokens: 4096,
+};
+
+/** Author one frame the way the decoder would deliver an OpenAI data line. */
+function frame(payload: unknown): SseFrame {
+	return { event: "message", data: JSON.stringify(payload) };
+}
+
+describe("buildOpenAiRequestBody", () => {
+	it("places the system prompt as the first message and requests streamed usage", () => {
+		const body = buildOpenAiRequestBody(baseRequest);
+		expect(body.model).toBe("gpt-4o");
+		expect(body.max_completion_tokens).toBe(4096);
+		expect(body.stream).toBe(true);
+		expect(body.stream_options).toEqual({ include_usage: true });
+		expect(body.messages).toEqual([
+			{ role: "system", content: "You are a threat modeling assistant." },
+			{ role: "user", content: "Review the gateway." },
+		]);
+	});
+
+	it("serializes tool results as role tool messages keyed by tool_call_id", () => {
+		const messages: ProtocolMessage[] = [
+			{
+				role: "assistant",
+				content: [
+					{ type: "text", text: "Adding it." },
+					{ type: "tool_call", id: "call_1", name: "add_note", input: { text: "hi" } },
+				],
+			},
+			{
+				role: "user",
+				content: [
+					{ type: "tool_result", toolCallId: "call_1", content: "ok" },
+					{ type: "text", text: "Thanks." },
+				],
+			},
+		];
+		const body = buildOpenAiRequestBody({ ...baseRequest, messages });
+		expect(body.messages).toEqual([
+			{ role: "system", content: "You are a threat modeling assistant." },
+			{
+				role: "assistant",
+				content: "Adding it.",
+				tool_calls: [
+					{
+						id: "call_1",
+						type: "function",
+						function: { name: "add_note", arguments: '{"text":"hi"}' },
+					},
+				],
+			},
+			// The tool message precedes the user's text: OpenAI requires results to
+			// directly follow the assistant message that made the calls.
+			{ role: "tool", tool_call_id: "call_1", content: "ok" },
+			{ role: "user", content: "Thanks." },
+		]);
+	});
+
+	it("serializes a text-less tool-call turn with null content", () => {
+		const body = buildOpenAiRequestBody({
+			...baseRequest,
+			messages: [
+				{
+					role: "assistant",
+					content: [{ type: "tool_call", id: "call_1", name: "add_note", input: {} }],
+				},
+			],
+		});
+		expect(body.messages[1]).toEqual({
+			role: "assistant",
+			content: null,
+			tool_calls: [
+				{ id: "call_1", type: "function", function: { name: "add_note", arguments: "{}" } },
+			],
+		});
+	});
+
+	it("advertises tools as function definitions with generated parameters and no strict flag", () => {
+		const withTools = buildOpenAiRequestBody({ ...baseRequest, tools: [addNoteTool] });
+		expect(withTools.tools).toEqual([
+			{
+				type: "function",
+				function: {
+					name: "add_note",
+					description: "Attach a note to the model.",
+					parameters: addNoteTool.jsonSchema(),
+				},
+			},
+		]);
+		// strict mode is deferred to #64; the flag must be absent, not false.
+		expect(withTools.tools?.[0]?.function).not.toHaveProperty("strict");
+
+		const withoutTools = buildOpenAiRequestBody(baseRequest);
+		expect(withoutTools).not.toHaveProperty("tools");
+	});
+});
+
+describe("createOpenAiStreamMapper", () => {
+	it("emits message_start once, from the first chunk that names the model", () => {
+		const mapper = createOpenAiStreamMapper();
+		const first = mapper.mapFrame(
+			frame({
+				model: "gpt-4o",
+				choices: [{ delta: { role: "assistant", content: "" }, finish_reason: null }],
+			}),
+		);
+		expect(first).toEqual([{ type: "message_start", model: "gpt-4o" }]);
+		const second = mapper.mapFrame(
+			frame({ model: "gpt-4o", choices: [{ delta: { content: "Hi" }, finish_reason: null }] }),
+		);
+		expect(second).toEqual([{ type: "text_delta", text: "Hi" }]);
+	});
+
+	it("skips empty and null content deltas", () => {
+		const mapper = createOpenAiStreamMapper();
+		mapper.mapFrame(frame({ model: "gpt-4o", choices: [] }));
+		expect(
+			mapper.mapFrame(frame({ choices: [{ delta: { content: "" }, finish_reason: null }] })),
+		).toEqual([]);
+		expect(
+			mapper.mapFrame(frame({ choices: [{ delta: { content: null }, finish_reason: null }] })),
+		).toEqual([]);
+	});
+
+	it("accumulates tool calls by index when id and name arrive on the first fragment only", () => {
+		const mapper = createOpenAiStreamMapper();
+		mapper.mapFrame(frame({ model: "gpt-4o", choices: [] }));
+		expect(
+			mapper.mapFrame(
+				frame({
+					choices: [
+						{
+							delta: {
+								tool_calls: [
+									{
+										index: 0,
+										id: "call_1",
+										type: "function",
+										function: { name: "add_note", arguments: "" },
+									},
+								],
+							},
+							finish_reason: null,
+						},
+					],
+				}),
+			),
+		).toEqual([{ type: "tool_call_start", id: "call_1", name: "add_note" }]);
+		// Later fragments carry neither id nor name; the index resolves them.
+		expect(
+			mapper.mapFrame(
+				frame({
+					choices: [
+						{
+							delta: { tool_calls: [{ index: 0, function: { arguments: '{"text":"h' } }] },
+							finish_reason: null,
+						},
+					],
+				}),
+			),
+		).toEqual([{ type: "tool_call_input_delta", id: "call_1", partialJson: '{"text":"h' }]);
+		expect(
+			mapper.mapFrame(
+				frame({
+					choices: [
+						{
+							delta: { tool_calls: [{ index: 0, function: { arguments: 'i"}' } }] },
+							finish_reason: null,
+						},
+					],
+				}),
+			),
+		).toEqual([{ type: "tool_call_input_delta", id: "call_1", partialJson: 'i"}' }]);
+		// finish_reason closes the choice: arguments are parsed exactly once here.
+		expect(
+			mapper.mapFrame(frame({ choices: [{ delta: {}, finish_reason: "tool_calls" }] })),
+		).toEqual([
+			{ type: "tool_call_complete", id: "call_1", name: "add_note", input: { text: "hi" } },
+		]);
+		expect(mapper.mapFrame({ event: "message", data: "[DONE]" })).toEqual([
+			{ type: "message_stop", stopReason: "tool_use" },
+		]);
+	});
+
+	it("keeps two parallel tool calls separate by index", () => {
+		const mapper = createOpenAiStreamMapper();
+		mapper.mapFrame(frame({ model: "gpt-4o", choices: [] }));
+		mapper.mapFrame(
+			frame({
+				choices: [
+					{
+						delta: {
+							tool_calls: [
+								{ index: 0, id: "call_a", function: { name: "add_note", arguments: "" } },
+								{ index: 1, id: "call_b", function: { name: "add_note", arguments: "" } },
+							],
+						},
+						finish_reason: null,
+					},
+				],
+			}),
+		);
+		mapper.mapFrame(
+			frame({
+				choices: [
+					{
+						delta: {
+							tool_calls: [
+								{ index: 1, function: { arguments: '{"text":"b"}' } },
+								{ index: 0, function: { arguments: '{"text":"a"}' } },
+							],
+						},
+						finish_reason: null,
+					},
+				],
+			}),
+		);
+		const completed = mapper.mapFrame(
+			frame({ choices: [{ delta: {}, finish_reason: "tool_calls" }] }),
+		);
+		expect(completed).toEqual([
+			{ type: "tool_call_complete", id: "call_a", name: "add_note", input: { text: "a" } },
+			{ type: "tool_call_complete", id: "call_b", name: "add_note", input: { text: "b" } },
+		]);
+	});
+
+	it("emits malformed_stream for one unparseable tool call while completing the others", () => {
+		const mapper = createOpenAiStreamMapper();
+		mapper.mapFrame(frame({ model: "gpt-4o", choices: [] }));
+		mapper.mapFrame(
+			frame({
+				choices: [
+					{
+						delta: {
+							tool_calls: [
+								{
+									index: 0,
+									id: "call_bad",
+									function: { name: "add_note", arguments: '{"text": ' },
+								},
+								{
+									index: 1,
+									id: "call_good",
+									function: { name: "add_note", arguments: '{"text":"ok"}' },
+								},
+							],
+						},
+						finish_reason: null,
+					},
+				],
+			}),
+		);
+		const events = mapper.mapFrame(
+			frame({ choices: [{ delta: {}, finish_reason: "tool_calls" }] }),
+		);
+		expect(events).toHaveLength(2);
+		expect(events[0]).toMatchObject({ type: "error", error: { code: "malformed_stream" } });
+		if (events[0].type !== "error") throw new Error("expected an error event");
+		expect(events[0].error.message).toBe(
+			"A tool call sent arguments that were not valid JSON, so the call was dropped.",
+		);
+		expect(events[0].error.providerDetail).toBe("add_note");
+		expect(events[1]).toEqual({
+			type: "tool_call_complete",
+			id: "call_good",
+			name: "add_note",
+			input: { text: "ok" },
+		});
+		// The turn still terminates normally.
+		expect(mapper.mapFrame({ event: "message", data: "[DONE]" })).toEqual([
+			{ type: "message_stop", stopReason: "tool_use" },
+		]);
+	});
+
+	it("emits malformed_stream for a first fragment that never names its call", () => {
+		const mapper = createOpenAiStreamMapper();
+		const events = mapper.mapFrame(
+			frame({
+				choices: [
+					{
+						delta: { tool_calls: [{ index: 0, function: { arguments: '{"a":1}' } }] },
+						finish_reason: null,
+					},
+				],
+			}),
+		);
+		expect(events).toMatchObject([{ type: "error", error: { code: "malformed_stream" } }]);
+	});
+
+	it.each([
+		["stop", "end_turn"],
+		["tool_calls", "tool_use"],
+		["length", "max_tokens"],
+		["content_filter", "unknown"],
+	] as const)("maps finish_reason %s to stop reason %s at [DONE]", (raw, mapped) => {
+		const mapper = createOpenAiStreamMapper();
+		mapper.mapFrame(frame({ choices: [{ delta: {}, finish_reason: raw }] }));
+		expect(mapper.mapFrame({ event: "message", data: "[DONE]" })).toEqual([
+			{ type: "message_stop", stopReason: mapped },
+		]);
+	});
+
+	it("reports unknown when [DONE] arrives without any finish_reason", () => {
+		const mapper = createOpenAiStreamMapper();
+		expect(mapper.mapFrame({ event: "message", data: "[DONE]" })).toEqual([
+			{ type: "message_stop", stopReason: "unknown" },
+		]);
+	});
+
+	it("maps the requested usage chunk to a usage event", () => {
+		const mapper = createOpenAiStreamMapper();
+		mapper.mapFrame(frame({ model: "gpt-4o", choices: [] }));
+		const events = mapper.mapFrame(
+			frame({ choices: [], usage: { prompt_tokens: 42, completion_tokens: 17 } }),
+		);
+		expect(events).toEqual([{ type: "usage", usage: { inputTokens: 42, outputTokens: 17 } }]);
+	});
+
+	it("emits malformed_stream for a data line that is not valid JSON", () => {
+		const mapper = createOpenAiStreamMapper();
+		const events = mapper.mapFrame({ event: "message", data: '{"choices":[{"del' });
+		expect(events).toMatchObject([{ type: "error", error: { code: "malformed_stream" } }]);
+	});
+
+	it("maps an in-stream rate limit error to rate_limited with redacted detail", () => {
+		const mapper = createOpenAiStreamMapper();
+		const events = mapper.mapFrame(
+			frame({
+				error: {
+					message: "Incorrect API key provided: sk-abc123DEF. Rate limit reached.",
+					type: "requests",
+					code: "rate_limit_exceeded",
+				},
+			}),
+		);
+		expect(events).toHaveLength(1);
+		if (events[0].type !== "error") throw new Error("expected an error event");
+		expect(events[0].error.code).toBe("rate_limited");
+		expect(events[0].error.message).toBe(
+			"OpenAI rate limit or quota exceeded — wait and try again.",
+		);
+		expect(events[0].error.providerDetail).toContain("[redacted-key]");
+		expect(events[0].error.providerDetail).not.toContain("sk-abc");
+	});
+
+	it("maps other in-stream errors to http_status with an authored message", () => {
+		const mapper = createOpenAiStreamMapper();
+		const events = mapper.mapFrame(
+			frame({ error: { message: "The server had an error.", type: "server_error", code: null } }),
+		);
+		expect(events).toMatchObject([
+			{
+				type: "error",
+				error: {
+					code: "http_status",
+					message: "OpenAI reported an error while streaming the response.",
+					providerDetail: "server_error: The server had an error.",
+				},
+			},
+		]);
+	});
+});
+
+/**
+ * The provider-neutrality proof: the same logical response, authored in each
+ * provider's documented streaming shape, must map to an identical StreamEvent
+ * sequence. Provider-assigned identifiers (the echoed model id and the tool
+ * call id) are deliberately authored equal across the two transcripts so the
+ * sequences can be compared exactly; everything else follows each provider's
+ * wire format. Both transcripts are hand-authored from the documented event
+ * shapes, not recorded from a live account.
+ */
+describe("cross-provider event equality", () => {
+	const ANTHROPIC_TRANSCRIPT =
+		"event: message_start\n" +
+		'data: {"type":"message_start","message":{"id":"msg_1","model":"test-model-1","usage":{"input_tokens":42,"output_tokens":1}}}\n\n' +
+		"event: content_block_start\n" +
+		'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n' +
+		"event: content_block_delta\n" +
+		'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I will add "}}\n\n' +
+		"event: content_block_delta\n" +
+		'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"a note."}}\n\n' +
+		"event: content_block_stop\n" +
+		'data: {"type":"content_block_stop","index":0}\n\n' +
+		"event: content_block_start\n" +
+		'data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"call_1","name":"add_note","input":{}}}\n\n' +
+		"event: content_block_delta\n" +
+		'data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\\"text\\":\\"Spoofed"}}\n\n' +
+		"event: content_block_delta\n" +
+		'data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":" client\\"}"}}\n\n' +
+		"event: content_block_stop\n" +
+		'data: {"type":"content_block_stop","index":1}\n\n' +
+		"event: message_delta\n" +
+		'data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":17}}\n\n' +
+		"event: message_stop\n" +
+		'data: {"type":"message_stop"}\n\n';
+
+	const OPENAI_TRANSCRIPT =
+		'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","model":"test-model-1","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}\n\n' +
+		'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","model":"test-model-1","choices":[{"index":0,"delta":{"content":"I will add "},"finish_reason":null}]}\n\n' +
+		'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","model":"test-model-1","choices":[{"index":0,"delta":{"content":"a note."},"finish_reason":null}]}\n\n' +
+		'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","model":"test-model-1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"add_note","arguments":""}}]},"finish_reason":null}]}\n\n' +
+		'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","model":"test-model-1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"text\\":\\"Spoofed"}}]},"finish_reason":null}]}\n\n' +
+		'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","model":"test-model-1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":" client\\"}"}}]},"finish_reason":null}]}\n\n' +
+		'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","model":"test-model-1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}\n\n' +
+		'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","model":"test-model-1","choices":[],"usage":{"prompt_tokens":42,"completion_tokens":17}}\n\n' +
+		"data: [DONE]\n\n";
+
+	const EXPECTED_SEQUENCE: StreamEvent[] = [
+		{ type: "message_start", model: "test-model-1" },
+		{ type: "text_delta", text: "I will add " },
+		{ type: "text_delta", text: "a note." },
+		{ type: "tool_call_start", id: "call_1", name: "add_note" },
+		{ type: "tool_call_input_delta", id: "call_1", partialJson: '{"text":"Spoofed' },
+		{ type: "tool_call_input_delta", id: "call_1", partialJson: ' client"}' },
+		{
+			type: "tool_call_complete",
+			id: "call_1",
+			name: "add_note",
+			input: { text: "Spoofed client" },
+		},
+		{ type: "usage", usage: { inputTokens: 42, outputTokens: 17 } },
+		{ type: "message_stop", stopReason: "tool_use" },
+	];
+
+	function decodeAndMap(
+		transcript: string,
+		mapper: { mapFrame(frame: SseFrame): StreamEvent[] },
+	): StreamEvent[] {
+		const decoder = createSseDecoder();
+		const events: StreamEvent[] = [];
+		for (const f of decoder.decode(new TextEncoder().encode(transcript))) {
+			events.push(...mapper.mapFrame(f));
+		}
+		return events;
+	}
+
+	it("maps the same logical response to an identical event sequence on both providers", () => {
+		const anthropicEvents = decodeAndMap(ANTHROPIC_TRANSCRIPT, createAnthropicStreamMapper());
+		const openAiEvents = decodeAndMap(OPENAI_TRANSCRIPT, createOpenAiStreamMapper());
+
+		// Guard against a vacuous pass: both sequences must be the expected one,
+		// not merely equal to each other (two empty sequences are also equal).
+		expect(anthropicEvents).toEqual(EXPECTED_SEQUENCE);
+		expect(openAiEvents).toEqual(EXPECTED_SEQUENCE);
+		expect(openAiEvents).toEqual(anthropicEvents);
+	});
+});

--- a/src/lib/ai/providers/openai.ts
+++ b/src/lib/ai/providers/openai.ts
@@ -1,0 +1,390 @@
+/**
+ * OpenAI Chat Completions mapper: request building and stream-chunk decoding.
+ *
+ * This module and `./anthropic.ts` are the only places OpenAI's wire shapes may
+ * appear; everything downstream speaks the protocol types in
+ * `src/lib/ai/protocol/`. Two logically identical responses from the two
+ * providers must map to identical `StreamEvent` sequences — the cross-provider
+ * equality test in `./openai.test.ts` is the proof.
+ *
+ * Tool results serialize as `role: "tool"` messages keyed by `tool_call_id`,
+ * which is OpenAI's shape; Anthropic's `tool_result`-block divergence lives
+ * wholly in `./anthropic.ts`.
+ *
+ * Tool definitions are emitted without `strict`. Strict mode additionally
+ * constrains optional fields (every property must be listed in `required`), so
+ * enabling it is a schema-shape decision deferred to issue #64 alongside the
+ * native graph tools.
+ */
+
+import { z } from "zod";
+import type { ProtocolError } from "@/lib/ai/protocol/errors";
+import { redactProviderDetail } from "@/lib/ai/protocol/errors";
+import type { StopReason, StreamEvent } from "@/lib/ai/protocol/events";
+import type { ProtocolMessage } from "@/lib/ai/protocol/messages";
+import type { ProviderChatRequest } from "@/lib/ai/protocol/request";
+import type { ToolInputJsonSchema } from "@/lib/ai/protocol/tools";
+import { finishPendingToolCall, malformedStreamError, type PendingToolCall } from "./mapper-events";
+import type { SseFrame } from "./sse";
+
+// ---------------------------------------------------------------------------
+// Request building
+// ---------------------------------------------------------------------------
+
+interface OpenAiSystemMessage {
+	role: "system";
+	content: string;
+}
+
+interface OpenAiUserMessage {
+	role: "user";
+	content: string;
+}
+
+interface OpenAiToolMessage {
+	role: "tool";
+	tool_call_id: string;
+	content: string;
+}
+
+interface OpenAiAssistantToolCall {
+	id: string;
+	type: "function";
+	function: { name: string; arguments: string };
+}
+
+interface OpenAiAssistantMessage {
+	role: "assistant";
+	content: string | null;
+	tool_calls?: OpenAiAssistantToolCall[];
+}
+
+type OpenAiRequestMessage =
+	| OpenAiSystemMessage
+	| OpenAiUserMessage
+	| OpenAiToolMessage
+	| OpenAiAssistantMessage;
+
+interface OpenAiToolPayload {
+	type: "function";
+	function: { name: string; description: string; parameters: ToolInputJsonSchema };
+}
+
+/** The body posted to `POST /v1/chat/completions`. */
+export interface OpenAiRequestBody {
+	model: string;
+	max_completion_tokens: number;
+	messages: OpenAiRequestMessage[];
+	stream: true;
+	stream_options: { include_usage: true };
+	tools?: OpenAiToolPayload[];
+}
+
+/**
+ * A protocol user message becomes up to several OpenAI messages: one
+ * `role: "tool"` message per `tool_result` block, then the user's text.
+ *
+ * Tool messages come first because OpenAI requires them to directly follow the
+ * assistant message that made the calls. OpenAI has no `is_error` flag on tool
+ * messages, so a failed result relies on its `content` describing the failure —
+ * which `ToolResultBlock.content` is documented to do.
+ */
+function serializeUserMessage(message: ProtocolMessage): OpenAiRequestMessage[] {
+	const serialized: OpenAiRequestMessage[] = [];
+	let text = "";
+	for (const block of message.content) {
+		if (block.type === "text") {
+			text += block.text;
+		} else if (block.type === "tool_result") {
+			serialized.push({ role: "tool", tool_call_id: block.toolCallId, content: block.content });
+		}
+		// A `tool_call` block in a user message violates the protocol contract
+		// (calls are assistant-authored); serializing it would fabricate a turn
+		// the model never took, so it is dropped.
+	}
+	if (text !== "" || serialized.length === 0) {
+		serialized.push({ role: "user", content: text });
+	}
+	return serialized;
+}
+
+function serializeAssistantMessage(message: ProtocolMessage): OpenAiAssistantMessage {
+	let text = "";
+	const toolCalls: OpenAiAssistantToolCall[] = [];
+	for (const block of message.content) {
+		if (block.type === "text") {
+			text += block.text;
+		} else if (block.type === "tool_call") {
+			toolCalls.push({
+				id: block.id,
+				type: "function",
+				// `input` came from JSON, so this only yields `undefined` for a
+				// hand-built non-JSON value; `{}` keeps the history serializable.
+				function: { name: block.name, arguments: JSON.stringify(block.input) ?? "{}" },
+			});
+		}
+		// A `tool_result` block in an assistant message violates the protocol
+		// contract (results answer the assistant) and is dropped.
+	}
+	const serialized: OpenAiAssistantMessage = {
+		role: "assistant",
+		// OpenAI rejects a null-content assistant message unless it carries tool
+		// calls, and a text-less tool-call turn is exactly the null-content case.
+		content: text === "" && toolCalls.length > 0 ? null : text,
+	};
+	if (toolCalls.length > 0) {
+		serialized.tool_calls = toolCalls;
+	}
+	return serialized;
+}
+
+/**
+ * Build the streaming request body for the OpenAI Chat Completions API.
+ *
+ * Tool-call/result pairing and block placement are the caller's contract,
+ * enforced upstream by `assertToolPairing` and the budgeter; a history that
+ * violates them serializes to whatever the provider makes of it (here,
+ * misplaced blocks are dropped — see the serializers). Only
+ * contract-conforming histories are guaranteed to serialize equivalently
+ * across the two builders.
+ */
+export function buildOpenAiRequestBody(request: ProviderChatRequest): OpenAiRequestBody {
+	const messages: OpenAiRequestMessage[] = [{ role: "system", content: request.system }];
+	for (const message of request.messages) {
+		if (message.role === "assistant") {
+			messages.push(serializeAssistantMessage(message));
+		} else {
+			messages.push(...serializeUserMessage(message));
+		}
+	}
+
+	const body: OpenAiRequestBody = {
+		model: request.modelId,
+		max_completion_tokens: request.maxOutputTokens,
+		messages,
+		stream: true,
+		// Without this opt-in the stream never reports usage: the final usage
+		// chunk (empty `choices`) is only sent when the request asks for it.
+		stream_options: { include_usage: true },
+	};
+	if (request.tools.length > 0) {
+		// `strict` is deliberately unset; see the module doc.
+		body.tools = request.tools.map((tool) => ({
+			type: "function",
+			function: {
+				name: tool.name,
+				description: tool.description,
+				parameters: tool.jsonSchema(),
+			},
+		}));
+	}
+	return body;
+}
+
+// ---------------------------------------------------------------------------
+// Stream mapping
+// ---------------------------------------------------------------------------
+
+/** OpenAI's terminal sentinel; it is not JSON and marks the end of the stream. */
+const DONE_SENTINEL = "[DONE]";
+
+/**
+ * Chunk schema, deliberately lenient: only the fields this mapper reads are
+ * declared and unknown keys are stripped, so fields OpenAI adds later cannot
+ * break decoding. An in-stream failure arrives as an `error` object instead of
+ * a chunk, which the same schema admits because every field is optional.
+ */
+const chunkSchema = z.object({
+	model: z.string().nullish(),
+	choices: z
+		.array(
+			z.object({
+				delta: z
+					.object({
+						content: z.string().nullish(),
+						tool_calls: z
+							.array(
+								z.object({
+									index: z.number().int(),
+									id: z.string().nullish(),
+									function: z
+										.object({
+											name: z.string().nullish(),
+											arguments: z.string().nullish(),
+										})
+										.nullish(),
+								}),
+							)
+							.nullish(),
+					})
+					.nullish(),
+				finish_reason: z.string().nullish(),
+			}),
+		)
+		.nullish(),
+	usage: z
+		.object({
+			prompt_tokens: z.number().nullish(),
+			completion_tokens: z.number().nullish(),
+		})
+		.nullish(),
+	error: z
+		.object({
+			message: z.string().nullish(),
+			type: z.string().nullish(),
+			code: z.string().nullish(),
+		})
+		.nullish(),
+});
+
+type OpenAiStreamError = NonNullable<z.infer<typeof chunkSchema>["error"]>;
+
+const FINISH_REASONS = new Map<string, StopReason>([
+	["stop", "end_turn"],
+	["tool_calls", "tool_use"],
+	["length", "max_tokens"],
+]);
+
+function mapFinishReason(raw: string): StopReason {
+	return FINISH_REASONS.get(raw) ?? "unknown";
+}
+
+function providerStreamError(error: OpenAiStreamError): StreamEvent[] {
+	const providerType = error.type ?? "";
+	const providerCode = error.code ?? "";
+	const providerMessage = error.message ?? "";
+	const rateLimited =
+		`${providerType} ${providerCode}`.includes("rate_limit") ||
+		`${providerType} ${providerCode}`.includes("insufficient_quota");
+	const mapped: ProtocolError = rateLimited
+		? {
+				code: "rate_limited",
+				message: "OpenAI rate limit or quota exceeded — wait and try again.",
+			}
+		: {
+				code: "http_status",
+				message: "OpenAI reported an error while streaming the response.",
+			};
+	const detailParts = [providerType, providerCode, providerMessage].filter((part) => part !== "");
+	if (detailParts.length > 0) {
+		mapped.providerDetail = redactProviderDetail(detailParts.join(": "));
+	}
+	return [{ type: "error", error: mapped }];
+}
+
+export interface OpenAiStreamMapper {
+	/** Map one decoded frame onto zero or more protocol events. */
+	mapFrame(frame: SseFrame): StreamEvent[];
+}
+
+/** Create a mapper holding the per-turn state of one OpenAI stream. */
+export function createOpenAiStreamMapper(): OpenAiStreamMapper {
+	/**
+	 * Calls in flight, keyed by `tool_calls[].index` — the id and name arrive on
+	 * the first fragment only, so later fragments resolve through this map.
+	 * Insertion order is arrival order, which completion preserves.
+	 */
+	const pendingToolCalls = new Map<number, PendingToolCall>();
+	let started = false;
+	let stopReason: StopReason | undefined;
+
+	return {
+		// OpenAI streams never name their events — every frame arrives as the SSE
+		// default "message" — so the frame's event field is not consulted.
+		mapFrame(frame: SseFrame): StreamEvent[] {
+			if (frame.data === DONE_SENTINEL) {
+				return [{ type: "message_stop", stopReason: stopReason ?? "unknown" }];
+			}
+
+			let payload: unknown;
+			try {
+				payload = JSON.parse(frame.data);
+			} catch {
+				return malformedStreamError(
+					"The OpenAI stream sent a chunk that could not be decoded.",
+					frame.data,
+				);
+			}
+			const parsed = chunkSchema.safeParse(payload);
+			if (!parsed.success) {
+				return malformedStreamError(
+					"The OpenAI stream sent a chunk that could not be decoded.",
+					frame.data,
+				);
+			}
+			const chunk = parsed.data;
+
+			if (chunk.error) {
+				return providerStreamError(chunk.error);
+			}
+
+			const events: StreamEvent[] = [];
+
+			if (!started && typeof chunk.model === "string" && chunk.model !== "") {
+				started = true;
+				events.push({ type: "message_start", model: chunk.model });
+			}
+
+			const choice = chunk.choices?.[0];
+			const delta = choice?.delta;
+
+			if (typeof delta?.content === "string" && delta.content !== "") {
+				events.push({ type: "text_delta", text: delta.content });
+			}
+
+			for (const fragment of delta?.tool_calls ?? []) {
+				const existing = pendingToolCalls.get(fragment.index);
+				const args = fragment.function?.arguments;
+				if (existing === undefined) {
+					const id = fragment.id;
+					const name = fragment.function?.name;
+					if (typeof id !== "string" || id === "" || typeof name !== "string" || name === "") {
+						// A first fragment must carry the id and name; without them the
+						// call can never be attributed, so say so instead of guessing.
+						events.push(
+							...malformedStreamError(
+								"The OpenAI stream sent a tool-call fragment before naming the call.",
+							),
+						);
+						continue;
+					}
+					const call: PendingToolCall = { id, name, fragments: [] };
+					pendingToolCalls.set(fragment.index, call);
+					events.push({ type: "tool_call_start", id, name });
+					if (typeof args === "string" && args !== "") {
+						call.fragments.push(args);
+						events.push({ type: "tool_call_input_delta", id, partialJson: args });
+					}
+					continue;
+				}
+				if (typeof args === "string" && args !== "") {
+					existing.fragments.push(args);
+					events.push({ type: "tool_call_input_delta", id: existing.id, partialJson: args });
+				}
+			}
+
+			const finishReason = choice?.finish_reason;
+			if (typeof finishReason === "string") {
+				stopReason = mapFinishReason(finishReason);
+				// The choice is finished, so every accumulated argument string is
+				// complete; parse each call exactly once, in arrival order.
+				for (const call of pendingToolCalls.values()) {
+					events.push(...finishPendingToolCall(call));
+				}
+				pendingToolCalls.clear();
+			}
+
+			if (chunk.usage) {
+				events.push({
+					type: "usage",
+					usage: {
+						inputTokens: chunk.usage.prompt_tokens ?? 0,
+						outputTokens: chunk.usage.completion_tokens ?? 0,
+					},
+				});
+			}
+
+			return events;
+		},
+	};
+}

--- a/src/lib/ai/providers/sse.test.ts
+++ b/src/lib/ai/providers/sse.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { createSseDecoder, type SseFrame } from "./sse";
+
+const encoder = new TextEncoder();
+
+/**
+ * A hand-authored Anthropic-shaped transcript (documented event shapes, not
+ * recorded from a live account). The multi-byte characters inside the JSON
+ * string ("café ☕") make byte-offset splits land mid-UTF-8-sequence as well as
+ * mid-line and mid-JSON.
+ */
+const TRANSCRIPT =
+	"event: message_start\n" +
+	'data: {"type":"message_start","message":{"model":"test-model-1"}}\n' +
+	"\n" +
+	"event: content_block_delta\n" +
+	'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"café ☕ review"}}\n' +
+	"\n" +
+	"event: message_stop\n" +
+	'data: {"type":"message_stop"}\n' +
+	"\n";
+
+const EXPECTED_FRAMES: SseFrame[] = [
+	{ event: "message_start", data: '{"type":"message_start","message":{"model":"test-model-1"}}' },
+	{
+		event: "content_block_delta",
+		data: '{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"café ☕ review"}}',
+	},
+	{ event: "message_stop", data: '{"type":"message_stop"}' },
+];
+
+function decodeChunks(chunks: Uint8Array[]): SseFrame[] {
+	const decoder = createSseDecoder();
+	const frames: SseFrame[] = [];
+	for (const chunk of chunks) {
+		frames.push(...decoder.decode(chunk));
+	}
+	return frames;
+}
+
+describe("createSseDecoder", () => {
+	it("decodes a whole transcript delivered as a single chunk", () => {
+		expect(decodeChunks([encoder.encode(TRANSCRIPT)])).toEqual(EXPECTED_FRAMES);
+	});
+
+	it("decodes identically when the transcript is split at every byte offset", () => {
+		const bytes = encoder.encode(TRANSCRIPT);
+		// Every interior offset, which includes every offset inside a JSON string
+		// and inside the multi-byte UTF-8 sequences of "café ☕".
+		for (let offset = 1; offset < bytes.length; offset++) {
+			const frames = decodeChunks([bytes.subarray(0, offset), bytes.subarray(offset)]);
+			expect(frames, `split at byte offset ${offset}`).toEqual(EXPECTED_FRAMES);
+		}
+	});
+
+	it("holds a trailing partial line until a later chunk completes it", () => {
+		const decoder = createSseDecoder();
+		expect(decoder.decode(encoder.encode('data: {"a":'))).toEqual([]);
+		expect(decoder.decode(encoder.encode("1}\n"))).toEqual([{ event: "message", data: '{"a":1}' }]);
+	});
+
+	it('assigns the SSE default event "message" to data lines with no event field', () => {
+		// OpenAI's stream shape: bare data lines, including the [DONE] sentinel.
+		const frames = decodeChunks([encoder.encode('data: {"choices":[]}\n\ndata: [DONE]\n\n')]);
+		expect(frames).toEqual([
+			{ event: "message", data: '{"choices":[]}' },
+			{ event: "message", data: "[DONE]" },
+		]);
+	});
+
+	it("resets the event name after each frame instead of letting it leak", () => {
+		const frames = decodeChunks([
+			encoder.encode("event: message_stop\ndata: {}\n\ndata: [DONE]\n\n"),
+		]);
+		expect(frames).toEqual([
+			{ event: "message_stop", data: "{}" },
+			{ event: "message", data: "[DONE]" },
+		]);
+	});
+
+	it("ignores comment keep-alives and blank lines", () => {
+		const frames = decodeChunks([encoder.encode(": keep-alive\n\n\nevent: ping\ndata: {}\n\n")]);
+		expect(frames).toEqual([{ event: "ping", data: "{}" }]);
+	});
+
+	it("decodes CRLF line endings the same as LF", () => {
+		const crlfTranscript = TRANSCRIPT.replace(/\n/g, "\r\n");
+		expect(decodeChunks([encoder.encode(crlfTranscript)])).toEqual(EXPECTED_FRAMES);
+	});
+
+	it("fails closed when an unterminated line exceeds the buffer cap", () => {
+		const decoder = createSseDecoder();
+		const oversized = new Uint8Array(1_048_576 + 1).fill(120); // "x", no newline
+		expect(() => decoder.decode(oversized)).toThrowError(
+			expect.objectContaining({
+				name: "ProtocolException",
+				error: expect.objectContaining({ code: "malformed_stream" }),
+			}),
+		);
+		// The buffer was dropped on breach: further chunks start clean instead of
+		// regrowing the abandoned line.
+		expect(decoder.decode(encoder.encode("data: {}\n"))).toEqual([
+			{ event: "message", data: "{}" },
+		]);
+	});
+
+	it("keeps buffering a stream that stays under the cap by terminating its lines", () => {
+		const decoder = createSseDecoder();
+		const bigButTerminated = `data: ${"y".repeat(500_000)}\n`;
+		const frames = [
+			...decoder.decode(encoder.encode(bigButTerminated)),
+			...decoder.decode(encoder.encode(bigButTerminated)),
+			...decoder.decode(encoder.encode(bigButTerminated)),
+		];
+		expect(frames).toHaveLength(3);
+	});
+
+	it("does not emit a final line the stream never terminated", () => {
+		// A truncated stream ends mid-data-line; the decoder must not present the
+		// fragment as a complete frame. Detecting truncation is the client's job.
+		const truncated = 'event: message_start\ndata: {"type":"message_st';
+		expect(decodeChunks([encoder.encode(truncated)])).toEqual([]);
+	});
+});

--- a/src/lib/ai/providers/sse.ts
+++ b/src/lib/ai/providers/sse.ts
@@ -1,0 +1,99 @@
+/**
+ * Byte-level server-sent-events decoder shared by both stream transports.
+ *
+ * The browser transport feeds it raw `fetch` body chunks; the desktop relay
+ * (issue #61 step 8) will perform equivalent framing in Rust before frames
+ * cross the IPC boundary, so this module is the single TypeScript place where
+ * provider bytes become frames. Network chunks can split anywhere — mid-line,
+ * mid-JSON, and mid-UTF-8-sequence — so decoding is stateful and a frame is
+ * emitted only once its `data:` line is complete.
+ *
+ * The framing is ported from the previous in-adapter parser
+ * (`src/lib/adapters/browser-chat-adapter.ts`) and keeps two of its
+ * simplifications the full SSE grammar does not share, both safe against the
+ * two official endpoints this protocol targets: each `data:` line dispatches
+ * one frame immediately rather than accumulating multi-line data until a blank
+ * line (Anthropic and OpenAI emit exactly one `data:` line per event), and
+ * field prefixes require the space after the colon (`data: x`, not `data:x`),
+ * which both endpoints always emit.
+ */
+
+import { ProtocolException } from "@/lib/ai/protocol/errors";
+
+/** The event name SSE assigns to a frame whose stream named none. */
+const DEFAULT_EVENT = "message";
+
+const EVENT_FIELD_PREFIX = "event: ";
+const DATA_FIELD_PREFIX = "data: ";
+
+/**
+ * Longest partial line the decoder will buffer before failing closed. Real
+ * provider data lines are a few KiB; a stream that exceeds this without a
+ * newline is not speaking the protocol. Without the cap, a stream that never
+ * terminates a line would grow the buffer forever while emitting zero frames —
+ * the one failure shape no downstream guard could ever observe.
+ */
+const MAX_BUFFERED_LINE_LENGTH = 1_048_576;
+
+/** One complete `{ event, data }` pair decoded from the stream. */
+export interface SseFrame {
+	/** The preceding `event:` field, or `"message"` when the stream named none. */
+	event: string;
+	/** The `data:` payload, untouched — JSON parsing is the mapper's job. */
+	data: string;
+}
+
+export interface SseDecoder {
+	/**
+	 * Feed one network chunk and collect every frame it completed. A trailing
+	 * partial line stays buffered until a later chunk finishes it. Throws a
+	 * `malformed_stream` {@link ProtocolException} if that partial line exceeds
+	 * the decoder's cap — the stream is not speaking SSE and must be abandoned.
+	 */
+	decode(chunk: Uint8Array): SseFrame[];
+}
+
+/** Create a decoder holding the partial-line and event-name state of one stream. */
+export function createSseDecoder(): SseDecoder {
+	// `stream: true` below keeps an incomplete UTF-8 sequence pending instead of
+	// emitting U+FFFD, so a chunk boundary inside a multi-byte character decodes
+	// identically to an unsplit stream.
+	const textDecoder = new TextDecoder();
+	let buffer = "";
+	let eventName = DEFAULT_EVENT;
+
+	return {
+		decode(chunk: Uint8Array): SseFrame[] {
+			const frames: SseFrame[] = [];
+			buffer += textDecoder.decode(chunk, { stream: true });
+
+			const lines = buffer.split("\n");
+			// The last element is a line the stream has not terminated yet; keep it
+			// for the next chunk.
+			buffer = lines.pop() ?? "";
+			if (buffer.length > MAX_BUFFERED_LINE_LENGTH) {
+				// Drop the buffer before throwing so a caller that survives the throw
+				// cannot keep growing it with further chunks.
+				buffer = "";
+				throw new ProtocolException({
+					code: "malformed_stream",
+					message: "The provider stream sent an unterminated line too long to be a real event.",
+				});
+			}
+
+			for (const rawLine of lines) {
+				// SSE permits CRLF line endings; the `\n` split leaves the `\r` behind.
+				const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+				if (line.startsWith(EVENT_FIELD_PREFIX)) {
+					eventName = line.slice(EVENT_FIELD_PREFIX.length).trim();
+				} else if (line.startsWith(DATA_FIELD_PREFIX)) {
+					frames.push({ event: eventName, data: line.slice(DATA_FIELD_PREFIX.length) });
+					eventName = DEFAULT_EVENT;
+				}
+				// Blank separator lines and `:` comment keep-alives carry nothing.
+			}
+
+			return frames;
+		},
+	};
+}


### PR DESCRIPTION
Part of #61 — plan steps 6–7 of [docs/plans/61-ai-conversation-protocol.md](https://github.com/exit-zero-labs/threat-forge/blob/main/docs/plans/61-ai-conversation-protocol.md). Steps 1–5 landed in #118 and #131; the Rust relay (step 8), typed transports (step 9), client rewire (step 10), fixtures/retries (step 11), and knowledge doc (step 12) follow in later slices.

## What this adds

- **`src/lib/ai/providers/sse.ts`** — one byte-level SSE decoder for both platforms. Stateful across chunk boundaries (mid-line, mid-JSON, mid-UTF-8 splits all decode identically), CRLF-tolerant, and fail-closed: an unterminated line over 1 MiB drops the buffer and throws a `malformed_stream` `ProtocolException`.
- **`src/lib/ai/providers/anthropic.ts`** — request builder + stream mapper for the full documented Messages event set (`message_start`, both `content_block_start` kinds, `text_delta`/`input_json_delta`, `content_block_stop`, `message_delta` stop reason + usage, `message_stop`, `error`). Tool results serialize as `tool_result` blocks in `user` messages.
- **`src/lib/ai/providers/openai.ts`** — the Chat Completions equivalent: `choices[0].delta` mapping, tool calls accumulated by `tool_calls[].index` (id/name arrive on the first fragment only), `finish_reason`, `[DONE]`, opt-in usage via `stream_options.include_usage`. Tool results serialize as `role: "tool"` messages. `strict` deliberately unset; deferred to #64.
- **`src/lib/ai/providers/mapper-events.ts`** — shared tool-call finishing: arguments JSON-parse exactly once at block/choice close; a fragment set that never parses emits a non-terminal `malformed_stream` scoped to that call and the turn continues.
- **Additive protocol support** — `ProviderChatRequest`, `AdvertisedTool`, `redactProviderDetail` (case-insensitive key masking before surrogate-safe 200-char truncation), and the pinned `ErrorEvent` terminality contract.

The provider-neutrality proof: a cross-provider test feeds the same logical response in each provider's wire shape through decoder + mapper and asserts an identical `StreamEvent` sequence, pinned to an explicit expected sequence to guard against a vacuous pass.

## Verification

- `npx vitest --run src/lib/ai` — 15 files, **240/240 pass** (68 new tests, including a decoder transcript split at every interior byte offset and the cross-provider equality test: `1 passed | 19 skipped` when isolated with `-t "identical event sequence"`)
- `npx biome check src/lib/ai` — clean; `npx tsc --noEmit` — clean
- `npm run ci:local` — all checks passed (Biome, tsc, Vitest, cargo fmt, Clippy, cargo test, lockfile, Tauri versions, web build, Worker dry run)

## Preflight record

Four lanes ran to convergence (author anti-slop pass, `pr-reviewer`, `slop-auditor`, `security-auditor`); final state: **zero must-fix, zero should-fix**.

Resolved during preflight:

- **must-fix (security):** the stream-supplied tool name was interpolated into the ThreatForge-authored `ProtocolError.message` (trusted, render-safe text), bypassing redaction and the length cap — an injection path for a steered model. Now a constant message; the name travels only as redacted `providerDetail`, with an end-to-end hostile-name test.
- **should-fix (security):** the SSE buffer grew silently and unboundedly on a stream that never terminates a line — the one failure shape no downstream guard could observe. Now the fail-closed 1 MiB cap.
- **should-fix (×3 lanes, converged):** the `ErrorEvent` doc understated the non-terminal `malformed_stream` cases; the terminality rule is now pinned exactly, including that a *thrown* `malformed_stream` is terminal by channel.
- **should-fix (slop):** present-tense claims about the unbuilt step-8 Rust redaction/framing are now stated as obligations.
- Adopted considers: case-insensitive key mask, surrogate-safe truncation, disclosed SSE grammar simplifications, builder docs declaring tool pairing the caller's contract.

Recorded, not adopted (lane-agreed): bare-`\r` SSE terminators (no real producer among the official endpoints); per-turn accumulation caps (owned by the step-8/9 transport stream budget); credential patterns beyond `sk-*` and input-side lone-surrogate scrubbing (`String.toWellFormed()` needs an ES2024 lib bump) — deferred to steps 8–10.

**Obligations inherited by later slices:**

1. Step 8 (Rust relay): mirror `redactProviderDetail` exactly (same pattern, mask-then-truncate order); enforce a per-stream byte/time budget; tolerate ill-formed UTF-16 in provider text at the serde boundary.
2. Step 10 (client): keep client-detected malformed failures on the exception/close path — never re-emit a thrown `malformed_stream` as a stream notice.

## Owner validation (beyond automated verification)

- Spot-check the mapped event sequences against Anthropic's documented streaming shape (plan step 6 intent gate).
- Confirm "OpenAI-compatible" scope is the official endpoint only; custom base URLs remain out of scope (plan step 7 intent gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
