### PR TITLE
ci: run Linux jobs on Hostinger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,8 @@ jobs:
             librsvg2-dev \
             patchelf \
             libdbus-1-dev \
-            libssl-dev
+            libssl-dev \
+            xdg-utils
 
       - name: Build Tauri app
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,7 @@ permissions:
 jobs:
   lockfile:
     name: Lockfile
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, hostinger]
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","hostinger"]') || 'ubuntu-latest' }}
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo-home
     steps:
@@ -41,8 +40,7 @@ jobs:
   lint:
     name: Lint
     needs: [lockfile]
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, hostinger]
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","hostinger"]') || 'ubuntu-latest' }}
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo-home
     steps:
@@ -99,8 +97,7 @@ jobs:
   test:
     name: Test
     needs: [lockfile]
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, hostinger]
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","hostinger"]') || 'ubuntu-latest' }}
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo-home
     steps:
@@ -149,8 +146,7 @@ jobs:
   e2e:
     name: E2E Tests
     needs: [test]
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, hostinger]
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","hostinger"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -180,8 +176,7 @@ jobs:
   build:
     name: Build (${{ matrix.platform }})
     needs: [lint, test]
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ${{ matrix.platform == 'ubuntu-latest' && fromJSON('["self-hosted","Linux","X64","hostinger"]') || matrix.platform }}
+    runs-on: ${{ matrix.platform == 'ubuntu-latest' && ((github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","hostinger"]') || 'ubuntu-latest') || matrix.platform }}
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo-home
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,8 @@ permissions:
 jobs:
   lockfile:
     name: Lockfile
-    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, Linux, X64, hostinger]
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo-home
     steps:
@@ -40,7 +41,8 @@ jobs:
   lint:
     name: Lint
     needs: [lockfile]
-    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, Linux, X64, hostinger]
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo-home
     steps:
@@ -97,7 +99,8 @@ jobs:
   test:
     name: Test
     needs: [lockfile]
-    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, Linux, X64, hostinger]
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo-home
     steps:
@@ -146,7 +149,8 @@ jobs:
   e2e:
     name: E2E Tests
     needs: [test]
-    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, Linux, X64, hostinger]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -176,7 +180,8 @@ jobs:
   build:
     name: Build (${{ matrix.platform }})
     needs: [lint, test]
-    runs-on: ${{ matrix.platform }}
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ${{ matrix.platform == 'ubuntu-latest' && fromJSON('["self-hosted","Linux","X64","hostinger"]') || matrix.platform }}
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo-home
     strategy:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,8 +10,7 @@ permissions:
 jobs:
   dependency-review:
     name: Dependency Review
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, hostinger]
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","hostinger"]') || 'ubuntu-latest' }}
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo-home
     steps:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,7 +10,8 @@ permissions:
 jobs:
   dependency-review:
     name: Dependency Review
-    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, Linux, X64, hostinger]
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo-home
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   validate:
     name: Validate
-    runs-on: [self-hosted, Linux, X64, hostinger]
+    runs-on: ubuntu-latest
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo-home
     steps:
@@ -101,7 +101,7 @@ jobs:
             args: "--target x86_64-apple-darwin"
           - platform: windows-latest
             args: ""
-    runs-on: ${{ matrix.settings.platform == 'ubuntu-latest' && fromJSON('["self-hosted","Linux","X64","hostinger"]') || matrix.settings.platform }}
+    runs-on: ${{ matrix.settings.platform }}
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo-home
     steps:
@@ -148,8 +148,7 @@ jobs:
             librsvg2-dev \
             patchelf \
             libdbus-1-dev \
-            libssl-dev \
-            xdg-utils
+            libssl-dev
 
       - name: Install Azure Trusted Signing dlib
         if: runner.os == 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,8 @@ jobs:
             librsvg2-dev \
             patchelf \
             libdbus-1-dev \
-            libssl-dev
+            libssl-dev \
+            xdg-utils
 
       - name: Install Azure Trusted Signing dlib
         if: runner.os == 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   validate:
     name: Validate
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, hostinger]
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo-home
     steps:
@@ -101,7 +101,7 @@ jobs:
             args: "--target x86_64-apple-darwin"
           - platform: windows-latest
             args: ""
-    runs-on: ${{ matrix.settings.platform }}
+    runs-on: ${{ matrix.settings.platform == 'ubuntu-latest' && fromJSON('["self-hosted","Linux","X64","hostinger"]') || matrix.settings.platform }}
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo-home
     steps:

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     patchelf \
     libdbus-1-dev \
     libssl-dev \
