### PR TITLE
fix(mcp): advertise the text element type in the add_element tool schema (#165)

### DIFF
--- a/src-tauri/src/mcp/fixtures/tool-surface.json
+++ b/src-tauri/src/mcp/fixtures/tool-surface.json
@@ -54,7 +54,7 @@
   },
   {
     "name": "add_element",
-    "description": "Add a new DFD element (process, data_store, or external_entity) to the threat model.",
+    "description": "Add a new DFD element (process, data_store, external_entity, or text) to the threat model.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
@@ -66,7 +66,7 @@
           ]
         },
         "element_type": {
-          "description": "Element type: process, data_store, or external_entity",
+          "description": "Element type: process, data_store, external_entity, or text",
           "type": "string"
         },
         "name": {

--- a/src-tauri/src/mcp/server.rs
+++ b/src-tauri/src/mcp/server.rs
@@ -140,7 +140,7 @@ struct GetModelRequest {}
 
 #[derive(Debug, Deserialize, JsonSchema)]
 struct AddElementRequest {
-    #[schemars(description = "Element type: process, data_store, or external_entity")]
+    #[schemars(description = "Element type: process, data_store, external_entity, or text")]
     element_type: String,
     #[schemars(description = "Human-readable element name")]
     name: String,
@@ -283,7 +283,7 @@ impl ThreatForgeServer {
     }
 
     #[tool(
-        description = "Add a new DFD element (process, data_store, or external_entity) to the threat model."
+        description = "Add a new DFD element (process, data_store, external_entity, or text) to the threat model."
     )]
     async fn add_element(
         &self,


### PR DESCRIPTION
## Summary

Closes #165. The MCP server accepts `text` in `VALID_ELEMENT_TYPES`, but the advertised `add_element` tool description and the `element_type` schema description listed only `process`, `data_store`, and `external_entity` — an under-described wire contract for MCP clients. This aligns the advertised descriptions (and the pinned `tool-surface.json` fixture) with the actual accepted set. Runtime validation is unchanged.

## Changes
- `src-tauri/src/mcp/server.rs` — `add_element` `#[tool(description)]` and `element_type` `#[schemars(description)]` now enumerate all four types (`process, data_store, external_entity, or text`).
- `src-tauri/src/mcp/fixtures/tool-surface.json` — regenerated to match; the `advertised_tool_surface_matches_the_pinned_contract` test asserts byte-equality with the live serialization, so the passing test proves the fixture is in sync.

## Verification
`cargo fmt` / `clippy -D warnings` / `cargo test` all clean (162 lib + 2 mcp_stdio + 1 prompt_ownership); the three tool-surface pinning tests pass.

🤖 Delegated to a feature-implementer, diff reviewed, verified.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>