### PR TITLE
fix(ci): report Playwright run-level errors instead of 'no tests reported'

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,10 +10,13 @@ export default defineConfig({
 	reporter: [
 		["html", { open: "never" }],
 		["list"],
-		// Machine-readable sibling of the HTML report, consumed by
-		// scripts/summarize-playwright.mjs to surface flaky/skipped outcomes in the CI
-		// run summary. Written after the HTML reporter regenerates the folder.
-		["json", { outputFile: "playwright-report/results.json" }],
+		// Machine-readable report consumed by scripts/summarize-playwright.mjs to
+		// surface flaky and skipped outcomes in the CI run summary. It lives under
+		// test-results/ rather than beside the HTML report because the HTML reporter
+		// deletes its own output folder at the start of onEnd, which would make
+		// correctness depend on reporter array order. test-results/ is gitignored and
+		// already uploaded with the HTML report on failure.
+		["json", { outputFile: "test-results/results.json" }],
 	],
 	use: {
 		baseURL: "http://localhost:3000",

--- a/scripts/summarize-playwright.mjs
+++ b/scripts/summarize-playwright.mjs
@@ -15,14 +15,15 @@
 // The report shape is @playwright/test's `JSONReport` (node_modules/playwright/types/
 // testReporter.d.ts). Fields read here: `stats.duration`; `suites[].specs[].tests[].status`
 // ("expected" | "unexpected" | "flaky" | "skipped"); `results[].status` (to separate a
-// timeout from an assertion failure); `results.length` (attempts); and each spec's
-// `title`, `file`, and `line`.
+// timeout from an assertion failure); `results.length` (attempts); each spec's `title`,
+// `file`, and `line`; and top-level `errors`, which is the only signal that a run died
+// before any test could report.
 
 import { appendFileSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const DEFAULT_REPORT_PATH = "playwright-report/results.json";
+const DEFAULT_REPORT_PATH = "test-results/results.json";
 const HEADING = "## Playwright E2E";
 
 /**
@@ -46,6 +47,10 @@ const HEADING = "## Playwright E2E";
  * @property {number} timedOut
  * @property {number} flaky
  * @property {number} skipped
+ * @property {number} other Statuses this script does not know, so counts stay additive
+ *   if a Playwright upgrade widens the union.
+ * @property {number} runErrors Failures that killed the run before any test could report,
+ *   such as a `webServer` that never started or a spec that failed to import.
  * @property {number | null} durationMs
  * @property {TestOutcome[]} flakyTests
  * @property {TestOutcome[]} failedTests Includes timed-out tests.
@@ -133,6 +138,8 @@ export const summarizeReport = (report) => {
 		timedOut: 0,
 		flaky: 0,
 		skipped: 0,
+		other: 0,
+		runErrors: 0,
 		durationMs: null,
 		flakyTests: [],
 		failedTests: [],
@@ -146,6 +153,11 @@ export const summarizeReport = (report) => {
 	if (typeof stats.duration === "number" && Number.isFinite(stats.duration)) {
 		summary.durationMs = stats.duration;
 	}
+
+	// A run that dies before any test executes reports zero tests and a non-empty
+	// `errors`. Counting these is what stops a red job from summarizing as
+	// "No tests were reported."
+	summary.runErrors = toArray(report.errors).length;
 
 	for (const fileSuite of toArray(report.suites)) {
 		if (!isRecord(fileSuite)) {
@@ -167,6 +179,11 @@ export const summarizeReport = (report) => {
 					summary.failed += 1;
 				}
 				summary.failedTests.push(outcome);
+			} else {
+				// A status this script does not know. Counting it keeps the buckets
+				// additive if a Playwright upgrade widens the union, rather than
+				// silently under-reporting the total.
+				summary.other += 1;
 			}
 		}
 	}
@@ -216,16 +233,32 @@ const formatCounts = (summary) => {
 		[summary.timedOut, "timed out"],
 		[summary.flaky, "flaky"],
 		[summary.skipped, "skipped"],
+		[summary.other, "other"],
 	]
 		.filter(([count]) => count > 0)
 		.map(([count, label]) => `${count} ${label}`);
 
 	if (parts.length === 0) {
-		return "No tests were reported.";
+		return summary.runErrors > 0 ? "No tests ran." : "No tests were reported.";
 	}
 
 	const duration = summary.durationMs === null ? "" : ` in ${formatDuration(summary.durationMs)}`;
 	return `${parts.join(", ")}${duration}.`;
+};
+
+/**
+ * The run-level error line. Without it a run that died before any test executed —
+ * a `webServer` that never started, a spec that failed to import — summarizes as
+ * "No tests were reported" on a red job, which is the blind spot this whole
+ * summary exists to close. The messages themselves stay in the HTML report:
+ * they are multi-line stack traces that would swamp the summary.
+ *
+ * @param {number} runErrors
+ * @returns {string}
+ */
+const formatRunErrors = (runErrors) => {
+	const noun = runErrors === 1 ? "error" : "errors";
+	return `⚠️ ${runErrors} run-level ${noun} before any test could report — see the uploaded HTML report.`;
 };
 
 /**
@@ -237,6 +270,10 @@ const formatCounts = (summary) => {
  */
 export const renderSummary = (summary) => {
 	const sections = [HEADING, formatCounts(summary)];
+
+	if (summary.runErrors > 0) {
+		sections.push(formatRunErrors(summary.runErrors));
+	}
 
 	if (summary.flakyTests.length > 0) {
 		sections.push(
@@ -287,12 +324,26 @@ const main = () => {
 		return;
 	}
 
-	let markdown;
+	// Only reading and parsing are guarded: a fault inside summarizeReport or
+	// renderSummary is this script's bug, and reporting it as an unusable report
+	// would blame the file for a code fault.
+	let report;
 	try {
-		markdown = renderSummary(summarizeReport(JSON.parse(readFileSync(reportPath, "utf8"))));
+		report = JSON.parse(readFileSync(reportPath, "utf8"));
 	} catch (error) {
-		markdown = renderUnavailable(reportPath, error);
+		writeSummary(renderUnavailable(reportPath, error));
+		return;
 	}
+
+	writeSummary(renderSummary(summarizeReport(report)));
+};
+
+/**
+ * @param {string} markdown
+ * @returns {void}
+ */
+const writeSummary = (markdown) => {
+	const summaryPath = process.env.GITHUB_STEP_SUMMARY;
 
 	try {
 		if (summaryPath) {

--- a/scripts/summarize-playwright.test.mjs
+++ b/scripts/summarize-playwright.test.mjs
@@ -1,3 +1,7 @@
+// @vitest-environment node
+//
+// This is a Node script, not a DOM module. Pinning the environment keeps the
+// scripts lane independent of the app's jsdom setup.
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -32,10 +36,10 @@ const spec = (title, file, line, status, attempts) => ({
  * @param {number} duration
  * @param {unknown[]} suites
  */
-const report = (duration, suites) => ({
+const report = (duration, suites, errors = []) => ({
 	config: { rootDir: "/repo/e2e" },
 	suites,
-	errors: [],
+	errors,
 	stats: { startTime: "2026-07-21T10:00:00.000Z", duration },
 });
 
@@ -184,9 +188,52 @@ describe("summarizeReport", () => {
 			failed: 0,
 		});
 	});
+
+	it("counts run-level errors that killed the run before any test reported", () => {
+		// A webServer that never starts, or a spec that fails to import, produces
+		// exactly this shape: zero suites and a non-empty errors array.
+		const died = report(
+			1200,
+			[],
+			[{ message: "Process from config.webServer was not able to start. Exit code: 3" }],
+		);
+		expect(summarizeReport(died)).toMatchObject({ passed: 0, failed: 0, runErrors: 1 });
+	});
+
+	it("counts an unknown status so the buckets stay additive", () => {
+		const widened = report(500, [
+			{
+				title: "future.spec.ts",
+				file: "future.spec.ts",
+				specs: [spec("uses a future status", "future.spec.ts", 3, "quarantined", ["passed"])],
+			},
+		]);
+		expect(summarizeReport(widened)).toMatchObject({ passed: 0, other: 1 });
+	});
 });
 
 describe("renderSummary", () => {
+	it("names run-level errors instead of claiming no tests were reported", () => {
+		const died = report(
+			1200,
+			[],
+			[
+				{ message: "Process from config.webServer was not able to start. Exit code: 3" },
+				{ message: "Error: Cannot find module './missing'" },
+			],
+		);
+		const rendered = render(died);
+		// The old wording read as "nothing happened, nothing to see" on a red job.
+		expect(rendered).not.toContain("No tests were reported.");
+		expect(rendered).toContain("No tests ran.");
+		expect(rendered).toContain("2 run-level errors before any test could report");
+	});
+
+	it("uses the singular for one run-level error", () => {
+		const died = report(900, [], [{ message: "boom" }]);
+		expect(render(died)).toContain("1 run-level error before any test could report");
+	});
+
 	it("renders a single counts line when nothing needs attention", () => {
 		expect(render(allPassReport)).toBe(
 			["## Playwright E2E", "", "2 passed, 2 skipped in 1m 23s.", ""].join("\n"),


### PR DESCRIPTION
Follow-up to #151, from its post-merge slop audit.

## The gap

Playwright's JSON report carries a top-level `errors: TestError[]` alongside `suites`. The summarizer ignored it, so a run that died *before any test could execute* rendered as:

```
## Playwright E2E

No tests were reported.
```

…on a red job. Both realistic causes were reproduced: a `webServer` that fails to start (`Process from config.webServer was not able to start. Exit code: 3`) and a spec that fails to import. "No tests were reported" reads as *nothing happened, nothing to see* — precisely the misleading-signal failure mode #138 exists to eliminate.

Now:

```
## Playwright E2E

No tests ran.

⚠️ 1 run-level error before any test could report — see the uploaded HTML report.
```

The error text itself stays in the HTML report; those are multi-line stack traces that would swamp a run summary.

## Also fixed, from the same audit

- **Unknown statuses are counted.** The `status` chain had no final branch, so a status outside the four known values was counted nowhere and the totals silently under-reported. Upgrade-hardening: the union is closed in 1.61.1, but a Playwright bump should not quietly break arithmetic.
- **Internal faults are no longer misattributed.** The `try` wrapped `summarizeReport`/`renderSummary` as well as the read, so a bug in this script reported as `No usable JSON report at <path>` — blaming the file for a code fault. The guard now covers only `readFileSync`/`JSON.parse`.
- **The reporter-ordering dependency is gone.** Correctness previously required `html` to precede `json` in the reporter array, because the HTML reporter `await removeFolders([outputFolder])` at the top of its `onEnd` — a future reorder would silently degrade the summary to "No usable JSON report" with nothing failing. The JSON now writes to `test-results/`, which is gitignored and already uploaded alongside the HTML report on failure.
- **The scripts test pins `@vitest-environment node`**, keeping the scripts lane independent of the app's jsdom setup.

## Verification

- `npx vitest --run scripts/` — 20 pass (4 new: run-level error counting, singular/plural rendering, unknown-status bucketing)
- `npx biome check` — clean
- Verified end-to-end by feeding a real dead-run report through the CLI (output above)
- `JSONReport.errors` confirmed against `node_modules/playwright/types/testReporter.d.ts:253` at the installed 1.61.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)