### PR TITLE
chore(deps): bump rand from 0.9 to 0.10 in /src-tauri

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3286,16 +3286,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
@@ -3326,16 +3316,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3351,15 +3331,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -4825,7 +4796,7 @@ dependencies = [
  "futures",
  "http",
  "quick-xml 0.41.0",
- "rand 0.9.2",
+ "rand 0.10.2",
  "reqwest 0.12.28",
  "rmcp",
  "schemars 1.2.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,7 +38,7 @@ uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 reqwest = { version = "0.12", features = ["json", "stream", "rustls-tls"], default-features = false }
 aes-gcm = "0.11"
-rand = "0.9"
+rand = "0.10"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
 futures = "0.3"

--- a/src-tauri/src/ai/keychain.rs
+++ b/src-tauri/src/ai/keychain.rs
@@ -5,7 +5,11 @@ use std::sync::Mutex;
 
 use aes_gcm::aead::{Aead, KeyInit};
 use aes_gcm::{Aes256Gcm, Nonce};
-use rand::RngCore;
+// `Rng` is rand 0.10's name for the byte-source trait that 0.9 called
+// `RngCore`; the old `Rng` extension trait is now `RngExt`. `fill_bytes` keeps
+// its 0.9 semantics, including panicking only if the OS entropy source fails
+// while reseeding `ThreadRng`, which `TryRng` does not avoid either.
+use rand::Rng;
 
 use crate::ai::types::AiProvider;
 use crate::errors::ThreatForgeError;


### PR DESCRIPTION
Supersedes #79, which failed to build because rand 0.10 reorganized its traits.

## The migration

rand 0.10 renames the byte-source trait `RngCore` to `Rng`, and renames the old `Rng` extension trait (`gen_range` and friends) to `RngExt`. The only consumer in this repo is `src-tauri/src/ai/keychain.rs`, which uses `fill_bytes` for the master encryption key and the AES nonce, so the fix is the import.

## Why the crypto behavior is unchanged

`fill_bytes` keeps its 0.9 semantics exactly: for `ThreadRng` it panics only if the OS entropy source fails while reseeding. I checked the vendored 0.10.2 source — `rngs/thread.rs` documents that *both* `Rng` and `TryRng` panic in that case, so switching to the fallible `try_fill_bytes` would not remove the panic path and would only add error plumbing. Key and nonce generation are byte-for-byte the same operation as before.

## Verification

- `cargo test` — 117 lib tests pass, including the key storage encrypt/decrypt round-trips
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)