### PR TITLE
feat(security): add a Content-Security-Policy to the web build (#156)

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,33 @@
+# Security headers for the deployed web build.
+#
+# Vite copies public/ into dist/, and Cloudflare Workers static assets honor this
+# _headers file, so the policy below is served for every route of the web app.
+#
+# The web build is the platform that needs a CSP: it holds the BYOK API key in
+# localStorage (webview-readable), whereas the desktop build keeps the key in Rust
+# and its CSP lives in src-tauri/tauri.conf.json. The primary key defense here is
+# script-src 'self' (with default-src 'self'): no inline or third-party script can
+# execute except the pinned analytics beacon, so an injected payload has no
+# foothold to read localStorage in the first place. connect-src is the
+# defense-in-depth second layer — it names only the hosts the app legitimately
+# talks to, none of them attacker-controlled:
+#
+#   api.anthropic.com, api.openai.com  the key-bearing provider endpoints; these
+#       must match the endpoint table (enforced by provider-endpoints.test.ts).
+#   cloudflareinsights.com  the Cloudflare Web Analytics beacon report endpoint
+#       (src/components/cloudflare-analytics.tsx, web build only), paired with the
+#       static.cloudflareinsights.com script origin. Carries no key.
+#   api.github.com  the read-only latest-release metadata the downloads page shows
+#       (src/hooks/use-latest-release.ts). Carries no key.
+#
+# If web analytics or the downloads release lookup is ever removed, drop its
+# origin(s) here too. See issue #156 for the full rationale.
+#
+# style-src 'unsafe-inline' is required for the app's runtime-injected styles
+# (ReactFlow, shadcn), matching the desktop CSP; inline styles cannot read the key.
+# object-src / base-uri / form-action / frame-ancestors close the plugin, base-tag,
+# form-hijack, and clickjacking vectors that default-src does not cover on its own.
+/*
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://api.anthropic.com https://api.openai.com https://cloudflareinsights.com https://api.github.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin

--- a/public/_headers
+++ b/public/_headers
@@ -9,25 +9,30 @@
 # script-src 'self' (with default-src 'self'): no inline or third-party script can
 # execute except the pinned analytics beacon, so an injected payload has no
 # foothold to read localStorage in the first place. connect-src is the
-# defense-in-depth second layer — it names only the hosts the app legitimately
-# talks to, none of them attacker-controlled:
+# defense-in-depth backstop — it is kept as narrow as the app's real network
+# surface allows, because a wide allowlist is an exfiltration drop if the primary
+# defense is ever bypassed:
 #
 #   api.anthropic.com, api.openai.com  the key-bearing provider endpoints; these
 #       must match the endpoint table (enforced by provider-endpoints.test.ts).
 #   cloudflareinsights.com  the Cloudflare Web Analytics beacon report endpoint
 #       (src/components/cloudflare-analytics.tsx, web build only), paired with the
-#       static.cloudflareinsights.com script origin. Carries no key.
-#   api.github.com  the read-only latest-release metadata the downloads page shows
-#       (src/hooks/use-latest-release.ts). Carries no key.
+#       static.cloudflareinsights.com script origin. It is a write-only RUM sink an
+#       attacker cannot read back, so it is a poor exfiltration drop; kept because
+#       analytics needs it.
 #
-# If web analytics or the downloads release lookup is ever removed, drop its
-# origin(s) here too. See issue #156 for the full rationale.
+# api.github.com is deliberately NOT allowlisted, even though the downloads page
+# reads the latest release from it: it is a write-capable multi-tenant API that a
+# post-XSS script could POST the key to (an attacker's own gist) and read back, so
+# it is the one origin worth removing from the backstop. The downloads page
+# degrades to a static GitHub-releases link when the lookup is blocked; issue #172
+# tracks proxying that lookup through the app origin to restore the live widget.
 #
 # style-src 'unsafe-inline' is required for the app's runtime-injected styles
 # (ReactFlow, shadcn), matching the desktop CSP; inline styles cannot read the key.
 # object-src / base-uri / form-action / frame-ancestors close the plugin, base-tag,
 # form-hijack, and clickjacking vectors that default-src does not cover on its own.
 /*
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://api.anthropic.com https://api.openai.com https://cloudflareinsights.com https://api.github.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://api.anthropic.com https://api.openai.com https://cloudflareinsights.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
 			}
 		],
 		"security": {
-			"csp": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: https://asset.localhost; font-src 'self' data:; connect-src 'self' https://api.anthropic.com https://api.openai.com ipc: http://ipc.localhost"
+			"csp": "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: https://asset.localhost; font-src 'self' data:; connect-src 'self' https://api.anthropic.com https://api.openai.com ipc: http://ipc.localhost; base-uri 'self'; form-action 'self'; object-src 'none'"
 		}
 	},
 	"plugins": {

--- a/src/lib/adapters/provider-endpoints.test.ts
+++ b/src/lib/adapters/provider-endpoints.test.ts
@@ -17,12 +17,21 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import { ProtocolException } from "@/lib/ai/protocol/errors";
+import webHeadersSource from "../../../public/_headers?raw";
 import rustRelaySource from "../../../src-tauri/src/ai/providers.rs?raw";
 import tauriConfigSource from "../../../src-tauri/tauri.conf.json?raw";
 import { PROVIDER_ENDPOINTS, providerEndpoint } from "./provider-endpoints";
 
 /** `pub const ANTHROPIC_API_URL: &str = "https://…";` */
 const RUST_ENDPOINT_CONSTANT = /pub const (\w+_API_URL): &str = "([^"]+)";/g;
