### PR TITLE
docs: define documentation information architecture

### DIFF
--- a/docs/knowledge/documentation-architecture.md
+++ b/docs/knowledge/documentation-architecture.md
@@ -1,0 +1,429 @@
+# Documentation information architecture
+
+Status: Canonical policy. Last updated: 2026-07-22. Owner: maintainers.
+
+This document is the single canonical information-architecture (IA) and source-of-truth
+policy for ThreatForge documentation. It assigns every existing documentation surface an
+explicit disposition, names one canonical owner for every mutable fact, fixes the GitHub
+Wiki handbook page map and boundaries, defines how shipped behavior is distinguished from
+planned direction and history, and hands issues `#159`, `#160`, `#161`, and `#162`
+measurable contracts and a fixed execution order.
+
+It follows `AGENTS.md` and `.github/instructions/docs.instructions.md`: sentence-case
+headings, ISO `YYYY-MM-DD` dates, canonical sources are linked rather than copied, and
+current behavior is separated from verified evidence, proposals, and history.
+
+## Scope and non-goals
+
+This artifact is a design and policy contract. It does **not**:
+
+- edit, refresh, move, or delete any inventoried document's content (that is `#159`,
+  `#160`, and `#162` work);
+- create handbook pages, `Home.md`, `_Sidebar.md`, or any Wiki content (`#160`, `#161`);
+- add a publishing workflow or touch `.github/workflows/**` (`#161`);
+- change product behavior, the `.thf` schema, or any code under `src/**` or `src-tauri/**`;
+- rewrite `docs/archive/**` or any historical record;
+- mutate GitHub state (labels, project fields, issue bodies, Wiki) or open a pull request.
+
+The implementation adds only this artifact; the required issue plan is a separate planning
+record.
+
+### Planned is never shown as shipped
+
+Per `AGENTS.md` ("Verification is not validation") and
+`.github/instructions/docs.instructions.md`, no document may present planned functionality
+as shipped behavior. Every capability claim is either verified against a named evidence
+source and marked shipped, or explicitly labeled planned with a link to
+`docs/plans/roadmap.md` or a canonical issue. Command results and precision are never
+fabricated. This invariant governs every disposition and downstream contract below.
+
+## How to read this document
+
+Every documentation file receives exactly **one** primary disposition from the closed set
+below, plus zero or more optional flags. A closed vocabulary is what makes coverage
+measurable for `#159`–`#162`.
+
+### Disposition vocabulary (closed set)
+
+| Disposition | Definition | Lifecycle rule |
+|-------------|------------|----------------|
+| `repository-canonical` | The authoritative source for its facts, versioned in this repository. | Edited only through pull request; other surfaces link to it and never copy its mutable facts. |
+| `wiki-facing-source` | Repository-versioned source for a user-facing handbook page, authored under `docs/wiki/`. | Reviewed via pull request in the repo; published to the GitHub Wiki by `#161`. The published Wiki is a mirror, never an independent source. |
+| `historical` | A read-only record of a past decision or execution. | Never rewritten to read as current state; preserved verbatim. |
+| `generated` | Derived from a canonical source (an adapter pointer or a build/publish output). | Never hand-edited as truth; regenerated from its canonical source. |
+| `superseded` | Replaced by a newer canonical source but retained for traceability. | Marked with its replacement; not treated as current. No file currently holds this disposition; it exists so future replacements are labeled rather than silently deleted. |
+| `internal-strategy` | Repository-canonical internal strategy or planning knowledge that is not user-facing and is not authoritative for shipped behavior. | Edited through pull request; never published to the user handbook and never cited as a capability source. |
+
+### Optional flags
+
+| Flag | Meaning |
+|------|---------|
+| `verify` | At least one claim in the file must be checked against code, tests, CI, or config before it is republished or cited. |
+| `contains-planned` | The file mixes shipped and future material; the future material must stay explicitly labeled (see "shipped vs planned vs history"). |
+| `transitional` | Canonical today, but slated to change role or destination via a named downstream issue. |
+
+## Documentation inventory and classification
+
+Verified by directory inspection on 2026-07-22 (`find docs -name '*.md'`, root `*.md`,
+`.github`). Every root and `docs/**` Markdown document that currently exists is classified
+below, including this artifact and the `#158` plan. Volatile counts (line counts, exact
+provider lists, test totals) are intentionally omitted here per the source-of-truth rule.
+
+### Root governance, legal, and engineering contracts
+
+| Path | Audience | Disposition | Flags | Canonical owner | Downstream issue |
+|------|----------|-------------|-------|-----------------|------------------|
+| `README.md` | Users + contributors | `repository-canonical` | `transitional` (→ identity + navigation landing) | Maintainers | `#162` |
+| `CONTRIBUTING.md` | Contributors | `repository-canonical` | — | Maintainers | — (stays in repo; `#144` non-goal to move) |
+| `SECURITY.md` | Users + researchers | `repository-canonical` | — | Maintainers | — (canonical security-policy source) |
+| `CODE_OF_CONDUCT.md` | Community | `repository-canonical` | — | Maintainers | — |
+| `LICENSE` | All | `repository-canonical` (legal, static) | — | Exit Zero Labs LLC | — |
+| `NOTICE` | All | `repository-canonical` (legal, static) | — | Exit Zero Labs LLC | — |
+| `AGENTS.md` | Agents + contributors | `repository-canonical` (engineering-process source of truth) | — | Maintainers | `#159` may add a pointer to this IA after owner validation |
+| `CLAUDE.md` | Claude agent | `generated` (adapter pointer to `AGENTS.md`) | — | Maintainers | — |
+
+`LICENSE` and `NOTICE` are not Markdown and fall outside the deterministic Markdown
+coverage check, but are recorded here for completeness of ownership.
+
+### `.github` adapters, instructions, and templates
+
+| Path | Audience | Disposition | Flags | Canonical owner | Downstream issue |
+|------|----------|-------------|-------|-----------------|------------------|
+| `.github/copilot-instructions.md` | Copilot agent | `generated` (adapter pointer to `AGENTS.md` + `.github/instructions/**`) | — | Maintainers | — |
+| `.github/instructions/**` (e.g. `.github/instructions/docs.instructions.md`) | Agents + contributors | `repository-canonical` (path-specific rules) | — | Maintainers | — |
+| `.github/PULL_REQUEST_TEMPLATE.md` | Contributors | `repository-canonical` (template) | — | Maintainers | — |
+| `.github/ISSUE_TEMPLATE/**` | Contributors | `repository-canonical` (templates) | — | Maintainers | — |
+| `.github/agents/**`, `.github/skills/**` | Agents | `repository-canonical` (agent/skill definitions) | — | Maintainers | — |
+| `.claude/**` adapters (`.claude/rules/**`, `.claude/agents`, `.claude/skills`) | Claude agent | `generated` (thin pointers; canonical = `AGENTS.md` + `.github/instructions/**`) | — | Maintainers | — |
+
+The canonical engineering source is `AGENTS.md` plus `.github/instructions/**`. `CLAUDE.md`,
+`.github/copilot-instructions.md`, and `.claude/**` are `generated` adapters that must remain
+thin pointers and never redefine policy.
+
+### `docs/knowledge/` — product and engineering knowledge
+
+| Path | Audience | Disposition | Flags | Canonical owner | Downstream issue |
+|------|----------|-------------|-------|-----------------|------------------|
+| `docs/knowledge/architecture.md` | Contributors | `repository-canonical` (architecture contract, named in `AGENTS.md`) | — | Maintainers | `#159` refresh; handbook links, never copies |
+| `docs/knowledge/file-format.md` | Contributors | `repository-canonical` (sole `.thf` contract, named in `AGENTS.md`) | — | Maintainers | `#159` refresh; handbook `.thf concepts` links only |
+| `docs/knowledge/glossary.md` | Users + contributors | `repository-canonical` (glossary terms source) | — | Maintainers | `#160` links/derives, does not fork |
+| `docs/knowledge/overview.md` | Users | `repository-canonical` (current product overview) | `verify`, `contains-planned`, `transitional` (→ handbook input, then a non-duplicative repository pointer) | Maintainers | `#159` verifies/removes duplicate claims; `#160` uses as handbook input |
+| `docs/knowledge/product-design.md` | Internal | `internal-strategy` | `verify`, `contains-planned` | Maintainers | `#159` verifies current claims and labels future material |
+| `docs/knowledge/go-to-market.md` | Internal | `internal-strategy` | — | Maintainers | — |
+| `docs/knowledge/market-analysis.md` | Internal | `internal-strategy` | `verify` | Maintainers | `#159` verifies market and capability claims |
+| `docs/knowledge/risks.md` | Internal | `internal-strategy` | `verify` | Maintainers | `#159` verifies current technical claims |
+| `docs/knowledge/mcp-server.md` | Contributors | `repository-canonical` | `verify` | Maintainers | `#159` refresh against `src-tauri/src/mcp/**` |
+| `docs/knowledge/documentation-architecture.md` | Contributors | `repository-canonical` (this IA and source-of-truth policy) | — | Maintainers | referenced by `#159`–`#162` |
+
+`docs/knowledge/mcp-server.md` documents **shipped** behavior, not a proposal: the MCP
+server is present in code and tests (`src-tauri/src/mcp/server.rs`,
+`src-tauri/src/bin/threatforge-mcp.rs`, `src-tauri/tests/mcp_stdio.rs`, and
+`rmcp = { version = "2.2", ... }` in `src-tauri/Cargo.toml`, verified 2026-07-22). Its
+`verify` flag means `#159` re-checks the described surface against that code.
+
+No current file is a `wiki-facing-source`: `docs/wiki/` does not exist until `#160` creates
+it. `overview.md` and `glossary.md` are repository-canonical inputs to that work, not handbook
+sources themselves.
+
+The `internal-strategy` set (`product-design`, `go-to-market`, `market-analysis`, `risks`)
+is repository-canonical but never user-facing or authoritative for shipped behavior.
+`internal-strategy` is distinct from `repository-canonical` precisely so these files are not
+mistaken for handbook or capability sources; its `verify` flags identify existing claims
+that `#159` must reconcile.
+
+### `docs/quality/` — quality doctrine
+
+| Path | Audience | Disposition | Flags | Canonical owner | Downstream issue |
+|------|----------|-------------|-------|-----------------|------------------|
+| `docs/quality/agentic-slop.md` | Agents + contributors | `repository-canonical` (doctrine, named in `AGENTS.md`) | — | Maintainers | — |
+| `docs/quality/ai-output-quality.md` | Agents + contributors | `repository-canonical` (method, named in `AGENTS.md`) | `contains-planned` (explicitly "not a production gate yet") | Maintainers | `#159` keeps forward-looking scope labeled |
+
+### `docs/runbooks/` — operational runbooks
+
+All runbooks are `repository-canonical` operational sources owned by maintainers.
+
+| Path | Disposition | Flags |
+|------|-------------|-------|
+| `docs/runbooks/adding-a-feature.md` | `repository-canonical` | — |
+| `docs/runbooks/configuring-release-signing.md` | `repository-canonical` | `contains-planned` (mixes shipped setup and remaining owner/implementation work) |
+| `docs/runbooks/debugging-tauri-ipc.md` | `repository-canonical` | — |
+| `docs/runbooks/deploying-the-website.md` | `repository-canonical` | — |
+| `docs/runbooks/diagnosing-ci-failures.md` | `repository-canonical` | — |
+| `docs/runbooks/onboarding-a-contributor.md` | `repository-canonical` | — |
+| `docs/runbooks/releasing-a-version.md` | `repository-canonical` | — |
+| `docs/runbooks/responding-to-issues.md` | `repository-canonical` | — |
+| `docs/runbooks/schema-migration.md` | `repository-canonical` | — |
+
+### `docs/plans/` — planning system
+
+`docs/plans/roadmap.md` is `repository-canonical` and the **canonical future-direction
+source**. `docs/plans/0000-template.md` and `docs/plans/README.md` are the
+`repository-canonical` plan contract and planning index. Issue-specific
+`<issue>-<slug>.md` plans are `repository-canonical` planning records: they append replan
+history and are execution contracts, never presented as shipped state or used to infer live
+issue status.
+
+| Path | Disposition | Flags |
+|------|-------------|-------|
+| `docs/plans/roadmap.md` | `repository-canonical` (canonical future direction) | — |
+| `docs/plans/0000-template.md` | `repository-canonical` (plan contract) | — |
+| `docs/plans/README.md` | `repository-canonical` (planning index) | — |
+| `docs/plans/53-document-registry.md` | `repository-canonical` (issue plan) | — |
+| `docs/plans/54-multi-tab-workspace.md` | `repository-canonical` (issue plan) | — |
+| `docs/plans/56-indexeddb-persistence.md` | `repository-canonical` (issue plan) | — |
+| `docs/plans/57-architecture-model.md` | `repository-canonical` (issue plan) | — |
+| `docs/plans/58-panel-information-architecture.md` | `repository-canonical` (issue plan) | — |
+| `docs/plans/59-component-icon-registry.md` | `repository-canonical` (issue plan) | — |
+| `docs/plans/61-ai-conversation-protocol.md` | `repository-canonical` (issue plan) | — |
+| `docs/plans/62-bounded-tool-loop.md` | `repository-canonical` (issue plan) | — |
+| `docs/plans/70-cross-agent-ai-harness.md` | `repository-canonical` (issue plan) | — |
+| `docs/plans/93-toolchain-upgrades.md` | `repository-canonical` (issue plan) | — |
+| `docs/plans/111-ci-reliability.md` | `repository-canonical` (issue plan) | — |
+| `docs/plans/116-browser-thf-validation.md` | `repository-canonical` (issue plan) | — |
+| `docs/plans/158-documentation-information-architecture.md` | `repository-canonical` (issue plan for this issue) | — |
+
+### `docs/archive/` — historical records
+
+All archived plans are `historical` and read-only. `docs/archive/plans/001.md` opens with
+"Historical execution record. Do not use as an active planning source." They are never
+rewritten to read as current state.
+
+| Path | Disposition |
+|------|-------------|
+| `docs/archive/plans/001.md` | `historical` |
+| `docs/archive/plans/002.md` | `historical` |
+| `docs/archive/plans/003.md` | `historical` |
+| `docs/archive/plans/004.md` | `historical` |
+| `docs/archive/plans/005.md` | `historical` |
+| `docs/archive/plans/006.md` | `historical` |
+| `docs/archive/plans/007.md` | `historical` |
+| `docs/archive/plans/008.md` | `historical` |
+
+### Generated non-documentation output (out of IA scope)
+
+`dist/`, `playwright-report/`, `test-results/`, and `screenshots/` are `generated` build and
+test output. They are explicitly out of the documentation IA scope and are never hand-edited
+as truth.
+
+## One source of truth and ownership
+
+The target architecture assigns each class of mutable fact exactly one canonical location
+and owner. Every other surface **links** to that source; it never copies the mutable fact.
+Existing transitional exceptions are named below. This is the anti-duplication rule that
+`#144` requires to end stale, contradictory claims.
+
+| Fact class | Single canonical source | Owner |
+|------------|-------------------------|-------|
+| Live task status, priority, size, ownership, dependencies | GitHub Project 2 (never in docs) | Maintainers |
+| Product direction and sequencing | `docs/plans/roadmap.md` | Maintainers |
+| Architecture contract | `docs/knowledge/architecture.md` | Maintainers |
+| `.thf` schema and format contract | `docs/knowledge/file-format.md` | Maintainers |
+| Engineering process and code conventions | `AGENTS.md` | Maintainers |
+| Path-specific engineering rules | `.github/instructions/**` | Maintainers |
+| Quality doctrine and AI-output-quality method | `docs/quality/agentic-slop.md`, `docs/quality/ai-output-quality.md` | Maintainers |
+| Security policy and vulnerability reporting | `SECURITY.md` | Maintainers |
+| Contribution process | `CONTRIBUTING.md` | Maintainers |
+| Community conduct | `CODE_OF_CONDUCT.md` | Maintainers |
+| Glossary terms | `docs/knowledge/glossary.md` | Maintainers |
+| Target user-facing capability descriptions | The single handbook page for that topic under `docs/wiki/` after `#160`, each claim verified against code/tests | Maintainers |
+| Planning contract and index | `docs/plans/0000-template.md`, `docs/plans/README.md` | Maintainers |
+| Historical execution records | `docs/archive/**` (read-only) and issue-plan replan logs | Maintainers |
+| Legal | `LICENSE`, `NOTICE` | Exit Zero Labs LLC |
+
+### Volatile-facts rule
+
+Volatile numeric or enumerated facts — test counts, exact AI provider lists, release or
+version status, "N themes", supported-platform matrices — are **not** duplicated in prose.
+They are either derived or generated from their source, cited to a specific code or CI
+evidence location, or omitted. Duplicating such facts in prose is the primary cause of the
+stale-claim drift `#144` names, so it is prohibited across all surfaces including `README.md`
+and every handbook page.
+
+Until `#159`, `#160`, and `#162` resolve the existing README/overview duplication, those
+files remain explicitly `transitional`; no new duplicate capability claims may be added
+during the transition.
+
+### Anti-duplication rule
+
+`README.md` and handbook pages describe and orient; they link to the canonical source above
+for any mutable fact. Restating a mutable fact that a canonical source owns is a defect that
+`#159` and `#162` must remove.
+
+## Wiki handbook architecture
+
+The user-facing handbook is authored and reviewed **in the repository** at `docs/wiki/`
+(`wiki-facing-source`) and published to the GitHub Wiki by `#161`. The published Wiki is a
+`generated` mirror: manual Wiki edits are non-canonical and are overwritten by the next
+publication. `docs/wiki/` does not exist yet; `#160` creates it against this contract.
+
+The owner selected `docs/wiki/` as the version-controlled handbook source on 2026-07-22
+(recorded in the `#158` plan). This keeps user-facing source separate from the
+`docs/knowledge/` engineering contracts while making the publication target explicit.
+
+### Page map
+
+The page map covers a new user's journey: installation → first model → threat analysis →
+optional AI → import/export → troubleshooting. Source slugs are kebab-case and map
+deterministically to Wiki page names; titles and headings are sentence-case.
+
+| Wiki page | Source slug (`docs/wiki/`) | Purpose |
+|-----------|---------------------------|---------|
+| `Home` | `Home.md` | Landing and orientation; entry to the whole handbook. |
+| `Installation` | `installation.md` | Desktop install per platform **and** browser access, both intentional. |
+| `Getting started` | `getting-started.md` | First run; create and open a model. |
+| `Core modeling workflows` | `core-modeling-workflows.md` | Canvas, components, relationships, data flows. |
+| `STRIDE threat analysis` | `stride-threat-analysis.md` | Running and reading STRIDE analysis. |
+| `AI-assisted analysis (BYOK)` | `ai-assisted-analysis-byok.md` | Optional, direct-to-provider, local encrypted keys, untrusted-output safety; no account or hosted backend. |
+| `Import and export` | `import-and-export.md` | TMT import, `.thf` export and download. |
+| `.thf concepts` | `thf-concepts.md` | User-facing conceptual overview linking to canonical `docs/knowledge/file-format.md`; never restates schema rules. |
+| `Troubleshooting` | `troubleshooting.md` | Common failures and recovery. |
+| `Glossary` | `glossary.md` | Sourced from `docs/knowledge/glossary.md`; links or derives, never forks. |
+
+### Navigation, naming, and footer
+
+- `_Sidebar.md` fixes deterministic navigation order: `Home` → `Installation` →
+  `Getting started` → `Core modeling workflows` → `STRIDE threat analysis` →
+  `AI-assisted analysis (BYOK)` → `Import and export` → `.thf concepts` →
+  `Troubleshooting` → `Glossary`.
+- `_Footer.md` holds a stable footer (project identity and license/security links).
+- GitHub Wiki reserves `Home.md`, `_Sidebar.md`, and `_Footer.md`; those names are used
+  verbatim. All other pages use stable kebab-case slugs so links do not rot.
+- Headings are sentence-case and dates are ISO `YYYY-MM-DD`, per
+  `.github/instructions/docs.instructions.md`.
+
+### Canonical-vs-Wiki ownership boundary
+
+Handbook pages describe **verified current behavior** and link to repository-canonical
+architecture, schema, security, roadmap, and contribution contracts for engineering detail.
+They never restate mutable engineering facts, never require a ThreatForge account, and never
+imply a hosted backend. The AI page describes optionality, direct-to-provider requests, local
+encrypted keys, and untrusted-output validation, consistent with the `AGENTS.md` product
+invariants. Both the desktop app and the browser build are covered as deliberate surfaces.
+
+## Shipped vs planned vs history labeling
+
+Every page must make it implausible to mistake planned functionality for shipped behavior.
+
+- **Shipped:** a capability statement is verified against a named evidence source — a code
+  path, a test, a CI job, or a config entry — and marked shipped. Example marker:
+  `Status: Shipped` (optionally with the evidence path).
+- **Planned:** future behavior is explicitly labeled and linked to `docs/plans/roadmap.md`
+  or a canonical issue. Example marker: `Status: Planned (#NNN)`. Blending shipped and
+  planned material without a label is prohibited.
+- **Verified evidence:** evidence is cited, not asserted; command results are never
+  fabricated (`.github/instructions/docs.instructions.md`).
+- **Proposal:** unresolved or exploratory material is marked as a proposal and is not read as
+  a commitment.
+- **History:** historical records live only in `docs/archive/**` and issue-plan replan logs;
+  history is never rewritten to read as current state.
+
+The marker convention is a lightweight status line or callout (for example
+`Status: Shipped` / `Status: Planned (#NNN)`) that renders identically in repository Markdown
+and in the published Wiki, so the shipped-vs-planned distinction survives publication. Files
+flagged `contains-planned` (`docs/knowledge/overview.md`,
+`docs/knowledge/product-design.md`,
+`docs/quality/ai-output-quality.md`, and
+`docs/runbooks/configuring-release-signing.md`) must keep their future material labeled this
+way.
+
+## Downstream contracts and sequencing for #159–#162
+
+Each child issue receives measurable inputs, deliverables, and a completion signal so a
+separate implementer can execute it without rediscovering this IA.
+
+### #159 — Canonical repository docs refresh
+
+- **Inputs:** this IA's inventory, source-of-truth map, and labeling convention.
+- **Deliverables:** every `repository-canonical` and `internal-strategy` document's
+  current-behavior claims verified against evidence; all `verify` flags resolved for
+  `docs/knowledge/overview.md`, `product-design.md`, `market-analysis.md`, `risks.md`, and
+  `mcp-server.md` (against `src-tauri/src/mcp/**`); every `contains-planned` file confirmed to
+  keep future material explicitly labeled (`docs/knowledge/overview.md`, `product-design.md`,
+  `docs/quality/ai-output-quality.md`, and
+  `docs/runbooks/configuring-release-signing.md`); duplicated mutable facts removed in favor
+  of canonical links; internal links resolve;
+  `docs/knowledge/architecture.md` and `docs/knowledge/file-format.md` retain their canonical
+  roles; issue plans keep replan history; archives untouched. May add a pointer to this IA
+  doc from `AGENTS.md` or docs indexes if the owner approves (deferred from `#158`).
+- **Completion signal:** every `verify` row is resolved, every `contains-planned` row retains
+  explicit future labeling, and no mutable fact is duplicated across surfaces.
+
+### #160 — Handbook authoring
+
+- **Inputs:** the page map, the `docs/wiki/` source location, the naming convention, the
+  `_Sidebar.md` order, and the boundary rules above.
+- **Deliverables:** each mapped page authored under `docs/wiki/` with verified current
+  behavior, planned content isolated and labeled, a `Home` page and deterministic
+  `_Sidebar.md`, no account or hosted-backend implication, both desktop and browser covered,
+  renders locally, and links to repository-canonical contracts instead of copying them.
+- **Completion signal:** a new user can complete the full install → first model → threat
+  analysis → optional AI → import/export → troubleshooting journey entirely from the
+  handbook.
+
+### #161 — Wiki publishing
+
+- **Inputs:** settled `docs/wiki/` content and this page map, plus the owner's one-time first
+  Wiki page creation (a HITL prerequisite, not resolved by `#158`).
+- **Deliverables:** a least-privilege workflow that publishes `docs/wiki/` to the GitHub Wiki
+  with SHA-pinned actions, trusted-`main`-only execution, deterministic `Home`, `_Sidebar`,
+  and asset ordering, visible failure, and a traceable Wiki commit. No manual Wiki source of
+  truth remains.
+- **Completion signal:** the published Wiki is a reproducible mirror of `docs/wiki/` from
+  trusted `main` content, with no hand-authored Wiki pages.
+
+### #162 — README landing and link repair
+
+- **Inputs:** the final canonical destinations settled by `#159`, `#160`, and `#161`.
+- **Deliverables:** `README.md` trimmed to product identity, verified highlights, a minimal
+  quick start, security and contribution entry points, and navigation; user-facing links
+  point to the Wiki, engineering links point to repository-canonical sources; deterministic
+  Markdown link validation is added; archived and historical docs are not rewritten.
+- **Completion signal:** deterministic link validation passes and no mutable fact is
+  duplicated between `README.md` and its canonical sources.
+
+### Sequencing (from #144)
+
+`#158` → (`#159` in parallel with `#160`) → `#161` (only after `#160` **and** the owner's
+first Wiki page) → `#162` (after `#159`, `#160`, and `#161` settle destinations).
+
+## Acceptance criteria coverage
+
+| `#158` acceptance criterion | Satisfying section |
+|-----------------------------|--------------------|
+| Complete inventory and classification of every root and `docs/**` Markdown document | "Documentation inventory and classification" |
+| Closed disposition vocabulary | "How to read this document" |
+| One source of truth and ownership matrix | "One source of truth and ownership" |
+| Deterministic Wiki page map, navigation, naming, and boundaries with `docs/wiki/` as canonical source and the published Wiki as generated mirror | "Wiki handbook architecture" |
+| Shipped vs verified vs planned vs proposal vs history labeling convention | "Shipped vs planned vs history labeling" |
+| Measurable downstream contracts and sequencing for `#159`–`#162` | "Downstream contracts and sequencing for #159–#162" |
+
+## Constraints and validation guidance
+
+- **Security and privacy:** no secrets, keys, or tokens appear in documentation. `SECURITY.md`
+  remains the canonical security-policy source. Handbook pages describe, never weaken, the
+  BYOK, key-locality, and untrusted-AI-output invariants in `AGENTS.md`. The `#161` publishing
+  contract records least-privilege, SHA-pinned, trusted-branch, fail-visible constraints; it
+  is not implemented here.
+- **`.thf` compatibility:** no schema or format change. `docs/knowledge/file-format.md` is the
+  sole canonical `.thf` contract; the handbook `.thf concepts` page links to it and must not
+  restate schema rules.
+- **Browser and desktop:** handbook installation and getting-started pages cover both the
+  desktop app and the browser build as deliberate surfaces, per `AGENTS.md`.
+- **Accessibility and UX:** a deterministic `_Sidebar.md` order and stable slugs keep
+  navigation predictable; sentence-case headings and ISO dates apply everywhere.
+- **Evidence:** every current-behavior claim in downstream docs must cite a verifiable
+  evidence source; the labeling convention forbids fabricated results.
+
+Deterministic verification for this artifact is inventory-coverage and internal-content
+checks (Biome does not lint Markdown, and no link checker exists yet — that arrives with
+`#162`). Owner validation must still confirm the judgment calls: the `internal-strategy` set
+(`product-design`, `go-to-market`, `market-analysis`, `risks`), the transition treatment for
+`overview` and `glossary`, every `verify` and `contains-planned` flag, the
+completeness of the page map for the target journey, and that the labeling convention makes
+planned-as-shipped reading implausible.
+
+## Replan log
+
+| Date | Change | Evidence and reason |
+|------|--------|---------------------|
+| 2026-07-22 | Initial IA | Issue `#158` plus repository evidence (`find docs -name '*.md'`, root `*.md`, `.github`, and code evidence for the MCP server). |