+    xdg-utils \
     && rm -rf /var/lib/apt/lists/*
 
 # 2. Node 22 via NodeSource

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -25,7 +25,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     patchelf \
     libdbus-1-dev \
     libssl-dev \
-    xdg-utils \
     && rm -rf /var/lib/apt/lists/*
 
 # 2. Node 22 via NodeSource


### PR DESCRIPTION
## Summary

Routes eligible Linux CI and dependency-review jobs to the Exit Zero Labs Hostinger self-hosted runner for trusted events and same-repository PRs. Fork PRs retain full CI coverage by falling back to GitHub-hosted `ubuntu-latest`, while macOS, Windows, Copilot infrastructure, and every release job remain on GitHub-hosted runners.

## Issue and Plan

- Closes: N/A — owner-directed infrastructure migration; no matching issue was open
- Parent initiative: N/A
- Plan: N/A — XS

## Acceptance Criteria

- [x] Trusted fixed Linux CI jobs use `[self-hosted, Linux, X64, hostinger]`
- [x] Fork PR Linux jobs fall back to `ubuntu-latest` instead of skipping
- [x] The CI build matrix dynamically routes only its Linux entry
- [x] macOS and Windows CI entries remain GitHub-hosted for every event
- [x] Dependency review uses the same trusted/self-hosted and fork/hosted fallback
- [x] Release validation and every release matrix leg retain their original GitHub-hosted selectors
- [x] `xdg-utils` is installed only by the CI Linux build and secret-free Docker CI paths
- [x] `.github/workflows/copilot-setup-steps.yml` remains unchanged
- [x] Commands, action versions, permissions, release behavior, and artifacts remain unchanged

## Changes

- Migrated CI lockfile, lint, test, E2E, and trusted Linux build jobs to Hostinger
- Preserved fork PR CI by routing Linux work to `ubuntu-latest`
- Migrated dependency review with equivalent trusted/fork routing
- Added `xdg-utils` to the CI Linux build and Docker CI image after Hostinger AppImage packaging required `/usr/bin/xdg-open`
- Kept release validation and all release matrix jobs on their original GitHub-hosted runners

## Verification

- [x] Smallest targeted checks passed: actionlint 1.7.12 parsed every workflow with `hostinger` configured as a custom label
- [x] Explicit assertions parsed all workflow YAML and verified push, same-repository PR, fork PR, Linux/macOS/Windows CI routing, fully hosted release routing, Copilot exclusion, and CI/Docker-only bundle dependency placement
- [x] `release.yml` has the same Git blob on PR head and `main`, and `gh pr view 147 --json files` does not list it
- [x] `npm run ci:local`
- [x] UI changes include before/after screenshots or traces — N/A, workflow-only change
- [x] `.thf` changes include migration, round-trip, and backward-compatibility evidence — N/A
- [x] AI mutations validate untrusted input and remain reviewable and undoable — N/A
- [x] No secrets, keys, credentials, or non-canonical lockfile sources

## Agent Preflight

- [x] Author anti-slop review complete — clean
- [x] PR reviewer converged
- [x] Independent slop auditor converged — clean
- [x] Security auditor complete — converged; release credentials remain isolated to hosted runners
- [x] Threat-model expert complete or not applicable — not applicable

## Owner Validation

- [ ] Confirm trusted events and same-repository PRs select `hostinger-vps-01` for eligible Linux CI jobs
- [ ] Confirm a fork PR runs Linux jobs on `ubuntu-latest` and still runs macOS/Windows build entries
- [ ] Confirm the Hostinger Linux AppImage build succeeds with `xdg-utils`
- [ ] Confirm release validation and Linux/macOS/Windows release jobs remain GitHub-hosted

## Screenshots and Artifacts

N/A — workflow-only change.

## Replan and Follow-up Work

- `34764fe` replaces the original skip guards with hosted fork fallbacks after independent review found the coverage regression.
- `05d921f` added `xdg-utils` after the first Hostinger Linux build exposed the missing package.
- `0b8fbd2` restores release jobs to their original hosted selectors so signing secrets and `contents: write` never reach the persistent CI runner.
- `d74cbba` restores `xdg-utils` to the secret-free Docker CI image while leaving release byte-identical to `main`.