+
+/**
+ * Origins the web CSP (`public/_headers`) allows for connect-src that carry no
+ * key — the analytics beacon and the read-only GitHub release lookup — so they
+ * are excluded when the web `connect-src` is compared against the key-bearing
+ * endpoint table. See the rationale in `public/_headers`.
+ */
+const WEB_NON_KEY_ORIGINS = new Set(["https://cloudflareinsights.com", "https://api.github.com"]);
 
 const tauriConfigSchema = z.object({
 	app: z.object({ security: z.object({ csp: z.string() }) }),
@@ -32,10 +41,9 @@ function rustEndpointUrls(): string[] {
 	return [...rustRelaySource.matchAll(RUST_ENDPOINT_CONSTANT)].map((match) => match[2]);
 }
 
-/** The `https:` origins the Tauri CSP permits the webview to connect to. */
-function cspConnectSrcOrigins(): string[] {
-	const config = tauriConfigSchema.parse(JSON.parse(tauriConfigSource));
-	const connectSrc = config.app.security.csp
+/** The `https:` origins a CSP's `connect-src` directive permits. */
+function connectSrcOrigins(csp: string): string[] {
+	const connectSrc = csp
 		.split(";")
 		.map((directive) => directive.trim())
 		.find((directive) => directive.startsWith("connect-src "));
@@ -44,6 +52,19 @@ function cspConnectSrcOrigins(): string[] {
 		.split(/\s+/)
 		.filter((source) => source.startsWith("https://"))
 		.map((source) => new URL(source).origin);
+}
+
+/** The `connect-src` https origins the desktop (Tauri) CSP permits. */
+function tauriCspConnectSrcOrigins(): string[] {
+	const config = tauriConfigSchema.parse(JSON.parse(tauriConfigSource));
+	return connectSrcOrigins(config.app.security.csp);
+}
+
+/** The single CSP the deployed web build serves for every route via `_headers`. */
+function webCsp(): string {
+	const match = webHeadersSource.match(/Content-Security-Policy:\s*([^\n]+)/);
+	expect(match, "public/_headers must declare a Content-Security-Policy").not.toBeNull();
+	return match?.[1]?.trim() ?? "";
 }
 
 const tableUrls = Object.values(PROVIDER_ENDPOINTS).map((endpoint) => endpoint.url);
@@ -59,18 +80,59 @@ describe("provider endpoint drift", () => {
 		expect([...tableUrls].sort()).toEqual([...rustEndpointUrls()].sort());
 	});
 
-	it("only names origins the Tauri CSP allows the webview to reach", () => {
-		const allowed = cspConnectSrcOrigins();
+	it("only names origins the desktop CSP allows the webview to reach", () => {
+		const allowed = tauriCspConnectSrcOrigins();
 		for (const url of tableUrls) {
-			expect(allowed, `${url} is not in the CSP connect-src allowlist`).toContain(
+			expect(allowed, `${url} is not in the desktop CSP connect-src allowlist`).toContain(
 				new URL(url).origin,
 			);
 		}
 	});
 
-	it("leaves no provider origin allowed by the CSP that nothing sends to", () => {
+	it("leaves no provider origin the desktop CSP allows that nothing sends to", () => {
 		const tableOrigins = tableUrls.map((url) => new URL(url).origin);
-		expect([...cspConnectSrcOrigins()].sort()).toEqual([...new Set(tableOrigins)].sort());
+		expect([...tauriCspConnectSrcOrigins()].sort()).toEqual([...new Set(tableOrigins)].sort());
+	});
+
+	it("lets the web build reach every provider origin the endpoint table names", () => {
+		const allowed = connectSrcOrigins(webCsp());
+		for (const url of tableUrls) {
+			expect(allowed, `${url} is not in the web CSP connect-src allowlist`).toContain(
+				new URL(url).origin,
+			);
+		}
+	});
+
+	it("allows the web build no key-bearing connect origin beyond the endpoint table", () => {
+		// The deployed web build additionally allows a small set of no-key service
+		// origins (analytics, GitHub release lookup); every other https origin the
+		// web CSP permits must be a table endpoint, so a stray host added to either
+		// side fails here.
+		const tableOrigins = new Set(tableUrls.map((url) => new URL(url).origin));
+		const keyBearing = connectSrcOrigins(webCsp()).filter(
+			(origin) => !WEB_NON_KEY_ORIGINS.has(origin),
+		);
+		expect([...keyBearing].sort()).toEqual([...tableOrigins].sort());
+	});
+
+	it("fails the web build's non-connect vectors closed", () => {
+		const csp = webCsp();
+		for (const directive of [
+			"default-src 'self'",
+			"object-src 'none'",
+			"base-uri 'self'",
+			"form-action 'self'",
+			"frame-ancestors 'none'",
+		]) {
+			expect(csp, `the web CSP must set ${directive}`).toContain(directive);
+		}
+	});
+
+	it("hardens the desktop CSP with base-uri and form-action", () => {
+		const config = tauriConfigSchema.parse(JSON.parse(tauriConfigSource));
+		for (const directive of ["base-uri 'self'", "form-action 'self'"]) {
+			expect(config.app.security.csp, `the desktop CSP must set ${directive}`).toContain(directive);
+		}
 	});
 
 	it("sends every provider request over https", () => {

--- a/src/lib/adapters/provider-endpoints.test.ts
+++ b/src/lib/adapters/provider-endpoints.test.ts
@@ -27,11 +27,12 @@ const RUST_ENDPOINT_CONSTANT = /pub const (\w+_API_URL): &str = "([^"]+)";/g;
 
 /**
  * Origins the web CSP (`public/_headers`) allows for connect-src that carry no
- * key — the analytics beacon and the read-only GitHub release lookup — so they
- * are excluded when the web `connect-src` is compared against the key-bearing
- * endpoint table. See the rationale in `public/_headers`.
+ * key — currently only the write-only analytics beacon — so they are excluded
+ * when the web `connect-src` is compared against the key-bearing endpoint table.
+ * See the rationale in `public/_headers`. Adding an origin here is a security
+ * change: it asserts the origin is not a usable exfiltration drop for the key.
  */
-const WEB_NON_KEY_ORIGINS = new Set(["https://cloudflareinsights.com", "https://api.github.com"]);
+const WEB_NON_KEY_ORIGINS = new Set(["https://cloudflareinsights.com"]);
 
 const tauriConfigSchema = z.object({
 	app: z.object({ security: z.object({ csp: z.string() }) }),


### PR DESCRIPTION
## Summary

Closes #156. The deployed web build shipped **no CSP**, leaving the browser BYOK
key (clear-text in `localStorage`) unprotected against an injected script
exfiltrating it. This adds a `public/_headers` policy (Vite copies `public/` into
`dist/`; Cloudflare Workers static assets honor `_headers`) and hardens the
desktop CSP to match.

## Web CSP (`public/_headers`)

```
default-src 'self'; script-src 'self' https://static.cloudflareinsights.com;
style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:;
connect-src 'self' https://api.anthropic.com https://api.openai.com https://cloudflareinsights.com;
object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'
```
Plus `X-Content-Type-Options: nosniff` and `Referrer-Policy: strict-origin-when-cross-origin`.

**Primary key defense is `script-src 'self'`**: no inline or third-party script can
execute except the pinned Cloudflare beacon (which serves only a fixed
`beacon.min.js` — not a general script host), so an injected payload has no
foothold to read `localStorage`. The security lane confirmed the app has **no
DOM-XSS sink** (no `dangerouslySetInnerHTML`/`innerHTML`/`eval`; `react-markdown`
omits `rehype-raw`) and that the four external origins below are the complete set
the web build touches. `connect-src` is the defense-in-depth backstop, kept as
narrow as the real network surface allows.

## `connect-src` origins

| Origin | Why | Key-bearing? |
|---|---|---|
| `api.anthropic.com`, `api.openai.com` | provider endpoints; drift-tested against the endpoint table + Rust constants | **yes** |
| `cloudflareinsights.com` | web-analytics beacon report endpoint; write-only RUM sink an attacker cannot read back (poor exfil drop) | no |

**`api.github.com` was deliberately removed** (security-lane should-fix): it is a
write-capable multi-tenant API a post-XSS script could POST the key to (an
attacker's own gist) and read back — the one origin worth keeping out of the
backstop. It served only the downloads page's live-release widget, which degrades
to a static GitHub link when blocked. **#172** tracks proxying that lookup through
the app origin to restore the live widget with no `connect-src` exception.

## Desktop CSP (`tauri.conf.json`)

Added the parity gaps: `base-uri 'self'`, `form-action 'self'`, `object-src 'none'`.

## Verification

- `provider-endpoints.test.ts` extended to read `public/_headers` and assert the
  web CSP names both provider origins, allows no *key-bearing* origin beyond the
  table, and sets the lock-down directives — **14 pass**.
- `tsc` clean; `npm run build` clean; `dist/_headers` emitted with the policy.
- Security preflight: **must-fix 0**, the one should-fix (`api.github.com`) applied.

## Owner validation (deferred, not waived)

1. **Deployed-header check (most important)** — the drift test proves the file's
   *content*, not that the header is *served*. Confirm on the live site:
   `curl -sI https://threatforge.dev | grep -i content-security-policy` (a
   `_headers` CSP is not applied by `vite preview`, so no-breakage was verified by
   directive reasoning, not a live browser load).
2. **HSTS** (security-lane consider) — protects the clear-text `localStorage`
   secret against an SSL-strip MITM, a threat CSP does not cover. Not added here
   because it is hard to reverse (browser-cached `max-age`) and Cloudflare often
   sets it at the zone level. **Verify** whether the edge already serves
   `Strict-Transport-Security`; if not, add it (owner decision on `includeSubDomains`).
3. **Downloads page** now shows its static-link fallback on web until #172 lands.

Relates to #133 (browser key-at-rest) but worth doing regardless.
