### PR TITLE
fix(ai): correct AI provider and key-storage copy across user surfaces (#166)

### DIFF
--- a/src/components/onboarding/whats-new-overlay.tsx
+++ b/src/components/onboarding/whats-new-overlay.tsx
@@ -27,7 +27,7 @@ const CHANGELOG: ChangelogEntry[] = [
 		changes: [
 			"Component library with 44 pre-built technology components + text annotations",
 			"STRIDE threat analysis engine with auto-generated threats",
-			"AI chat pane with BYOK support (OpenAI, Anthropic, Ollama)",
+			"AI chat pane with BYOK support (OpenAI, Anthropic)",
 			"Human-readable YAML file format — git-diffable",
 			"Undo/redo with 20-action history",
 			"Copy, cut, paste, and multi-select on canvas",

--- a/src/lib/onboarding/guides.ts
+++ b/src/lib/onboarding/guides.ts
@@ -109,7 +109,7 @@ export const AI_ASSISTANT_GUIDE: OnboardingGuide = {
 			targetSelector: "[data-testid='btn-settings-dialog']",
 			title: "Configure API Key",
 			content:
-				"To use AI features, open Settings and add your API key (OpenAI, Anthropic, or Ollama). Keys are stored securely in encrypted storage.",
+				"To use AI features, open Settings and add your API key (OpenAI or Anthropic). Desktop keys are encrypted at rest; browser keys are stored in localStorage.",
 			placement: "bottom",
 		},
 		{

--- a/src/pages/privacy-page.tsx
+++ b/src/pages/privacy-page.tsx
@@ -23,8 +23,10 @@ export function PrivacyPage() {
 						<p>
 							Threat Forge uses a Bring Your Own Key (BYOK) model for AI features. When you use
 							AI-powered threat analysis or chat, your API key and prompts are sent directly from
-							your machine to your chosen provider (OpenAI, Anthropic, or Ollama). Your API keys are
-							encrypted at rest using AES-256-GCM and are never transmitted to Exit Zero Labs.
+							your machine to your chosen provider (OpenAI or Anthropic). On the desktop app, your
+							API keys are encrypted at rest using AES-256-GCM; in the web app, they are stored in
+							your browser&apos;s localStorage. In both cases, your keys are never transmitted to
+							Exit Zero Labs.
 						</p>
 						<p>
 							AI features are entirely optional. The application is fully functional without them.

--- a/src/pages/support-page.tsx
+++ b/src/pages/support-page.tsx
@@ -12,7 +12,7 @@ const FAQ_ITEMS = [
 	{
 		question: "Do I need an API key for AI features?",
 		answer:
-			"Yes — AI features use a Bring Your Own Key (BYOK) model. You provide your own OpenAI, Anthropic, or Ollama API key. AI features are entirely optional; the app is fully functional without them.",
+			"Yes — AI features use a Bring Your Own Key (BYOK) model. You provide your own OpenAI or Anthropic API key. AI features are entirely optional; the app is fully functional without them.",
 	},
 	{
 		question: "What file format does Threat Forge use?",

--- a/src/pages/terms-page.tsx
+++ b/src/pages/terms-page.tsx
@@ -38,8 +38,8 @@ export function TermsPage() {
 					<Section title="AI Disclaimer">
 						<p>
 							AI-generated threat suggestions, mitigations, and analysis are produced by third-party
-							language models (OpenAI, Anthropic, Ollama) using your own API key. These outputs are
-							not professional security advice and should be reviewed by qualified security
+							language models (OpenAI, Anthropic) using your own API key. These outputs are not
+							professional security advice and should be reviewed by qualified security
 							professionals before being relied upon.
 						</p>
 					</Section>


### PR DESCRIPTION
## Summary

Closes #166. User-facing onboarding, changelog, support, terms, and privacy copy listed **Ollama** as a supported BYOK provider (the runtime supports only Anthropic + OpenAI) and claimed **all** API keys are encrypted at rest (true only on desktop; the web build stores them in clear-text `localStorage`). This corrects every surface to match the runtime.

## Changes (all copy-only, accuracy fixes)
- `src/lib/onboarding/guides.ts` — drop Ollama; state desktop-encrypted vs browser-`localStorage`.
- `src/components/onboarding/whats-new-overlay.tsx` — drop Ollama from the v1.0.0 entry.
- `src/pages/support-page.tsx` — drop Ollama from the API-key FAQ.
- `src/pages/privacy-page.tsx` — drop Ollama; replace the blanket "encrypted at rest" claim with the accurate desktop-vs-browser distinction, **preserving** "never transmitted to Exit Zero Labs" and adding no new commitment.
- `src/pages/terms-page.tsx` — drop Ollama from the AI-disclaimer model list.

Ground truth: `AiProvider = "anthropic" | "openai"` (`messages.ts`); browser keys in `localStorage` (`browser-keychain-adapter.ts`); desktop keys AES-256-GCM (`keychain.rs`). New browser-storage wording mirrors the existing in-app note in `ai-settings-content.tsx`.

## ⚠️ Owner-sensitive surfaces
`privacy-page.tsx` and `terms-page.tsx` are legal/policy pages. This PR **only removes an inaccurate claim and corrects the key-storage wording to be truthful** — it fixes a live privacy page that currently misstates web-build key encryption. No new policy commitment is added. Flagged for your validation; adjust wording if you prefer different phrasing.

## Verification
`tsc` clean; `biome check src` clean (one pre-existing unrelated `styles.css` warning); `use-onboarding-triggers.test.ts` 9/9. No test pins the changed strings.

🤖 Delegated to a feature-implementer, diffs reviewed (legal hunks read directly).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>