--- a/docs/plans/158-documentation-information-architecture.md
+++ b/docs/plans/158-documentation-information-architecture.md
@@ -1,0 +1,492 @@
+# Issue 158 — Define the documentation information architecture
+
+## Objective
+
+Produce one reviewed, committed documentation information-architecture (IA) and
+source-of-truth policy that:
+
+- assigns every existing documentation collection and document an explicit disposition,
+- names a single canonical owner for every mutable fact,
+- specifies the GitHub Wiki handbook page map, deterministic navigation, naming, and
+  ownership boundaries,
+- defines how shipped behavior, verified evidence, future direction, proposals, and history
+  are distinguished, and
+- hands #159, #160, #161, and #162 measurable contracts and a fixed sequencing order.
+
+The deliverable is a design/policy artifact. It does not refresh canonical docs (#159),
+author handbook content (#160), publish the Wiki (#161), or rewrite the README (#162).
+
+## Issue contract
+
+- **Issue:** `#158`
+- **Parent initiative:** `#144`
+- **Type:** `Task`
+- **Size:** `M`
+- **Priority:** `P1`
+- **Autonomy:** `Automatable`
+- **Dependencies:** None. Blocks `#159` and `#160` (which transitively gate `#161`, `#162`).
+- **Non-goals:**
+  - Editing, refreshing, moving, or deleting any inventoried document's content (that is
+    #159/#160/#162 work). This plan's implementation adds the IA policy artifact only.
+  - Creating handbook pages, `Home.md`, `_Sidebar.md`, or any Wiki content.
+  - Adding a publishing workflow or touching `.github/workflows/**`.
+  - Changing product behavior, the `.thf` schema, or any code under `src/**`, `src-tauri/**`.
+  - Rewriting `docs/archive/**` or any historical record.
+  - Mutating GitHub state (labels, project fields, issue bodies, Wiki) or creating a PR.
+  - Resolving the owner's one-time Wiki first-page creation (a `#161` HITL prerequisite).
+
+## Current behavior and evidence
+
+### Documentation surfaces that exist today
+
+Verified by directory inspection on 2026-07-22 (`find docs -type f`, root `*.md`,
+`.github/*.md`).
+
+Root governance and legal:
+
+- `README.md` (261 lines) — product intro plus duplicated feature list, file-format
+  example, getting-started, tech stack, architecture summary, security, contributing.
+- `CONTRIBUTING.md` (190), `SECURITY.md` (72), `CODE_OF_CONDUCT.md` (56).
+- `LICENSE`, `NOTICE` (Apache-2.0, Exit Zero Labs LLC).
+- `AGENTS.md` (261) — canonical cross-agent engineering contract.
+- `CLAUDE.md` (10), `.github/copilot-instructions.md` (8) — thin adapters that point to
+  `AGENTS.md`; `.github/instructions/**` holds path-specific rules; `.claude/**` mirrors.
+- `.github/PULL_REQUEST_TEMPLATE.md`, `.github/ISSUE_TEMPLATE/**` (referenced by archive
+  history; templates).
+
+`docs/knowledge/` (product/engineering knowledge):
+
+- `architecture.md` (292) — canonical architecture entry point (named in `AGENTS.md`).
+- `file-format.md` (352) — canonical `.thf` contract (named in `AGENTS.md`).
+- `glossary.md` (51) — term definitions and references.
+- `overview.md` (55) — product overview / "what it is".
+- `product-design.md` (103) — personas and product design.
+- `go-to-market.md` (84), `market-analysis.md` (66), `risks.md` (58) — internal strategy.
+- `mcp-server.md` (155) — MCP server docs. Verified as **present in code**
+  (`src-tauri/src/mcp/server.rs`, `src-tauri/src/bin/threatforge-mcp.rs`,
+  `src-tauri/tests/mcp_stdio.rs`, `rmcp = "2.2"` in `src-tauri/Cargo.toml`), so it
+  documents shipped behavior, not a proposal.
+
+`docs/quality/`:
+
+- `agentic-slop.md` (105) — quality doctrine referenced by `AGENTS.md`.
+- `ai-output-quality.md` (83) — AI output quality method (explicitly "not a production gate
+  yet"; forward-looking scope must stay labeled).
+
+`docs/runbooks/` (operational, all currently repository-canonical):
+
+- `adding-a-feature.md` (100), `configuring-release-signing.md` (572, preserves remaining
+  owner/implementation work — mixes shipped and planned, must stay labeled),
+  `debugging-tauri-ipc.md` (175), `deploying-the-website.md` (86),
+  `diagnosing-ci-failures.md` (384), `onboarding-a-contributor.md` (107),
+  `releasing-a-version.md` (150), `responding-to-issues.md` (120),
+  `schema-migration.md` (132).
+
+`docs/plans/` (planning system):
+
+- `0000-template.md` (plan contract), `README.md` (planning index),
+  `roadmap.md` (canonical strategic direction, named in `AGENTS.md`), and active
+  `<issue>-<slug>.md` plans (`53`, `54`, `56`, `57`, `58`, `59`, `61`, `62`, `70`, `93`,
+  `111`, `116`). Active plans append replan history and are not shipped-state docs.
+
+`docs/archive/plans/` (`001.md`–`008.md`) — read-only historical execution records
+(`001.md` opens with "Historical execution record. Do not use as an active planning
+source.").
+
+Non-documentation generated output present in the tree but out of scope: `dist/`,
+`playwright-report/`, `test-results/`, `screenshots/`.
+
+### Governing rules already in force
+
+- `AGENTS.md` fixes the canonical roles of `docs/knowledge/architecture.md`,
+  `docs/knowledge/file-format.md`, `docs/plans/roadmap.md`, `docs/quality/agentic-slop.md`,
+  and `docs/quality/ai-output-quality.md`, and makes GitHub Project 2 the sole live task
+  tracker.
+- `.github/instructions/docs.instructions.md` requires sentence-case headings, ISO dates,
+  pointing to canonical sources instead of duplicating mutable facts, read-only
+  `docs/archive/`, distinguishing current/verified/proposed/unresolved, and appended replan
+  history.
+- Parent `#144` fixes the hybrid strategy and the execution order:
+  `#158` → (`#159`, `#160`) → `#161` (after `#160` and the owner's first Wiki page) →
+  `#162`.
+
+### Toolchain evidence relevant to verification
+
+- `package.json` scripts: `check` (`biome check .`), `test`, `test:e2e`, `ci:local`
+  (`bash scripts/ci-local.sh`). No Markdown linter or link checker exists today
+  (`grep` for `markdown|remark|lint-md|link|vale|cspell` finds only `react-markdown` and
+  `remark-gfm` runtime deps). Deterministic link validation is therefore introduced later
+  by `#162`, not required here; this plan's verification is inventory-coverage and
+  internal-link checks over the single new artifact.
+- Biome does not lint Markdown, so the new `.md` artifact is verified by targeted `grep`
+  coverage checks and manual review, not `npm run check`.
+
+## Design decisions resolved from repository evidence
+
+These remove avoidable ambiguity for the implementer. Each is derived from existing
+structure or an explicit owner decision recorded below.
+
+1. **Artifact location.** The IA/source-of-truth policy is a durable, code-coupled
+   governance contract, so it is repository-canonical and lives at
+   `docs/knowledge/documentation-architecture.md`. Rationale: `docs/knowledge/` already
+   holds the canonical `architecture.md` and `file-format.md` contracts that `AGENTS.md`
+   names; the documentation IA is the same class of durable contract and belongs beside
+   them. It is not placed under `docs/plans/` (those are per-issue execution plans) or at
+   repo root (root is being slimmed by `#162`).
+2. **Handbook source-of-truth location (contract handed to #160/#161).** Handbook pages are
+   authored and reviewed in the repository at `docs/wiki/` and published to the Wiki by
+   `#161`; the Wiki is a generated mirror, never an independent source. Rationale: `#144`
+   and `#160` require "version-controlled" handbook source reviewed via pull requests, and
+   `#161` publishes "from trusted `main` content". A dedicated `docs/wiki/` directory keeps
+   user-facing source separate from `docs/knowledge/` engineering contracts while making
+   its publication target explicit. The owner selected this location on 2026-07-22.
+3. **Wiki naming/navigation.** GitHub Wiki reserves `Home.md`, `_Sidebar.md`, `_Footer.md`.
+   Handbook source files use kebab-case slugs that map deterministically to Wiki page names,
+   and `_Sidebar.md` fixes navigation order. This matches `.github/instructions/docs.instructions.md`
+   (sentence-case headings) and the `#161` requirement for deterministic ordering.
+4. **No AGENTS.md / README edits in this issue.** Adding pointers to the new IA doc from
+   `AGENTS.md` or `README.md` is deferred to `#159`/`#162` to avoid editing canonical
+   contracts inside an IA-definition issue. This plan records that as a downstream contract,
+   not a step here.
+5. **Disposition vocabulary is closed.** Every document receives exactly one primary
+   disposition from a fixed set (below), plus optional flags (`verify`, `contains-planned`,
+   `transitional`). A closed vocabulary is what makes coverage measurable for `#159`–`#162`.
+
+## Implementation steps
+
+Each step is XS/S-sized. The implementer produces one new Markdown artifact,
+`docs/knowledge/documentation-architecture.md`, built section by section. No other file is
+edited.
+
+### 1. Scaffold the canonical IA artifact
+
+- **Behavior:** Create `docs/knowledge/documentation-architecture.md` with sentence-case
+  headings, an ISO-dated status line, a scope statement, and a "how to read this document"
+  legend defining the closed disposition vocabulary and the optional flags.
+- **Files:** `docs/knowledge/documentation-architecture.md` (new).
+- **Implementation:**
+  - Define the disposition set exactly: `repository-canonical`, `wiki-facing-source`,
+    `historical`, `generated`, `superseded`, `internal-strategy`. Give each a one-line
+    definition and the rule that governs its lifecycle (e.g. `historical` = read-only,
+    never rewritten to look current; `generated` = derived from a canonical source, never
+    hand-edited as truth).
+  - Define optional flags: `verify` (claim must be checked against code/tests/CI/config
+    before publication), `contains-planned` (mixes shipped and future; requires explicit
+    labeling), `transitional` (canonical today, slated to change destination via a named
+    downstream issue).
+  - State the non-goals and the "planned is never shown as shipped" invariant up front,
+    citing `AGENTS.md` and `.github/instructions/docs.instructions.md`.
+- **Targeted verification:**
+  `test -f docs/knowledge/documentation-architecture.md &&
+   grep -nE "repository-canonical|wiki-facing-source|historical|generated|superseded|internal-strategy"
+   docs/knowledge/documentation-architecture.md`
+  must list all six dispositions.
+- **Intent validation:** Owner confirms the vocabulary is complete and unambiguous and that
+  `internal-strategy` versus `repository-canonical` is a meaningful distinction for the
+  `docs/knowledge/*` strategy files.
+
+### 2. Write the full inventory and classification table
+
+- **Behavior:** A single table (or grouped tables per collection) listing **every** file
+  from the "Current behavior and evidence" inventory with its path, audience, primary
+  disposition, flags, canonical owner, and the downstream issue that acts on it.
+- **Files:** `docs/knowledge/documentation-architecture.md`.
+- **Implementation:** Populate with at least these rows (dispositions resolved from
+  evidence; the implementer re-verifies each before committing):
+  - `README.md` → `repository-canonical`, `transitional` (→ landing page via `#162`),
+    owner: maintainers.
+  - `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md` → `repository-canonical`
+    governance, owner: maintainers; must not move to Wiki (`#144` non-goal).
+  - `LICENSE`, `NOTICE` → `repository-canonical` legal (static), owner: Exit Zero Labs LLC.
+  - `AGENTS.md` → `repository-canonical` (engineering-process source of truth), owner:
+    maintainers.
+  - `CLAUDE.md`, `.github/copilot-instructions.md`, `.claude/**` adapters → `generated`
+    (adapter pointers; canonical = `AGENTS.md` + `.github/instructions/**`).
+  - `.github/instructions/**`, `.github/PULL_REQUEST_TEMPLATE.md`,
+    `.github/ISSUE_TEMPLATE/**` → `repository-canonical`.
+  - `docs/knowledge/architecture.md`, `docs/knowledge/file-format.md` →
+    `repository-canonical` (named in `AGENTS.md`); refreshed by `#159`; handbook may link
+    but never copy.
+  - `docs/knowledge/glossary.md` → `repository-canonical` and canonical **source** for the
+    Wiki glossary page (`wiki-facing-source` flag); `#160` links/derives, does not fork.
+  - `docs/knowledge/overview.md` → `wiki-facing-source` candidate for the handbook home
+    (owner confirms) with `verify`.
+  - `docs/knowledge/product-design.md`, `go-to-market.md`, `market-analysis.md`, `risks.md`
+    → `internal-strategy` (repository-canonical, not user-facing, not shipped-behavior
+    claims), owner: maintainers.
+  - `docs/knowledge/mcp-server.md` → `repository-canonical` with `verify` (code present;
+    refresh against `src-tauri/src/mcp/**` in `#159`).
+  - `docs/quality/agentic-slop.md`, `ai-output-quality.md` → `repository-canonical` doctrine
+    (named in `AGENTS.md`); `ai-output-quality.md` carries `contains-planned`.
+  - Every `docs/runbooks/*.md` → `repository-canonical` operational; `configuring-release-signing.md`
+    carries `contains-planned`.
+  - `docs/plans/0000-template.md`, `docs/plans/README.md` → `repository-canonical` planning
+    contract/index.
+  - `docs/plans/roadmap.md` → `repository-canonical`, designated **canonical future-direction
+    source**.
+  - Active `docs/plans/<issue>-<slug>.md` → `repository-canonical` planning records; append
+    replans, never present as shipped state.
+  - `docs/archive/plans/001.md`–`008.md` → `historical` (read-only).
+  - Generated non-doc output (`dist/`, `playwright-report/`, `test-results/`, `screenshots/`)
+    → `generated`, explicitly out of documentation IA scope.
+- **Targeted verification:** Coverage check — every path from the inventory appears exactly
+  once:
+  `for f in $(find docs -name '*.md' | sort) README.md CONTRIBUTING.md SECURITY.md
+   CODE_OF_CONDUCT.md AGENTS.md CLAUDE.md; do grep -q "$f" docs/knowledge/documentation-architecture.md
+   || echo "MISSING: $f"; done` prints nothing.
+- **Intent validation:** Owner spot-checks that no document was mis-audited (especially the
+  `internal-strategy` set and the `wiki-facing-source` candidates) and that every
+  `verify`/`contains-planned` flag is justified.
+
+### 3. Define one-source-of-truth and ownership rules for mutable facts
+
+- **Behavior:** A "source of truth" section mapping each class of mutable fact to exactly one
+  canonical location and owner, plus the anti-duplication rule that all other surfaces link
+  rather than copy.
+- **Files:** `docs/knowledge/documentation-architecture.md`.
+- **Implementation:** Record at minimum:
+  - Live task status/priority/size/ownership/dependencies → GitHub Project 2 (never docs),
+    per `AGENTS.md`.
+  - Product direction and sequencing → `docs/plans/roadmap.md`.
+  - Architecture contract → `docs/knowledge/architecture.md`.
+  - `.thf` schema/format contract → `docs/knowledge/file-format.md`.
+  - Engineering process and code conventions → `AGENTS.md`; path rules →
+    `.github/instructions/**`.
+  - Quality doctrine → `docs/quality/**`.
+  - Security policy and vulnerability reporting → `SECURITY.md`.
+  - Contribution process → `CONTRIBUTING.md`; code of conduct → `CODE_OF_CONDUCT.md`.
+  - Glossary terms → `docs/knowledge/glossary.md`.
+  - Current user-facing capability descriptions → the single handbook page for that topic,
+    each claim verified against code/tests; README and other pages link, never restate.
+  - Volatile numeric/enumerated facts (test counts, exact provider lists, release/version
+    status, "N themes") → not duplicated in prose; either derived/generated or cited to
+    code/CI evidence, or omitted. This directly targets the stale-claim risk `#144` names.
+  - Explicit ownership rows for: README, contributor/security/governance files,
+    architecture/schema contracts, plans, runbooks, quality doctrine, and archives (the
+    acceptance-criteria list).
+- **Targeted verification:**
+  `grep -nE "Project 2|roadmap.md|architecture.md|file-format.md|AGENTS.md|SECURITY.md|CONTRIBUTING.md|glossary.md"
+   docs/knowledge/documentation-architecture.md` shows each canonical anchor is named.
+- **Intent validation:** Owner confirms there is exactly one owner per fact class and that
+  the volatile-facts rule is strict enough to prevent the duplication `#144` flags.
+
+### 4. Specify the Wiki handbook page map, navigation, naming, and boundaries
+
+- **Behavior:** A "Wiki handbook architecture" section giving the deterministic page map,
+  `_Sidebar.md` order, naming convention, source location, and the canonical-vs-Wiki
+  ownership boundary. This is the contract `#160` and `#161` implement.
+- **Files:** `docs/knowledge/documentation-architecture.md`.
+- **Implementation:**
+  - Source of truth: `docs/wiki/` in the repo (decision #2). Publishing target: the
+    GitHub Wiki, mirrored by `#161`. Wiki is `generated`; manual Wiki edits are non-canonical
+    and overwritten by the next publication.
+  - Page map covering the required topics (installation, core workflows, AI/BYOK, `.thf`
+    concepts, troubleshooting, glossary), e.g.:
+    - `Home` (`Home.md`) — landing/orientation.
+    - `Installation` — desktop install per platform + browser access.
+    - `Getting started` — first run, create/open a model.
+    - `Core modeling workflows` — canvas, components, relationships, data flows.
+    - `STRIDE threat analysis` — running and reading analysis.
+    - `AI-assisted analysis (BYOK)` — optional, direct-to-provider, key locality/encryption,
+      untrusted-output safety; no account/hosted backend implied.
+    - `Import and export` — TMT import, `.thf` export/download.
+    - `.thf concepts` — user-facing conceptual overview linking to canonical
+      `docs/knowledge/file-format.md`.
+    - `Troubleshooting` — common failures and recovery.
+    - `Glossary` — sourced from `docs/knowledge/glossary.md`.
+    - `_Sidebar.md`, `_Footer.md` — deterministic navigation and footer.
+  - Naming convention: kebab-case source slugs → Wiki page names; sentence-case titles and
+    headings; ISO dates; stable slugs so links do not rot.
+  - Ownership boundary rule: handbook pages describe verified current behavior and link to
+    repository-canonical architecture/schema/security/roadmap/contribution contracts for
+    engineering detail; they never restate mutable engineering facts, never require a
+    ThreatForge account, and never imply a hosted backend (per `#160`).
+- **Targeted verification:**
+  `grep -niE "installation|core.*workflow|BYOK|thf concept|troubleshoot|glossary|_Sidebar"
+   docs/knowledge/documentation-architecture.md` confirms every required topic and the
+  sidebar are present.
+- **Intent validation:** Owner confirms the page map is complete for a new user's
+  install → first model → threat analysis → optional AI → import/export → troubleshooting
+  journey, and that the `docs/wiki/` source-versus-published-Wiki boundary is understandable.
+
+### 5. Define the shipped-vs-planned-vs-history labeling convention
+
+- **Behavior:** A section fixing how any page distinguishes shipped behavior, verified
+  evidence, future direction, proposals, and historical records.
+- **Files:** `docs/knowledge/documentation-architecture.md`.
+- **Implementation:**
+  - Every capability statement is either (a) verified against a named evidence source
+    (code path, test, CI, config) and marked shipped, or (b) explicitly labeled planned with
+    a link to the roadmap or a canonical issue. No blending without labeling.
+  - Prescribe a consistent lightweight marker convention (e.g. a "Status: Shipped" /
+    "Status: Planned (#NNN)" line or callout) usable in both repo Markdown and Wiki render.
+  - Verified evidence is cited, not asserted; command results are never fabricated
+    (`.github/instructions/docs.instructions.md`).
+  - History lives only in `docs/archive/**` and active-plan replan logs; it is never
+    rewritten to read as current state.
+- **Targeted verification:**
+  `grep -niE "shipped|planned|verified|roadmap|archive" docs/knowledge/documentation-architecture.md`
+  shows the five distinctions are addressed.
+- **Intent validation:** Owner confirms the marker convention makes it implausible to mistake
+  planned functionality for shipped behavior in either surface.
+
+### 6. Define downstream contracts and sequencing for #159–#162
+
+- **Behavior:** A "downstream contracts" section giving each child issue measurable inputs,
+  deliverables, and completion signals, plus the fixed execution order and dependency notes.
+- **Files:** `docs/knowledge/documentation-architecture.md`.
+- **Implementation:** Record, per issue:
+  - **#159 (canonical repo docs refresh):** inputs = this IA's inventory + source-of-truth +
+    labeling rules. Deliverables = every `repository-canonical`/`internal-strategy` doc's
+    current-behavior claims verified against evidence; `verify`/`contains-planned` flags
+    resolved; duplicated mutable facts removed in favor of canonical links; internal links
+    resolve; `architecture.md`/`file-format.md` retain canonical roles; active plans keep
+    replan history; archives untouched. Contract: add pointer(s) to this IA doc from
+    `AGENTS.md`/docs indexes if owner approves (decision #4). Completion = inventory rows
+    marked `verify` are all resolved.
+  - **#160 (handbook authoring):** inputs = the page map, `docs/wiki/` source location,
+    naming, sidebar order, boundary rules. Deliverables = each mapped page authored with
+    verified current behavior, planned content isolated and linked, `Home` + deterministic
+    `_Sidebar`, no account/hosted-backend implication, renders locally, links to canonical
+    contracts instead of copying. Completion = a new user can complete the full journey from
+    the handbook.
+  - **#161 (Wiki publishing):** inputs = settled `docs/wiki/` content and page map; the
+    owner's one-time first-page creation (HITL). Deliverables = least-privilege workflow
+    publishing `docs/wiki/` → Wiki with SHA-pinned actions, trusted-`main`-only
+    execution, deterministic `Home`/`_Sidebar`/asset order, visible failure, traceable Wiki
+    commit, no manual Wiki source of truth.
+  - **#162 (README landing + link repair):** inputs = final canonical destinations from
+    #159–#161. Deliverables = README trimmed to identity + verified highlights + minimal
+    quick start + security/contribution entry points + navigation; user links → Wiki,
+    engineering links → repository-canonical; deterministic link validation added; no
+    unnecessary rewrite of archived/historical docs.
+  - Sequencing (from `#144`): `#158` → (`#159` ∥ `#160`) → `#161` (after `#160` **and** the
+    owner's first Wiki page) → `#162` (after `#159`, `#160`, `#161` settle destinations).
+- **Targeted verification:**
+  `grep -nE "#159|#160|#161|#162" docs/knowledge/documentation-architecture.md` shows each
+  child has explicit inputs, deliverables, and ordering.
+- **Intent validation:** Owner confirms each child could be executed against these contracts
+  by a separate implementer without rediscovering the IA, and that the ordering matches
+  `#144`.
+
+### 7. Add the acceptance-criteria mapping and initialize the replan log
+
+- **Behavior:** An "acceptance criteria coverage" table mapping each `#158` acceptance
+  criterion to the section that satisfies it, and a dated replan log seeded per template.
+- **Files:** `docs/knowledge/documentation-architecture.md`.
+- **Implementation:**
+  - Map the six `#158` acceptance criteria (inventory coverage; disposition classification;
+    one-source-of-truth + ownership; Wiki page map/nav/naming/boundaries;
+    shipped-vs-planned-vs-history distinction; measurable downstream contracts) to their
+    sections.
+  - Add an ISO-dated change-log table: `2026-07-22 | Initial IA | Issue #158 + repository
+    evidence`.
+- **Targeted verification:** Every acceptance criterion string maps to a section reference;
+  table has no empty cells.
+- **Intent validation:** Owner confirms full acceptance-criteria coverage with no gap.
+
+## Cross-cutting requirements
+
+- **Security and privacy:** No secrets, keys, tokens, or credentials appear in the artifact.
+  The IA reaffirms that `SECURITY.md` is the canonical security-policy source and that
+  BYOK/key-locality/untrusted-AI-output invariants (`AGENTS.md`) are described, never
+  weakened, by handbook pages. The `#161` publishing contract records least-privilege,
+  SHA-pinned, trusted-branch, fail-visible constraints but is not implemented here.
+- **`.thf` compatibility:** No schema or format change. The IA designates
+  `docs/knowledge/file-format.md` as the sole canonical `.thf` contract; the handbook `.thf`
+  concepts page links to it and must not restate schema rules.
+- **Browser and desktop:** Handbook installation/getting-started pages must cover both the
+  desktop app and browser build as intentional, per `AGENTS.md`; the IA records this as a
+  `#160` boundary requirement.
+- **AI safety:** The AI/BYOK handbook page contract requires describing optionality,
+  direct-to-provider requests, local encrypted keys, and untrusted-output validation; it must
+  not imply an account or hosted backend.
+- **Accessibility and UX:** Deterministic `_Sidebar.md` ordering and stable slugs keep
+  navigation predictable; sentence-case headings and ISO dates per
+  `.github/instructions/docs.instructions.md`.
+- **Observability and evidence:** Every current-behavior claim in downstream docs must cite a
+  verifiable evidence source; the labeling convention (step 5) forbids fabricated results.
+
+## Verification gate
+
+This issue ships one Markdown artifact and edits no code, so the code CI gate is not the
+discriminating check. Run, in order:
+
+```bash
+# 1. Artifact exists and vocabulary is complete
+test -f docs/knowledge/documentation-architecture.md
+grep -nE "repository-canonical|wiki-facing-source|historical|generated|superseded|internal-strategy" \
+  docs/knowledge/documentation-architecture.md
+
+# 2. Inventory coverage: every existing doc is classified
+for f in $(find docs -name '*.md' | sort) README.md CONTRIBUTING.md SECURITY.md \
+  CODE_OF_CONDUCT.md AGENTS.md CLAUDE.md .github/copilot-instructions.md; do
+  grep -q "$f" docs/knowledge/documentation-architecture.md || echo "MISSING: $f"
+done   # expect no output
+
+# 3. Required Wiki topics and downstream contracts are present
+grep -niE "installation|BYOK|thf concept|troubleshoot|glossary|_Sidebar" \
+  docs/knowledge/documentation-architecture.md
+grep -nE "#159|#160|#161|#162" docs/knowledge/documentation-architecture.md
+
+# 4. No accidental code change
+git status --porcelain   # expect only docs/... additions
+```
+
+Because the plan touches only Markdown (Biome does not lint Markdown, and no link checker
+exists yet), `npm run ci:local` is not required for correctness here; run it only if any
+non-Markdown file was unexpectedly modified. Deterministic Markdown link validation is
+introduced by `#162`.
+
+## Owner validation
+
+The handbook source location is settled as `docs/wiki/`. Deterministic checks cannot decide
+the remaining validation points; the owner must:
+
+- Confirm the artifact location `docs/knowledge/documentation-architecture.md` and whether a
+  pointer to it should be added to `AGENTS.md`/README (deferred to `#159`/`#162` here).
+- Confirm the disposition assignments for judgment calls: the `internal-strategy` set
+  (`product-design`, `go-to-market`, `market-analysis`, `risks`), the `wiki-facing-source`
+  candidates (`overview`, `glossary`), and every `verify`/`contains-planned` flag.
+- Confirm the Wiki page map is complete for the target new-user journey and that
+  canonical-vs-Wiki boundaries feel natural rather than forced.
+- Confirm the labeling convention makes it implausible to read planned functionality as
+  shipped.
+
+## Risks and mitigations
+
+- **Mis-audited disposition** propagates wrong actions into `#159`/`#160`. Mitigation: closed
+  vocabulary, coverage check, and explicit owner spot-check of judgment calls.
+- **Stale claims baked into the IA** (e.g. treating `mcp-server.md` or release status as
+  shipped without verification). Mitigation: `verify` flags plus the source-of-truth rule
+  that volatile facts are cited or omitted; MCP presence already verified in code.
+- **Source/target ambiguity** because `docs/wiki/` is canonical source while GitHub Wiki is a
+  generated mirror. Mitigation: the disposition vocabulary and ownership rules label the
+  repository directory `wiki-facing-source` and the published Wiki `generated`.
+- **Scope creep into refresh/authoring.** Mitigation: non-goals forbid editing any
+  inventoried document; the only file created is the IA artifact.
+- **Duplication reintroduced downstream.** Mitigation: the anti-duplication rule and
+  per-fact ownership table give `#159`/`#162` a testable contract.
+
+## Rollback
+
+The implementation adds exactly one new file. To roll back, delete
+`docs/knowledge/documentation-architecture.md` (or revert the single commit that adds it).
+No other file, workflow, schema, or GitHub state is touched, so rollback carries no data or
+behavior risk.
+
+## Specialist review
+
+- [x] PR reviewer — contract completeness, downstream mapping, template conformance.
+- [x] Slop auditor — no fabricated precision/coverage; dispositions are evidence-backed.
+- [ ] Security auditor — not triggered (no code, workflow, secret, or boundary change); the
+  IA only records the `#161` publishing security constraints for later implementation.
+- [ ] Threat-model expert — not triggered (no `.thf` schema or STRIDE change; the IA points
+  to the canonical `file-format.md` without altering it).
+
+## Replan log
+
+| Date | Change | Evidence and reason |
+|------|--------|---------------------|
+| 2026-07-22 | Initial plan | Issue `#158`, parent `#144`, children `#159`–`#162`, `AGENTS.md`, `.github/instructions/docs.instructions.md`, `docs/plans/0000-template.md`, full `docs/**` + root doc inventory, and code evidence for the MCP server. |
+| 2026-07-22 | Set handbook source to `docs/wiki/` | Owner selected `docs/wiki/` for the version-controlled handbook source; updated the #160/#161 contracts, validation, and risk treatment. |


### PR DESCRIPTION
## Summary

- add the committed implementation plan for the documentation information-architecture work
- define a canonical disposition and ownership policy for every current documentation collection
- establish `docs/wiki/` as the reviewed handbook source and GitHub Wiki as its generated mirror
- define deterministic Wiki navigation, shipped/planned/history labeling, and measurable contracts for #159–#162

## Issue

Closes #158

Parent initiative: #144

Plan: [`docs/plans/158-documentation-information-architecture.md`](docs/plans/158-documentation-information-architecture.md)

## Scope boundaries

This PR adds documentation policy only. It does not refresh existing content, create handbook pages, publish the Wiki, change README, alter `.thf`, or modify runtime behavior. Those outcomes remain assigned to #159–#162.

## Verification

- complete inventory coverage over every current `docs/**/*.md` file and root governance document: no missing classifications
- disposition/flag vocabulary, required Wiki topics, ownership matrix, and downstream contracts verified
- cited MCP behavior checked against Rust source, tests, and Cargo configuration
- `git diff --check`
- `npm run ci:local` — passed: Biome, TypeScript, Rust formatting/clippy, 869 Vitest tests, Rust tests, web build, and Worker dry run
- existing unrelated Biome warning remains for `!important` in CSS

## Agent preflight

- author anti-slop review: clean after correcting disposition/flag mixing, stale plan-status wording, transition ownership, and planned-content tracking
- PR reviewer: clean after convergence; no remaining findings
- slop auditor: clean after convergence; no remaining findings
- security lane: not triggered (no workflow, secret, capability, trust-boundary, or runtime change)
- threat-model lane: not triggered (no `.thf`, STRIDE, schema, or threat-quality change)

The full preflight record is preserved on #158.

## Owner validation

- confirm the `internal-strategy` disposition is useful and not over-specialized
- confirm the overview/glossary transition keeps one source of truth without hiding useful repository context
- confirm the Wiki page map covers the intended new-user journey
- confirm shipped/planned/history markers are understandable and difficult to misread

The one-time creation of the first GitHub Wiki page remains a later HITL prerequisite for #161.