### PR TITLE
chore(web): enable Cloudflare observability logs for the web worker

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,19 +1,36 @@
+/** @format */
+
 {
-	"$schema": "./node_modules/wrangler/config-schema.json",
-	"name": "threat-forge-web",
-	"compatibility_date": "2026-07-20",
-	"assets": {
-		"directory": "./dist",
-		"not_found_handling": "single-page-application"
-	},
-	"routes": [
-		{
-			"pattern": "threatforge.dev",
-			"custom_domain": true
-		},
-		{
-			"pattern": "www.threatforge.dev",
-			"custom_domain": true
-		}
-	]
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "threat-forge-web",
+  "compatibility_date": "2026-07-20",
+  "assets": {
+    "directory": "./dist",
+    "not_found_handling": "single-page-application",
+  },
+  "observability": {
+    "enabled": false,
+    "head_sampling_rate": 1,
+    "logs": {
+      "enabled": true,
+      "head_sampling_rate": 1,
+      "persist": true,
+      "invocation_logs": true,
+    },
+    "traces": {
+      "enabled": false,
+      "persist": true,
+      "head_sampling_rate": 1,
+    },
+  },
+  "routes": [
+    {
+      "pattern": "threatforge.dev",
+      "custom_domain": true,
+    },
+    {
+      "pattern": "www.threatforge.dev",
+      "custom_domain": true,
+    },
+  ],
 }


### PR DESCRIPTION
Enables persisted invocation logs for the threat-forge-web Worker (owner-requested observability change) and reformats wrangler.jsonc with the project formatter. Traces and metrics observability remain disabled.

Verification: `npm run ci:local` passed on this configuration, including the `wrangler deploy --dry-run` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
