### PR TITLE
feat(ai): add provider contract fixtures, bounded retry, and the protocol knowledge doc (#61 steps 11–12)

### DIFF
--- a/docs/knowledge/ai-protocol.md
+++ b/docs/knowledge/ai-protocol.md
@@ -106,14 +106,21 @@ counted. The estimate is deliberately dependency-free and conservative; a reques
 that fits locally can still overflow at the provider, which surfaces as a
 `context_overflow` error from the stream rather than silent truncation.
 
-## Provider mappers and the shared decoder
+## Byte framing and the shared mappers
 
-`src/lib/ai/providers/sse.ts` is the one byte-level SSE decoder. It accepts
-arbitrary chunk boundaries — mid-line, mid-JSON, mid-multi-byte-UTF-8 — and emits
-complete `{ event, data }` frames, holding a trailing partial line until a later
-chunk finishes it. It fails closed (`malformed_stream`) on an unterminated line
-that exceeds a fixed buffer cap, the one failure shape no downstream guard could
-otherwise observe.
+Byte-level SSE framing exists once per platform, deliberately mirrored rather than
+shared. `src/lib/ai/providers/sse.ts` frames the browser `fetch` body: it accepts
+arbitrary chunk boundaries — mid-line, mid-JSON, mid-multi-byte-UTF-8 — emits
+complete `{ event, data }` frames, holds a trailing partial line until a later
+chunk finishes it, and fails closed (`malformed_stream`) on an unterminated line
+over a fixed buffer cap, the one failure shape no downstream guard could otherwise
+observe. On desktop the Rust relay does its own byte framing in `SseFrameSplitter`
+(`src-tauri/src/ai/providers.rs`), which mirrors `src/lib/ai/providers/sse.ts` —
+the same buffered-line
+cap, the same default event name, the same fail-closed behavior — and relays
+already-framed `{ event, data }` pairs, so the TypeScript byte decoder never runs
+on that path. What is genuinely single and shared is the layer above: the
+frame→`StreamEvent` mapper pair.
 
 `src/lib/ai/providers/anthropic.ts` and `src/lib/ai/providers/openai.ts` are the
 only modules that may mention a provider's wire shapes. Each builds its request
@@ -148,11 +155,13 @@ provider and relay SSE frames back, and neither knows a provider's event protoco
 The reason the key stays in Rust is separation of concerns, not decoding: the only
 thing Rust must own is the credential and the endpoint/auth headers built from it
 (`endpoint_for`, `auth_headers`, `validate_body`, and `redact_provider_detail` in
-`src-tauri/src/ai/providers.rs`). Rust relays raw SSE frames to the webview and the
-same TypeScript decoder maps them, so there is one decoder rather than two kept in
-agreement. Desktop already received raw provider error text before this design, so
-no secret crosses a boundary it did not already cross — but it makes redaction
-mandatory, in Rust, before frames leave the process. The desktop key boundary is a
+`src-tauri/src/ai/providers.rs`). Rust frames the SSE bytes itself (`SseFrameSplitter`,
+above) and relays already-framed `{ event, data }` pairs to the webview, where the
+same shared mapper pair turns them into `StreamEvent`s — so the implementation kept
+single across platforms is the mapper, while byte framing is two mirrored,
+fail-closed twins. Desktop already received raw provider error text before this
+design, so no secret crosses a boundary it did not already cross — but it makes
+redaction mandatory, in Rust, before frames leave the process. The desktop key boundary is a
 compile-time property: the shared `KeychainAdapter` interface does not declare
 `getKey`, so desktop code cannot ask for a key.
 
@@ -188,9 +197,11 @@ Two constraints bound it:
 
 The default policy (`DEFAULT_RETRY_POLICY`) is three attempts with exponential
 backoff capped at ten seconds. A provider `retry-after` hint is honored when
-present and is never shortened below the computed backoff. The backoff has no
-jitter, so the schedule is deterministic and testable; the sleep is injectable so
-tests advance without real time.
+present and is never shortened below the computed backoff, but it is first clamped
+to an absolute ceiling (ten minutes) inside `retryDelayMs` itself — so a hostile or
+misconfigured provider cannot park a retry indefinitely even if a transport failed
+to clamp the hint. The backoff has no jitter, so the schedule is deterministic and
+testable; the sleep is injectable so tests advance without real time.
 
 ## Error taxonomy and redaction
 
@@ -270,7 +281,7 @@ Every test file colocates with the implementation it exercises.
 | Tool schema generation and validation | `src/lib/ai/protocol/tools.ts`, `src/lib/ai/schemas/actions.ts` | `src/lib/ai/protocol/tools.test.ts`, `src/lib/ai/schemas/actions.test.ts`, `src/lib/ai-actions.test.ts` |
 | Preflight and capabilities | `src/lib/ai/protocol/request.ts`, `src/lib/ai-models.ts` | `src/lib/ai/protocol/request.test.ts` |
 | Budgeting | `src/lib/ai/protocol/budget.ts` | `src/lib/ai/protocol/budget.test.ts` |
-| SSE decoder and mappers | `src/lib/ai/providers/sse.ts`, `src/lib/ai/providers/anthropic.ts`, `src/lib/ai/providers/openai.ts`, `src/lib/ai/providers/mapper-events.ts` | `src/lib/ai/providers/sse.test.ts`, `src/lib/ai/providers/anthropic.test.ts`, `src/lib/ai/providers/openai.test.ts` |
+| Byte framing (mirrored twins) and the shared mappers | `src/lib/ai/providers/sse.ts`, `SseFrameSplitter` in `src-tauri/src/ai/providers.rs`, `src/lib/ai/providers/anthropic.ts`, `src/lib/ai/providers/openai.ts`, `src/lib/ai/providers/mapper-events.ts` | `src/lib/ai/providers/sse.test.ts`, `src/lib/ai/providers/anthropic.test.ts`, `src/lib/ai/providers/openai.test.ts`, `cargo test --manifest-path src-tauri/Cargo.toml ai::` |
 | Transports and the key boundary | `src/lib/adapters/browser-chat-adapter.ts`, `src/lib/adapters/tauri-chat-adapter.ts`, `src/lib/adapters/chat-adapter.ts` | `src/lib/adapters/browser-chat-adapter.test.ts`, `src/lib/adapters/tauri-chat-adapter.test.ts`, `src/lib/adapters/provider-endpoints.test.ts` |
 | Rust relay and redaction | `src-tauri/src/ai/providers.rs`, `src-tauri/src/commands/ai_commands.rs` | `cargo test --manifest-path src-tauri/Cargo.toml ai::` |
 | Retry policy | `src/lib/ai/protocol/retry.ts` | `src/lib/ai/protocol/contract.test.ts` |

--- a/docs/knowledge/ai-protocol.md
+++ b/docs/knowledge/ai-protocol.md
@@ -1,0 +1,280 @@
+# ThreatForge — AI conversation protocol
+
+The AI stack speaks one provider-neutral, platform-neutral protocol. A single
+TypeScript implementation maps every Anthropic and OpenAI response onto the same
+typed event stream, budgets and validates every request before it leaves the
+machine, and keeps the desktop API key inside Rust. This document describes that
+contract so that the bounded tool loop ([`#62`](https://github.com/exit-zero-labs/threat-forge/issues/62))
+and the native graph tool registry ([`#64`](https://github.com/exit-zero-labs/threat-forge/issues/64))
+can be built from a written spec rather than by reading the implementation.
+
+It describes behavior and the reasons behind it. The types and functions named
+here are the source of truth for their own signatures; the plan that introduced
+the protocol is [`docs/plans/61-ai-conversation-protocol.md`](../plans/61-ai-conversation-protocol.md).
+
+## Scope and invariants
+
+- **BYOK, direct-to-provider, no ThreatForge backend.** Requests go straight to
+  `api.anthropic.com` or `api.openai.com` over HTTPS with the user's own key. No
+  proxy, account, or telemetry is introduced.
+- **One implementation, two transports.** Provider decoding, request shaping,
+  budgeting, the system prompt, and the error taxonomy are shared code. The only
+  platform-specific piece is the transport — who holds the key and who performs
+  the HTTPS request.
+- **Model output is untrusted until it passes a generated schema.** A tool call's
+  arguments are `unknown` everywhere except the one parser that validates them.
+- **Failures fail closed and never leak secrets.** A provider error body is
+  redacted and length-capped before it can reach the UI, logs, or storage.
+
+Out of scope here, and owned elsewhere: the tool-execution loop, approval modes,
+and undo (`#62`); native graph tool definitions (`#64`); IndexedDB conversation
+persistence (`#63`); and user-configurable or self-hosted base URLs.
+
+## The message model
+
+`src/lib/ai/protocol/messages.ts` defines a turn as a list of content blocks
+rather than a string, so text, tool calls, and tool results can share one message
+without being encoded into prose:
+
+- A `ProtocolMessage` is `{ role: "user" | "assistant"; content: ContentBlock[] }`.
+- A `ContentBlock` is a `TextBlock`, a `ToolCallBlock`, or a `ToolResultBlock`.
+- `ToolCallBlock.input` is deliberately `unknown`. Reading it as a validated
+  value is only possible through `ToolDefinition.parseInput` (see below).
+- The **system prompt is not a message**. Anthropic carries it as a top-level
+  field and OpenAI as a leading message, so keeping it out of `ProtocolMessage`
+  stops that divergence from leaking into every consumer.
+
+`upgradeLegacyMessage` reads a pre-protocol `{ role, content: string }` session
+into block form, and `flattenText` collapses a message back to a display string
+byte-for-byte, so `localStorage` chat sessions written by earlier builds stay
+readable. `assertToolPairing` reports every tool-call/tool-result pairing
+violation in a complete history; it is the invariant truncation must preserve,
+not a happy-path guard.
+
+## The event vocabulary
+
+`src/lib/ai/protocol/events.ts` defines the `StreamEvent` discriminated union —
+the only vocabulary a consumer ever sees:
+
+`message_start`, `text_delta`, `tool_call_start`, `tool_call_input_delta`,
+`tool_call_complete`, `usage`, `message_stop` (carrying a `stopReason`), `error`,
+and `aborted`.
+
+Two logically identical responses from the two providers must produce an
+identical `StreamEvent` sequence. That equality is asserted directly in the
+provider tests and in the fixture corpus.
+
+Terminality rules that matter to a consumer:
+
+- **Cancellation is `aborted`, never `error`.** A user stop keeps whatever text
+  arrived and must not render as a failure banner.
+- **A mapper-emitted `malformed_stream` `error` is a non-terminal notice** scoped
+  to the one undecodable frame, orphan fragment, or dropped tool call it reports;
+  the mapper keeps going. An `error` with any other code is terminal, because the
+  provider closes the stream after it.
+- **A truncated stream is a failure, not a short success.** If the provider closes
+  the body without the mapper ever emitting a terminal event, the client emits a
+  `malformed_stream` error rather than letting a cut-off answer look finished.
+
+## Request preflight and model capabilities
+
+Model capabilities live on the curated model list in `src/lib/ai-models.ts`
+(`toolCalling`, `parallelToolCalls`, `streaming`, `maxInputTokens`) so a
+capability and the model it describes cannot drift apart. `resolveCapabilities`
+returns `{ known: true, capabilities } | { known: false }`.
+
+`preflightRequest` (`src/lib/ai/protocol/request.ts`) runs before any network
+call and throws `unsupported_capability` when tools are requested against a model
+that cannot call them, or against an unknown model id. A **text-only** request
+against an unknown model id is still allowed — a stale settings value should not
+block plain chat — which is today's behavior.
+
+## Context budgeting
+
+`budgetMessages` (`src/lib/ai/protocol/budget.ts`) drops history oldest-first at
+**turn-group granularity**. A turn group is an assistant message that opens one or
+more tool calls together with every later message whose `tool_result` blocks
+answer them; groups are indivisible. This is the invariant a naive tail slice
+breaks: cutting through a group produces a history where a `tool_result` has no
+matching `tool_call`, which both providers reject. If the newest group alone
+exceeds the window, budgeting returns a typed `context_overflow` error rather than
+an unpairable history. `capMessageHistory` applies the same group-atomic rule when
+the chat store persists a session, so a saved session can never be unpairable.
+
+Tokens are **estimated** (characters ÷ 4 plus a fixed per-message overhead), not
+counted. The estimate is deliberately dependency-free and conservative; a request
+that fits locally can still overflow at the provider, which surfaces as a
+`context_overflow` error from the stream rather than silent truncation.
+
+## Provider mappers and the shared decoder
+
+`src/lib/ai/providers/sse.ts` is the one byte-level SSE decoder. It accepts
+arbitrary chunk boundaries — mid-line, mid-JSON, mid-multi-byte-UTF-8 — and emits
+complete `{ event, data }` frames, holding a trailing partial line until a later
+chunk finishes it. It fails closed (`malformed_stream`) on an unterminated line
+that exceeds a fixed buffer cap, the one failure shape no downstream guard could
+otherwise observe.
+
+`src/lib/ai/providers/anthropic.ts` and `src/lib/ai/providers/openai.ts` are the
+only modules that may mention a provider's wire shapes. Each builds its request
+body from the neutral `ProviderChatRequest` and maps its stream onto
+`StreamEvent`s. The divergence between Anthropic's `tool_result` blocks and
+OpenAI's `role: "tool"` messages is confined to these two files. Shared finishing
+logic lives in `src/lib/ai/providers/mapper-events.ts`: a tool call's streamed
+JSON fragments are concatenated and parsed exactly once, and a fragment set that
+never parses drops that one call with a `malformed_stream` notice without aborting
+the turn. Tool definitions are advertised without OpenAI `strict` mode, which is
+deferred to `#64`.
+
+## The transport split, and why the key stays in Rust
+
+`ChatTransport.open(request, callbacks, signal)` in
+`src/lib/adapters/chat-adapter.ts` is the only platform-specific interface left.
+Both implementations are transport-only: they carry a provider-shaped body to the
+provider and relay SSE frames back, and neither knows a provider's event protocol.
+
+- **Browser** (`src/lib/adapters/browser-chat-adapter.ts`): reads the key from
+  `localStorage`, fetches the endpoint from the frozen table in
+  `src/lib/adapters/provider-endpoints.ts` with the mapper's headers, refuses
+  redirects (so a 3xx cannot re-send the key to another origin), enforces a
+  per-gap read timeout and a total-bytes budget, and streams the body through the
+  shared decoder.
+- **Desktop** (`src/lib/adapters/tauri-chat-adapter.ts`): calls
+  `start_ai_stream({ provider, body, streamId })`, subscribes to
+  `ai:stream-frame`/`ai:stream-closed`, **filters every event by `streamId`**, and
+  routes a stop to `cancel_ai_stream(streamId)`. The frontend supplies no URL and
+  no header.
+
+The reason the key stays in Rust is separation of concerns, not decoding: the only
+thing Rust must own is the credential and the endpoint/auth headers built from it
+(`endpoint_for`, `auth_headers`, `validate_body`, and `redact_provider_detail` in
+`src-tauri/src/ai/providers.rs`). Rust relays raw SSE frames to the webview and the
+same TypeScript decoder maps them, so there is one decoder rather than two kept in
+agreement. Desktop already received raw provider error text before this design, so
+no secret crosses a boundary it did not already cross — but it makes redaction
+mandatory, in Rust, before frames leave the process. The desktop key boundary is a
+compile-time property: the shared `KeychainAdapter` interface does not declare
+`getKey`, so desktop code cannot ask for a key.
+
+Three places must name the same origins — the TypeScript endpoint table, the Rust
+constants, and the Tauri CSP `connect-src` allowlist — and
+`src/lib/adapters/provider-endpoints.test.ts` reads the other two from disk and
+fails on drift.
+
+`TransportFailureReason` (`network`, `malformedStream`, `responseTooLarge`) is the
+discriminator the retry policy and the client branch on; nothing branches by
+matching an error message.
+
+## Retry policy
+
+`src/lib/ai/protocol/retry.ts` wraps a transport with bounded retry.
+`createRetryingTransport(inner, policy, options)` returns a `ChatTransport`, and
+`src/lib/adapters/get-chat-transport.ts` wraps both platform transports with it so
+retry behaves identically on both. Retry is a transport concern, deliberately not
+a store one: it must never run after the store has begun rendering a partial turn.
+
+Two constraints bound it:
+
+- **Only before the first protocol event of the turn has reached the consumer.**
+  The decorator commits on the first frame it forwards to the client — which is at
+  or before the first protocol event the client maps from it — and never retries
+  after that. Replaying after any output would duplicate it. This is why the retry
+  lives below the client and not in a store loop.
+- **Only for transient failures.** A `429`, any `5xx`, and a below-HTTP `network`
+  failure are retried (`isRetriableHttpStatus`, `isRetriableTransportReason`).
+  A `4xx` other than `429`, a `malformedStream`, a `responseTooLarge`, and every
+  up-front refusal (`ChatTransport.open` rejecting for a missing key or a relay
+  refusal) are surfaced on the first attempt.
+
+The default policy (`DEFAULT_RETRY_POLICY`) is three attempts with exponential
+backoff capped at ten seconds. A provider `retry-after` hint is honored when
+present and is never shortened below the computed backoff. The backoff has no
+jitter, so the schedule is deterministic and testable; the sleep is injectable so
+tests advance without real time.
+
+## Error taxonomy and redaction
+
+`src/lib/ai/protocol/errors.ts` defines a **closed** `ProtocolErrorCode` union —
+`unsupported_capability`, `no_api_key`, `http_status`, `rate_limited`,
+`transport`, `malformed_stream`, `context_overflow`, `cancelled` — so every
+surface has to decide what each failure means to a user. A `ProtocolError`
+carries a one-sentence `message` authored by ThreatForge (safe to render, log,
+and persist) and an optional `providerDetail`.
+
+`redactProviderDetail` masks key-shaped tokens (`sk-…`, case-insensitive) and then
+caps the result at 200 characters, mask-before-truncate so a cut cannot leave a
+recognizable key prefix. Provider text is assumed to contain key material until
+proven otherwise — an OpenAI 401 body echoes the submitted key. The desktop relay
+applies the same rule in Rust before frames cross the IPC boundary.
+
+## The protocol client
+
+`streamConversation(request, transport, handlers, signal)` in
+`src/lib/ai/protocol/client.ts` runs one turn to a terminal event: preflight,
+budgeting, provider mapping, the transport, and decoding, emitting nothing but
+`StreamEvent`s. It resolves — never rejects — for every expected protocol
+outcome: preflight, budgeting, HTTP, transport, and up-front refusals all arrive
+as `error` events, and a stop arrives as `aborted`. It isolates the consumer
+callback so a throw from `onEvent` cannot tear down the stream on either platform,
+and it is where a `done` close with no terminal mapper event becomes a
+`malformed_stream` error.
+
+The chat store (`src/stores/chat-store.ts`) consumes those events: `text_delta`
+appends to the last assistant message's text block, `tool_call_complete` appends a
+tool-call block, `usage` and `stopReason` are recorded on the message, and `error`
+maps to the existing error banner through the authored `message`.
+
+## The fenced compatibility boundary
+
+Until native tool calling exists, the model still expresses edits and threats as
+fenced ` ```actions ` / ` ```threats ` blocks inside its answer text.
+`src/lib/ai/legacy/fenced-actions.ts` is the **only** place that fenced text may
+be parsed, and it consumes only accumulated `text_delta` output — never a raw
+provider payload or a tool-call block. `buildSystemPrompt`
+(`src/lib/ai-prompt.ts`) emits the fenced-action instructions only when the tool
+list is empty.
+
+`#64` removes the whole path in one move: flip `LEGACY_FENCED_ACTIONS_ENABLED` to
+`false`, delete `src/lib/ai/legacy/fenced-actions.ts`, and drop the
+`tools.length === 0` branch of `buildSystemPrompt`. Nothing else in the tree
+parses assistant prose, so those are the complete removal steps.
+
+## The fixture corpus
+
+`src/lib/ai/providers/test-fixtures/` holds hand-authored SSE transcripts written
+from each provider's documented event shapes — no fixture is recorded from a live
+account — stored as frame arrays and imported only by tests, so nothing ships in
+the bundle. `src/lib/ai/providers/test-fixtures/fake-stream.ts` turns a fixture
+into a byte-split `fetch` `Response` for the browser path (`fakeStream`) and
+replays the same frames through the desktop relay event shape (`replayTauriFrames`),
+so one corpus drives both transports.
+
+`src/lib/ai/protocol/contract.test.ts` runs the corpus against both providers and
+both transports and asserts the whole emitted event sequence for each case: a
+complete text and tool-call response, byte-split partial streams, a truncated
+stream that must report `malformed_stream`, malformed events (invalid JSON, an
+unknown event type, unparseable tool arguments, an orphan tool-input fragment), an
+in-stream rate limit with redacted detail, cancellation, an HTTP 429 with a
+`retry-after` hint, and the retry cases — a transient failure before the first
+event retries and then succeeds, a failure after the first `text_delta` is
+surfaced rather than retried, a non-retriable `4xx` is not retried, and the retry
+bound is respected.
+
+## Where each concern is verified
+
+Every test file colocates with the implementation it exercises.
+
+| Concern | Implementation | Tests |
+|---------|----------------|-------|
+| Message model, pairing, legacy upgrade | `src/lib/ai/protocol/messages.ts` | `src/lib/ai/protocol/messages.test.ts` |
+| Tool schema generation and validation | `src/lib/ai/protocol/tools.ts`, `src/lib/ai/schemas/actions.ts` | `src/lib/ai/protocol/tools.test.ts`, `src/lib/ai/schemas/actions.test.ts`, `src/lib/ai-actions.test.ts` |
+| Preflight and capabilities | `src/lib/ai/protocol/request.ts`, `src/lib/ai-models.ts` | `src/lib/ai/protocol/request.test.ts` |
+| Budgeting | `src/lib/ai/protocol/budget.ts` | `src/lib/ai/protocol/budget.test.ts` |
+| SSE decoder and mappers | `src/lib/ai/providers/sse.ts`, `src/lib/ai/providers/anthropic.ts`, `src/lib/ai/providers/openai.ts`, `src/lib/ai/providers/mapper-events.ts` | `src/lib/ai/providers/sse.test.ts`, `src/lib/ai/providers/anthropic.test.ts`, `src/lib/ai/providers/openai.test.ts` |
+| Transports and the key boundary | `src/lib/adapters/browser-chat-adapter.ts`, `src/lib/adapters/tauri-chat-adapter.ts`, `src/lib/adapters/chat-adapter.ts` | `src/lib/adapters/browser-chat-adapter.test.ts`, `src/lib/adapters/tauri-chat-adapter.test.ts`, `src/lib/adapters/provider-endpoints.test.ts` |
+| Rust relay and redaction | `src-tauri/src/ai/providers.rs`, `src-tauri/src/commands/ai_commands.rs` | `cargo test --manifest-path src-tauri/Cargo.toml ai::` |
+| Retry policy | `src/lib/ai/protocol/retry.ts` | `src/lib/ai/protocol/contract.test.ts` |
+| Error taxonomy and redaction | `src/lib/ai/protocol/errors.ts` | `src/lib/ai/protocol/errors.test.ts` |
+| Client orchestration and truncation | `src/lib/ai/protocol/client.ts` | `src/lib/ai/protocol/client.test.ts` |
+| Fixture corpus, failure modes | `src/lib/ai/providers/test-fixtures/` | `src/lib/ai/protocol/contract.test.ts` |
+| Store event consumption | `src/stores/chat-store.ts` | `src/stores/chat-store.test.ts` |

--- a/docs/knowledge/architecture.md
+++ b/docs/knowledge/architecture.md
@@ -36,6 +36,12 @@ In the browser, AI requests also go directly to the configured provider. Browser
 local browser storage with an explicit UI warning; desktop keys use the encrypted Rust
 storage path. Browser file operations use import/download adapters instead of Tauri IPC.
 
+The AI chat path — the provider-neutral message and event model, the browser/desktop
+transport split and why the desktop key stays in Rust, tool-schema generation, context
+budgeting, the retry policy, the error taxonomy and redaction rule, and the bounded fenced
+compatibility boundary — is documented in
+[`ai-protocol.md`](ai-protocol.md).
+
 ## Technology stack
 
 | Layer | Technology | Why |
@@ -343,7 +349,7 @@ npm run ci:docker:build  # Docker lint + test + Tauri build
 | Layer | Approach |
 |-------|---------|
 | API Key Storage | Desktop: AES-256-GCM encrypted file in app data directory. Browser: local storage with an explicit UI warning. |
-| AI API Calls | Direct from user's machine with user's key; HTTPS only |
+| AI API Calls | Direct from user's machine with user's key; HTTPS only. Provider decoding, request validation, and error redaction are shared and typed — see [`ai-protocol.md`](ai-protocol.md) |
 | File Integrity | Explicit version checks and typed deserialization; unknown fields remain tolerated for forward compatibility |
 | Auto-Update | Tauri updater can verify signed update metadata once signing is provisioned; rollout and end-to-end verification remain roadmap gates |
 | Supply Chain | Dependabot plus lockfile, dependency-review, and GitHub CodeQL default-setup checks |

--- a/src/lib/adapters/get-chat-transport.test.ts
+++ b/src/lib/adapters/get-chat-transport.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Production transport wiring.
+ *
+ * `getChatTransport` must wrap the platform transport in the retry decorator, so a
+ * transient failure before the first frame is retried on the real browser and
+ * desktop paths — not just in the decorator's own unit tests. Asserting the
+ * factory itself is what catches a "retry removed from production" regression that
+ * `retry.ts`'s tests would not.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildAnthropicRequestBody } from "@/lib/ai/providers/anthropic";
+import { ANTHROPIC_TEXT_STREAM } from "@/lib/ai/providers/test-fixtures/anthropic-fixtures";
+import { fakeErrorResponse, fakeStream } from "@/lib/ai/providers/test-fixtures/fake-stream";
+import { BrowserKeychainAdapter } from "./browser-keychain-adapter";
+import type { ProviderStreamRequest, TransportCallbacks } from "./chat-adapter";
+
+// Force the browser path so the factory builds the real BrowserChatTransport.
+vi.mock("@/lib/platform", () => ({ isTauri: () => false }));
+
+const request: ProviderStreamRequest = {
+	provider: "anthropic",
+	body: buildAnthropicRequestBody({
+		modelId: "claude-sonnet-4-20250514",
+		system: "system prompt",
+		messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+		tools: [],
+		maxOutputTokens: 1024,
+	}),
+};
+
+function recordingCallbacks() {
+	return {
+		onFrame: vi.fn(),
+		onHttpError: vi.fn(),
+		onTransportError: vi.fn(),
+		onClose: vi.fn(),
+	} satisfies TransportCallbacks;
+}
+
+beforeEach(async () => {
+	// The factory memoizes its transport in a module-level binding; reset the module
+	// registry so each test starts from a fresh, unwrapped-then-wrapped factory.
+	vi.resetModules();
+	vi.stubGlobal("fetch", vi.fn());
+	await new BrowserKeychainAdapter().setKey("anthropic", "sk-ant-wiring-test");
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	localStorage.clear();
+});
+
+describe("getChatTransport", () => {
+	it("wraps the platform transport so production retries a transient 429", async () => {
+		// First attempt: a retriable 429. Second: the real stream. If the factory did
+		// not wrap the transport in retry, the 429 would surface and fetch run once.
+		vi.mocked(fetch)
+			.mockResolvedValueOnce(fakeErrorResponse('{"type":"error"}', { status: 429 }))
+			.mockResolvedValueOnce(fakeStream(ANTHROPIC_TEXT_STREAM));
+		const { getChatTransport } = await import("./get-chat-transport");
+		const transport = await getChatTransport();
+		const callbacks = recordingCallbacks();
+
+		await transport.open(request, callbacks);
+
+		expect(fetch).toHaveBeenCalledTimes(2);
+		// The held 429 was retried, not surfaced; the second attempt streamed to done.
+		expect(callbacks.onHttpError).not.toHaveBeenCalled();
+		expect(callbacks.onFrame).toHaveBeenCalled();
+		expect(callbacks.onClose).toHaveBeenCalledWith("done");
+	});
+
+	it("memoizes the wrapped transport across calls", async () => {
+		const { getChatTransport } = await import("./get-chat-transport");
+		const first = await getChatTransport();
+		const second = await getChatTransport();
+		expect(second).toBe(first);
+	});
+});

--- a/src/lib/adapters/get-chat-transport.ts
+++ b/src/lib/adapters/get-chat-transport.ts
@@ -1,3 +1,4 @@
+import { createRetryingTransport } from "@/lib/ai/protocol/retry";
 import { isTauri } from "@/lib/platform";
 import type { ChatTransport } from "./chat-adapter";
 
@@ -9,19 +10,28 @@ import type { ChatTransport } from "./chat-adapter";
  * frames the same way on both platforms. The browser transport fetches the
  * provider directly with the user's stored key; the desktop transport relays
  * through Rust, which holds the key and owns the endpoint and headers.
+ *
+ * Both platform transports are wrapped in the retry decorator
+ * (`src/lib/ai/protocol/retry.ts`), so a transient `429`, `5xx`, or dropped
+ * connection before the first frame is retried identically on both platforms.
+ * Retry is a transport concern, not a store one: it must not run after the store
+ * has begun rendering a partial turn, and wrapping here keeps the client and
+ * store unaware of it.
  */
 let cached: ChatTransport | null = null;
 
 export async function getChatTransport(): Promise<ChatTransport> {
 	if (cached) return cached;
 
+	let platformTransport: ChatTransport;
 	if (isTauri()) {
 		const { TauriChatTransport } = await import("./tauri-chat-adapter");
-		cached = new TauriChatTransport();
+		platformTransport = new TauriChatTransport();
 	} else {
 		const { BrowserChatTransport } = await import("./browser-chat-adapter");
-		cached = new BrowserChatTransport();
+		platformTransport = new BrowserChatTransport();
 	}
 
+	cached = createRetryingTransport(platformTransport);
 	return cached;
 }

--- a/src/lib/ai/protocol/client.test.ts
+++ b/src/lib/ai/protocol/client.test.ts
@@ -170,6 +170,13 @@ describe("streamConversation orchestration", () => {
 					}),
 				});
 				cb.onFrame({ event: "content_block_stop", data: JSON.stringify({ index: 0 }) });
+				// A real tool-call turn still ends with a stop reason and message_stop;
+				// omitting them would trip truncation detection (see the truncation test).
+				cb.onFrame({
+					event: "message_delta",
+					data: JSON.stringify({ delta: { stop_reason: "tool_use" } }),
+				});
+				cb.onFrame({ event: "message_stop", data: "{}" });
 				cb.onClose("done");
 			}),
 			{ onEvent },
@@ -183,6 +190,63 @@ describe("streamConversation orchestration", () => {
 				id: "toolu_1",
 				name: "add_element",
 				input: { action: "add_element" },
+			},
+			{ type: "message_stop", stopReason: "tool_use" },
+		]);
+	});
+
+	it("surfaces a done close with no terminal event as malformed_stream, not a silent end", async () => {
+		// A stream that delivers text and then closes without a message_stop is
+		// truncated. Presenting it as a finished answer would be a success-shaped
+		// failure indistinguishable from a complete but short response.
+		const { events, onEvent } = collect();
+
+		await streamConversation(
+			anthropicRequest(),
+			scriptedTransport((cb) => {
+				cb.onFrame({
+					event: "content_block_delta",
+					data: JSON.stringify({ index: 0, delta: { type: "text_delta", text: "half a th" } }),
+				});
+				cb.onClose("done");
+			}),
+			{ onEvent },
+		);
+
+		expect(events).toEqual([
+			{ type: "text_delta", text: "half a th" },
+			{
+				type: "error",
+				error: { code: "malformed_stream", message: expect.stringContaining("ended before") },
+			},
+		]);
+	});
+
+	it("does not flag a done close as truncated when the provider already reported an error", async () => {
+		// An in-stream provider error is itself terminal; a truncation notice on top
+		// of it would be a second, redundant failure for the same turn.
+		const { events, onEvent } = collect();
+
+		await streamConversation(
+			anthropicRequest(),
+			scriptedTransport((cb) => {
+				cb.onFrame({
+					event: "error",
+					data: JSON.stringify({ error: { type: "overloaded_error", message: "Overloaded" } }),
+				});
+				cb.onClose("done");
+			}),
+			{ onEvent },
+		);
+
+		expect(events).toEqual([
+			{
+				type: "error",
+				error: {
+					code: "http_status",
+					message: "Anthropic reported an error while streaming the response.",
+					providerDetail: "overloaded_error: Overloaded",
+				},
 			},
 		]);
 	});

--- a/src/lib/ai/protocol/client.ts
+++ b/src/lib/ai/protocol/client.ts
@@ -239,7 +239,14 @@ export async function streamConversation(
 			// events rather than throwing), so only the consumer dispatch below can
 			// throw, and only it is isolated.
 			for (const event of mapper.mapFrame(frame)) {
-				if (event.type === "message_stop" || event.type === "error") {
+				// A `malformed_stream` error is a non-terminal notice scoped to one bad
+				// frame (see `events.ts`); the turn continues, so it must not count as
+				// the terminal event. Only a `message_stop` or a terminal provider error
+				// ends the turn.
+				if (
+					event.type === "message_stop" ||
+					(event.type === "error" && event.error.code !== "malformed_stream")
+				) {
 					sawTerminalEvent = true;
 				}
 				dispatch(event);

--- a/src/lib/ai/protocol/client.ts
+++ b/src/lib/ai/protocol/client.ts
@@ -227,12 +227,21 @@ export async function streamConversation(
 	};
 	const { streamRequest, mapper } = buildProviderStream(request.provider, providerRequest);
 
+	// Whether the mapper produced a terminal event before the stream closed. A
+	// normal `done` close after a `message_stop` (or after a provider error the
+	// mapper already reported) is complete; a `done` close with neither is a
+	// truncated response, which must not pass as a silent success (see `onClose`).
+	let sawTerminalEvent = false;
+
 	const callbacks: TransportCallbacks = {
 		onFrame: (frame) => {
 			// Mappers are total (they report undecodable frames as `malformed_stream`
 			// events rather than throwing), so only the consumer dispatch below can
 			// throw, and only it is isolated.
 			for (const event of mapper.mapFrame(frame)) {
+				if (event.type === "message_stop" || event.type === "error") {
+					sawTerminalEvent = true;
+				}
 				dispatch(event);
 			}
 		},
@@ -240,11 +249,24 @@ export async function streamConversation(
 		onTransportError: (failure) =>
 			dispatch({ type: "error", error: transportFailureToProtocolError(failure) }),
 		onClose: (reason) => {
-			// A normal close needs no event: the mapper already emitted `message_stop`
-			// if the provider sent one. Only cancellation has no in-band frame, so the
-			// client is what turns it into the terminal `aborted` event.
+			// Cancellation has no in-band frame, so the client is what turns it into
+			// the terminal `aborted` event.
 			if (reason === "cancelled") {
 				dispatch({ type: "aborted" });
+				return;
+			}
+			// A `done` close means the provider closed the body. If the mapper never
+			// reported a terminal event, the stream ended before it was complete: a
+			// truncated answer that renders as a finished one is a success-shaped
+			// failure, so it surfaces as `malformed_stream` rather than nothing.
+			if (!sawTerminalEvent) {
+				dispatch({
+					type: "error",
+					error: {
+						code: "malformed_stream",
+						message: "The AI response ended before it was complete. Please try again.",
+					},
+				});
 			}
 		},
 	};

--- a/src/lib/ai/protocol/contract.test.ts
+++ b/src/lib/ai/protocol/contract.test.ts
@@ -1,0 +1,740 @@
+/**
+ * Provider-contract corpus, failure modes, and the retry policy.
+ *
+ * Every case here runs against a deterministic fixture — a hand-authored SSE
+ * transcript, no key and no network — driven through the real protocol client
+ * and a real transport. The browser path uses a stubbed `fetch` returning
+ * `fakeStream`; the desktop path replays the same fixture frames through the real
+ * Tauri relay event shape. Because one corpus feeds both transports, an identical
+ * `StreamEvent` sequence across them is the transport-neutrality proof, and the
+ * shared `EXPECTED_*` sequences across the two providers are the
+ * provider-neutrality proof.
+ *
+ * Assertions check the whole emitted event sequence, never merely that no
+ * exception was thrown — a truncated stream that produced a silent `message_stop`
+ * would pass a "no throw" check while being exactly the success-shaped failure
+ * this corpus exists to catch.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BrowserChatTransport } from "@/lib/adapters/browser-chat-adapter";
+import { BrowserKeychainAdapter } from "@/lib/adapters/browser-keychain-adapter";
+import { TauriChatTransport } from "@/lib/adapters/tauri-chat-adapter";
+import type { StreamEvent } from "@/lib/ai/protocol/events";
+import type { AiProvider, ProtocolMessage } from "@/lib/ai/protocol/messages";
+import type { SseFrame } from "@/lib/ai/providers/sse";
+import {
+	ANTHROPIC_BAD_TOOL_ARGS_STREAM,
+	ANTHROPIC_INSTREAM_RATE_LIMIT_STREAM,
+	ANTHROPIC_INVALID_JSON_STREAM,
+	ANTHROPIC_ORPHAN_TOOL_INPUT_STREAM,
+	ANTHROPIC_TEXT_STREAM,
+	ANTHROPIC_TOOL_STREAM,
+	ANTHROPIC_TRUNCATED_STREAM,
+	ANTHROPIC_UNKNOWN_EVENT_STREAM,
+	EXPECTED_BAD_TOOL_ARGS_EVENTS,
+	EXPECTED_INSTREAM_RATE_LIMIT_EVENTS,
+	EXPECTED_INVALID_JSON_EVENTS,
+	EXPECTED_ORPHAN_TOOL_INPUT_EVENTS,
+	EXPECTED_TEXT_EVENTS,
+	EXPECTED_TOOL_EVENTS,
+	EXPECTED_TRUNCATED_EVENTS,
+	EXPECTED_UNKNOWN_EVENT_EVENTS,
+	FIXTURE_MODEL,
+} from "@/lib/ai/providers/test-fixtures/anthropic-fixtures";
+import {
+	fakeErrorResponse,
+	fakeStream,
+	replayTauriFrames,
+	serializeFrames,
+} from "@/lib/ai/providers/test-fixtures/fake-stream";
+import {
+	EXPECTED_OPENAI_BAD_TOOL_ARGS_EVENTS,
+	EXPECTED_OPENAI_INSTREAM_RATE_LIMIT_EVENTS,
+	EXPECTED_OPENAI_INVALID_JSON_EVENTS,
+	EXPECTED_OPENAI_ORPHAN_FRAGMENT_EVENTS,
+	OPENAI_BAD_TOOL_ARGS_STREAM,
+	OPENAI_INSTREAM_RATE_LIMIT_STREAM,
+	OPENAI_INVALID_JSON_STREAM,
+	OPENAI_ORPHAN_FRAGMENT_STREAM,
+	OPENAI_TEXT_STREAM,
+	OPENAI_TOOL_STREAM,
+	OPENAI_TRUNCATED_STREAM,
+} from "@/lib/ai/providers/test-fixtures/openai-fixtures";
+import { type ConversationRequest, streamConversation } from "./client";
+import {
+	createRetryingTransport,
+	DEFAULT_RETRY_POLICY,
+	isRetriableHttpStatus,
+	isRetriableTransportReason,
+	type RetryPolicy,
+	retryDelayMs,
+} from "./retry";
+
+// The desktop transport talks to Tauri; a fake relay stands in for the IPC layer,
+// driven with the same fixture frames the browser path decodes off `fetch`.
+const relay = vi.hoisted(() => {
+	type Handler = (event: { payload: unknown }) => void;
+	const handlers = new Map<string, Set<Handler>>();
+	const listen = vi.fn(async (name: string, handler: Handler): Promise<() => void> => {
+		const registered = handlers.get(name) ?? new Set<Handler>();
+		registered.add(handler);
+		handlers.set(name, registered);
+		return () => registered.delete(handler);
+	});
+	const invoke = vi.fn(async (_command: string, _args?: unknown): Promise<unknown> => undefined);
+	return {
+		listen,
+		invoke,
+		emit(name: string, payload: unknown): void {
+			for (const handler of [...(handlers.get(name) ?? [])]) handler({ payload });
+		},
+		reset(): void {
+			handlers.clear();
+			listen.mockClear();
+			invoke.mockReset();
+			invoke.mockResolvedValue(undefined);
+		},
+	};
+});
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: relay.invoke }));
+vi.mock("@tauri-apps/api/event", () => ({ listen: relay.listen }));
+
+const KNOWN_MODEL: Record<AiProvider, string> = {
+	anthropic: "claude-sonnet-4-20250514",
+	openai: "gpt-4o",
+};
+
+const ANTHROPIC_KEY = "sk-ant-contract-test-key";
+const OPENAI_KEY = "sk-proj-contract-test-key";
+
+const userTurn: ProtocolMessage[] = [{ role: "user", content: [{ type: "text", text: "hi" }] }];
+
+function request(provider: AiProvider): ConversationRequest {
+	return {
+		provider,
+		modelId: KNOWN_MODEL[provider],
+		system: "system prompt",
+		messages: userTurn,
+		tools: [],
+		maxOutputTokens: 1024,
+	};
+}
+
+function collect(): { events: StreamEvent[]; onEvent: (event: StreamEvent) => void } {
+	const events: StreamEvent[] = [];
+	return { events, onEvent: (event) => events.push(event) };
+}
+
+/** Every `start_ai_stream` argument the fake relay has been invoked with, in order. */
+function startCalls(): Array<{ streamId: string }> {
+	return relay.invoke.mock.calls
+		.filter((call) => call[0] === "start_ai_stream")
+		.map((call) => call[1] as { streamId: string });
+}
+
+/** Wait until the desktop transport has invoked `start_ai_stream` at least `n` times. */
+async function nthStreamId(n: number): Promise<string> {
+	await vi.waitFor(() => {
+		expect(startCalls().length).toBeGreaterThanOrEqual(n);
+	});
+	return startCalls()[n - 1].streamId;
+}
+
+/** Run a fixture through the real browser transport with a stubbed `fetch`. */
+async function runBrowser(
+	provider: AiProvider,
+	frames: SseFrame[],
+	options: { splitAt?: number[] } = {},
+): Promise<StreamEvent[]> {
+	vi.mocked(fetch).mockResolvedValue(fakeStream(frames, options));
+	const { events, onEvent } = collect();
+	await streamConversation(request(provider), new BrowserChatTransport(), { onEvent });
+	return events;
+}
+
+/** Run a fixture through the real desktop transport, replaying frames over the relay. */
+async function runTauri(provider: AiProvider, frames: SseFrame[]): Promise<StreamEvent[]> {
+	const { events, onEvent } = collect();
+	const open = streamConversation(request(provider), new TauriChatTransport(), { onEvent });
+	const streamId = await nthStreamId(1);
+	replayTauriFrames(relay, streamId, frames);
+	await open;
+	return events;
+}
+
+/** A response body that stays open until the test pushes to it or the reader cancels it. */
+function openResponse(): {
+	response: Response;
+	push: (text: string) => boolean;
+	cancelled: () => boolean;
+} {
+	const encoder = new TextEncoder();
+	let wasCancelled = false;
+	let sink: ReadableStreamDefaultController<Uint8Array> | undefined;
+	const body = new ReadableStream<Uint8Array>({
+		start(controller) {
+			sink = controller;
+		},
+		cancel() {
+			wasCancelled = true;
+		},
+	});
+	return {
+		response: new Response(body),
+		push: (text: string): boolean => {
+			try {
+				sink?.enqueue(encoder.encode(text));
+				return true;
+			} catch {
+				return false;
+			}
+		},
+		cancelled: () => wasCancelled,
+	};
+}
+
+/** A `delay` that never waits but records the schedule, for deterministic retry tests. */
+function recordingDelay(): { waits: number[]; delay: (ms: number) => Promise<void> } {
+	const waits: number[] = [];
+	return {
+		waits,
+		delay: (ms: number) => {
+			waits.push(ms);
+			return Promise.resolve();
+		},
+	};
+}
+
+const RETRY_POLICY: RetryPolicy = { maxAttempts: 3, baseDelayMs: 500, maxDelayMs: 10_000 };
+
+type Runner = (provider: AiProvider, frames: SseFrame[]) => Promise<StreamEvent[]>;
+const TRANSPORTS: Array<[string, Runner]> = [
+	["browser", runBrowser],
+	["desktop", runTauri],
+];
+
+beforeEach(async () => {
+	relay.reset();
+	vi.stubGlobal("fetch", vi.fn());
+	await new BrowserKeychainAdapter().setKey("anthropic", ANTHROPIC_KEY);
+	await new BrowserKeychainAdapter().setKey("openai", OPENAI_KEY);
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.useRealTimers();
+	localStorage.clear();
+});
+
+describe("provider and transport neutrality", () => {
+	it.each(TRANSPORTS)("decodes a complete Anthropic text response on %s", async (_t, run) => {
+		expect(await run("anthropic", ANTHROPIC_TEXT_STREAM)).toEqual(EXPECTED_TEXT_EVENTS);
+	});
+
+	it.each(TRANSPORTS)("decodes a complete OpenAI text response on %s", async (_t, run) => {
+		expect(await run("openai", OPENAI_TEXT_STREAM)).toEqual(EXPECTED_TEXT_EVENTS);
+	});
+
+	it.each(TRANSPORTS)("decodes a complete Anthropic tool-call response on %s", async (_t, run) => {
+		expect(await run("anthropic", ANTHROPIC_TOOL_STREAM)).toEqual(EXPECTED_TOOL_EVENTS);
+	});
+
+	it.each(TRANSPORTS)("decodes a complete OpenAI tool-call response on %s", async (_t, run) => {
+		expect(await run("openai", OPENAI_TOOL_STREAM)).toEqual(EXPECTED_TOOL_EVENTS);
+	});
+
+	it("tolerates unknown Anthropic event types on both transports", async () => {
+		expect(await runBrowser("anthropic", ANTHROPIC_UNKNOWN_EVENT_STREAM)).toEqual(
+			EXPECTED_UNKNOWN_EVENT_EVENTS,
+		);
+		expect(await runTauri("anthropic", ANTHROPIC_UNKNOWN_EVENT_STREAM)).toEqual(
+			EXPECTED_UNKNOWN_EVENT_EVENTS,
+		);
+	});
+});
+
+describe("partial streams split at arbitrary byte boundaries (browser)", () => {
+	// A short transcript whose text carries multi-byte UTF-8 ("café ☕"), so a
+	// byte-offset split lands mid-line, mid-JSON, and mid-multi-byte-sequence.
+	const MULTIBYTE_FRAMES: SseFrame[] = [
+		{ event: "message_start", data: JSON.stringify({ message: { model: FIXTURE_MODEL } }) },
+		{
+			event: "content_block_delta",
+			data: JSON.stringify({ index: 0, delta: { type: "text_delta", text: "café ☕ review" } }),
+		},
+		{ event: "message_stop", data: JSON.stringify({ type: "message_stop" }) },
+	];
+	const MULTIBYTE_EXPECTED: StreamEvent[] = [
+		{ type: "message_start", model: FIXTURE_MODEL },
+		{ type: "text_delta", text: "café ☕ review" },
+		{ type: "message_stop", stopReason: "unknown" },
+	];
+
+	it("decodes identically at every interior byte offset", async () => {
+		const bytes = new TextEncoder().encode(serializeFrames(MULTIBYTE_FRAMES));
+		for (let offset = 1; offset < bytes.length; offset += 1) {
+			vi.mocked(fetch).mockResolvedValue(fakeStream(MULTIBYTE_FRAMES, { splitAt: [offset] }));
+			const { events, onEvent } = collect();
+			await streamConversation(request("anthropic"), new BrowserChatTransport(), { onEvent });
+			expect(events, `split at byte offset ${offset}`).toEqual(MULTIBYTE_EXPECTED);
+		}
+	});
+
+	it("decodes a whole fixture split at several interior offsets at once", async () => {
+		const events = await runBrowser("anthropic", ANTHROPIC_TEXT_STREAM, {
+			splitAt: [10, 40, 90, 130],
+		});
+		expect(events).toEqual(EXPECTED_TEXT_EVENTS);
+	});
+});
+
+describe("truncated stream — ends without a terminal event", () => {
+	// The one case the plan calls out by name: a stream that ends with no
+	// message_stop must surface `malformed_stream`, never a silent success.
+	it.each([
+		["browser Anthropic", runBrowser, "anthropic", ANTHROPIC_TRUNCATED_STREAM] as const,
+		["desktop Anthropic", runTauri, "anthropic", ANTHROPIC_TRUNCATED_STREAM] as const,
+		["browser OpenAI", runBrowser, "openai", OPENAI_TRUNCATED_STREAM] as const,
+		["desktop OpenAI", runTauri, "openai", OPENAI_TRUNCATED_STREAM] as const,
+	])("reports malformed_stream, not a silent end, on %s", async (_label, run, provider, frames) => {
+		const events = await run(provider, frames);
+		expect(events).toEqual(EXPECTED_TRUNCATED_EVENTS);
+		// Guard the exact failure the plan warns against: the last event must be the
+		// malformed_stream error, not a fabricated message_stop.
+		expect(events[events.length - 1]).toEqual({
+			type: "error",
+			error: { code: "malformed_stream", message: expect.stringContaining("ended before") },
+		});
+		expect(events).not.toContainEqual(expect.objectContaining({ type: "message_stop" }));
+	});
+});
+
+describe("malformed events are reported without aborting the turn", () => {
+	it.each([
+		[
+			"browser Anthropic invalid JSON",
+			runBrowser,
+			"anthropic",
+			ANTHROPIC_INVALID_JSON_STREAM,
+			EXPECTED_INVALID_JSON_EVENTS,
+		] as const,
+		[
+			"desktop Anthropic invalid JSON",
+			runTauri,
+			"anthropic",
+			ANTHROPIC_INVALID_JSON_STREAM,
+			EXPECTED_INVALID_JSON_EVENTS,
+		] as const,
+		[
+			"browser OpenAI invalid JSON",
+			runBrowser,
+			"openai",
+			OPENAI_INVALID_JSON_STREAM,
+			EXPECTED_OPENAI_INVALID_JSON_EVENTS,
+		] as const,
+		[
+			"desktop OpenAI invalid JSON",
+			runTauri,
+			"openai",
+			OPENAI_INVALID_JSON_STREAM,
+			EXPECTED_OPENAI_INVALID_JSON_EVENTS,
+		] as const,
+		[
+			"browser Anthropic bad tool args",
+			runBrowser,
+			"anthropic",
+			ANTHROPIC_BAD_TOOL_ARGS_STREAM,
+			EXPECTED_BAD_TOOL_ARGS_EVENTS,
+		] as const,
+		[
+			"desktop Anthropic bad tool args",
+			runTauri,
+			"anthropic",
+			ANTHROPIC_BAD_TOOL_ARGS_STREAM,
+			EXPECTED_BAD_TOOL_ARGS_EVENTS,
+		] as const,
+		[
+			"browser OpenAI bad tool args",
+			runBrowser,
+			"openai",
+			OPENAI_BAD_TOOL_ARGS_STREAM,
+			EXPECTED_OPENAI_BAD_TOOL_ARGS_EVENTS,
+		] as const,
+		[
+			"browser Anthropic orphan tool input",
+			runBrowser,
+			"anthropic",
+			ANTHROPIC_ORPHAN_TOOL_INPUT_STREAM,
+			EXPECTED_ORPHAN_TOOL_INPUT_EVENTS,
+		] as const,
+		[
+			"browser OpenAI orphan tool fragment",
+			runBrowser,
+			"openai",
+			OPENAI_ORPHAN_FRAGMENT_STREAM,
+			EXPECTED_OPENAI_ORPHAN_FRAGMENT_EVENTS,
+		] as const,
+	])(
+		"maps %s to a malformed_stream notice and still finishes",
+		async (_label, run, provider, frames, expected) => {
+			expect(await run(provider, frames)).toEqual(expected);
+		},
+	);
+
+	it("keeps a hostile stream-supplied tool name out of the authored message", async () => {
+		const events = await runBrowser("anthropic", ANTHROPIC_BAD_TOOL_ARGS_STREAM);
+		const failure = events.find((event) => event.type === "error");
+		if (failure?.type !== "error") throw new Error("expected a malformed_stream error");
+		expect(failure.error.message).toBe(
+			"A tool call sent arguments that were not valid JSON, so the call was dropped.",
+		);
+		// The tool name survives only as providerDetail, never inside the message.
+		expect(failure.error.providerDetail).toBe("add_element");
+	});
+});
+
+describe("in-stream rate limit (a provider error event, after text)", () => {
+	it.each([
+		[
+			"browser Anthropic",
+			runBrowser,
+			"anthropic",
+			ANTHROPIC_INSTREAM_RATE_LIMIT_STREAM,
+			EXPECTED_INSTREAM_RATE_LIMIT_EVENTS,
+		] as const,
+		[
+			"desktop Anthropic",
+			runTauri,
+			"anthropic",
+			ANTHROPIC_INSTREAM_RATE_LIMIT_STREAM,
+			EXPECTED_INSTREAM_RATE_LIMIT_EVENTS,
+		] as const,
+		[
+			"browser OpenAI",
+			runBrowser,
+			"openai",
+			OPENAI_INSTREAM_RATE_LIMIT_STREAM,
+			EXPECTED_OPENAI_INSTREAM_RATE_LIMIT_EVENTS,
+		] as const,
+	])(
+		"surfaces a redacted rate_limited error on %s",
+		async (_label, run, provider, frames, expected) => {
+			const events = await run(provider, frames);
+			expect(events).toEqual(expected);
+			const failure = events.find((event) => event.type === "error");
+			if (failure?.type !== "error") throw new Error("expected a rate_limited error");
+			expect(failure.error.providerDetail).toContain("[redacted-key]");
+			expect(failure.error.providerDetail).not.toMatch(/sk-(ant|proj)/);
+		},
+	);
+});
+
+describe("HTTP rate limit (a 429 response) carries a retry hint and redacted detail", () => {
+	const RATE_LIMIT_BODY_WITH_KEY = JSON.stringify({
+		type: "error",
+		error: {
+			type: "rate_limit_error",
+			message: "Slow down; key sk-ant-live-SECRET99 is over its limit",
+		},
+	});
+
+	it("forwards retryAfterMs into the retry schedule and redacts the surfaced detail", async () => {
+		// Every attempt is a 429 with a 1-second retry-after, so the turn exhausts
+		// its retries and the final rate_limited error is what the consumer sees.
+		vi.mocked(fetch).mockImplementation(async () =>
+			fakeErrorResponse(RATE_LIMIT_BODY_WITH_KEY, { status: 429, headers: { "retry-after": "1" } }),
+		);
+		const { waits, delay } = recordingDelay();
+		const { events, onEvent } = collect();
+
+		await streamConversation(
+			request("anthropic"),
+			createRetryingTransport(new BrowserChatTransport(), RETRY_POLICY, { delay }),
+			{ onEvent },
+		);
+
+		// The provider's 1-second hint is honored on each retry, never shortened.
+		expect(waits).toEqual([1000, 1000]);
+		expect(fetch).toHaveBeenCalledTimes(3);
+		expect(events).toHaveLength(1);
+		const failure = events[0];
+		if (failure.type !== "error") throw new Error("expected a rate_limited error");
+		expect(failure.error.code).toBe("rate_limited");
+		expect(failure.error.providerDetail).toContain("[redacted-key]");
+		expect(failure.error.providerDetail).not.toContain("SECRET99");
+		expect(failure.error.providerDetail).not.toContain("sk-ant");
+	});
+});
+
+describe("cancellation is a terminal aborted, with no events afterward", () => {
+	it("aborts a browser stream mid-flight and cancels the reader", async () => {
+		const controller = new AbortController();
+		const provider = openResponse();
+		vi.mocked(fetch).mockResolvedValue(provider.response);
+		const { events, onEvent } = collect();
+
+		const open = streamConversation(
+			request("anthropic"),
+			new BrowserChatTransport(),
+			{ onEvent },
+			controller.signal,
+		);
+		provider.push(
+			'event: content_block_delta\ndata: {"index":0,"delta":{"type":"text_delta","text":"partial"}}\n\n',
+		);
+		await vi.waitFor(() => {
+			expect(events.some((event) => event.type === "text_delta")).toBe(true);
+		});
+
+		controller.abort();
+		await open;
+
+		expect(events).toEqual([{ type: "text_delta", text: "partial" }, { type: "aborted" }]);
+		expect(provider.cancelled()).toBe(true);
+		// The reader is released, so the provider has nowhere left to deliver.
+		expect(provider.push("data: after-abort\n\n")).toBe(false);
+		expect(events).toHaveLength(2);
+	});
+
+	it("aborts a desktop stream, cancels the matching id, and drops later frames", async () => {
+		const controller = new AbortController();
+		const { events, onEvent } = collect();
+
+		const open = streamConversation(
+			request("anthropic"),
+			new TauriChatTransport(),
+			{ onEvent },
+			controller.signal,
+		);
+		const streamId = await nthStreamId(1);
+		relay.emit("ai:stream-frame", {
+			streamId,
+			event: "content_block_delta",
+			data: JSON.stringify({ index: 0, delta: { type: "text_delta", text: "partial" } }),
+		});
+
+		controller.abort();
+		await open;
+
+		expect(events).toEqual([{ type: "text_delta", text: "partial" }, { type: "aborted" }]);
+		const cancelCalls = relay.invoke.mock.calls
+			.filter((call) => call[0] === "cancel_ai_stream")
+			.map((call) => call[1]);
+		expect(cancelCalls).toEqual([{ streamId }]);
+
+		// A frame the relay emits after the stop is ignored, not appended.
+		relay.emit("ai:stream-frame", { streamId, event: "message", data: "late" });
+		expect(events).toHaveLength(2);
+	});
+});
+
+describe("retry policy predicates and schedule", () => {
+	it.each([
+		[429, true],
+		[500, true],
+		[503, true],
+		[599, true],
+		[400, false],
+		[401, false],
+		[404, false],
+		[200, false],
+	])("treats HTTP %i as retriable=%s", (status, retriable) => {
+		expect(isRetriableHttpStatus(status)).toBe(retriable);
+	});
+
+	it.each([
+		["network", true],
+		["malformedStream", false],
+		["responseTooLarge", false],
+	] as const)("treats a %s transport failure as retriable=%s", (reason, retriable) => {
+		expect(isRetriableTransportReason(reason)).toBe(retriable);
+	});
+
+	it("computes exponential backoff and honors a retry-after floor", () => {
+		expect(retryDelayMs(1, RETRY_POLICY)).toBe(500);
+		expect(retryDelayMs(2, RETRY_POLICY)).toBe(1000);
+		expect(retryDelayMs(3, RETRY_POLICY)).toBe(2000);
+		// A retry-after longer than the backoff wins; a shorter one never shortens it.
+		expect(retryDelayMs(1, RETRY_POLICY, 5000)).toBe(5000);
+		expect(retryDelayMs(3, RETRY_POLICY, 100)).toBe(2000);
+	});
+
+	it("caps computed backoff at maxDelayMs while still honoring a larger retry-after", () => {
+		const tight: RetryPolicy = { maxAttempts: 10, baseDelayMs: 1000, maxDelayMs: 3000 };
+		expect(retryDelayMs(9, tight)).toBe(3000);
+		expect(retryDelayMs(9, tight, 60_000)).toBe(60_000);
+	});
+
+	it("ships a conservative default policy", () => {
+		expect(DEFAULT_RETRY_POLICY.maxAttempts).toBe(3);
+		expect(DEFAULT_RETRY_POLICY.maxAttempts).toBeGreaterThan(1);
+	});
+});
+
+describe("retry only before the first event, only for transient failures", () => {
+	it("retries a 429 that arrives before any event, then succeeds (browser)", async () => {
+		vi.mocked(fetch)
+			.mockResolvedValueOnce(
+				fakeErrorResponse('{"type":"error"}', { status: 429, headers: { "retry-after": "2" } }),
+			)
+			.mockResolvedValueOnce(fakeStream(ANTHROPIC_TEXT_STREAM));
+		const { waits, delay } = recordingDelay();
+		const { events, onEvent } = collect();
+
+		await streamConversation(
+			request("anthropic"),
+			createRetryingTransport(new BrowserChatTransport(), RETRY_POLICY, { delay }),
+			{ onEvent },
+		);
+
+		expect(events).toEqual(EXPECTED_TEXT_EVENTS);
+		expect(fetch).toHaveBeenCalledTimes(2);
+		expect(waits).toEqual([2000]);
+	});
+
+	it("retries a dropped connection before any frame, then succeeds (browser)", async () => {
+		const dropped = new ReadableStream<Uint8Array>({
+			pull(controller) {
+				controller.error(new TypeError("connection reset"));
+			},
+		});
+		vi.mocked(fetch)
+			.mockResolvedValueOnce(new Response(dropped))
+			.mockResolvedValueOnce(fakeStream(ANTHROPIC_TEXT_STREAM));
+		const { waits, delay } = recordingDelay();
+		const { events, onEvent } = collect();
+
+		await streamConversation(
+			request("anthropic"),
+			createRetryingTransport(new BrowserChatTransport(), RETRY_POLICY, { delay }),
+			{ onEvent },
+		);
+
+		expect(events).toEqual(EXPECTED_TEXT_EVENTS);
+		expect(fetch).toHaveBeenCalledTimes(2);
+		expect(waits).toEqual([500]);
+	});
+
+	it("does NOT retry a failure that arrives after the first text_delta (browser)", async () => {
+		// A text frame reaches the consumer, then the connection drops. Replaying would
+		// duplicate the text already rendered, so the drop is surfaced, never retried.
+		const encoder = new TextEncoder();
+		const partialThenDrop = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(
+					encoder.encode(
+						'event: content_block_delta\ndata: {"index":0,"delta":{"type":"text_delta","text":"partial"}}\n\n',
+					),
+				);
+			},
+			pull(controller) {
+				controller.error(new TypeError("connection reset"));
+			},
+		});
+		vi.mocked(fetch).mockResolvedValue(new Response(partialThenDrop));
+		const { waits, delay } = recordingDelay();
+		const { events, onEvent } = collect();
+
+		await streamConversation(
+			request("anthropic"),
+			createRetryingTransport(new BrowserChatTransport(), RETRY_POLICY, { delay }),
+			{ onEvent },
+		);
+
+		expect(events).toEqual([
+			{ type: "text_delta", text: "partial" },
+			{ type: "error", error: { code: "transport", message: expect.any(String) } },
+		]);
+		expect(fetch).toHaveBeenCalledTimes(1);
+		expect(waits).toEqual([]);
+	});
+
+	it("does NOT retry an in-stream 429 that arrives after text (browser)", async () => {
+		// The rate limit is a mapper-level event after a text_delta, so it is committed
+		// output: surfaced as a rate_limited error, and the request is made only once.
+		vi.mocked(fetch).mockResolvedValue(fakeStream(ANTHROPIC_INSTREAM_RATE_LIMIT_STREAM));
+		const { waits, delay } = recordingDelay();
+		const { events, onEvent } = collect();
+
+		await streamConversation(
+			request("anthropic"),
+			createRetryingTransport(new BrowserChatTransport(), RETRY_POLICY, { delay }),
+			{ onEvent },
+		);
+
+		expect(events).toEqual(EXPECTED_INSTREAM_RATE_LIMIT_EVENTS);
+		expect(fetch).toHaveBeenCalledTimes(1);
+		expect(waits).toEqual([]);
+	});
+
+	it.each([400, 401, 403, 404])("does NOT retry a non-retriable %i (browser)", async (status) => {
+		vi.mocked(fetch).mockResolvedValue(
+			fakeErrorResponse('{"error":{"message":"nope"}}', { status }),
+		);
+		const { waits, delay } = recordingDelay();
+		const { events, onEvent } = collect();
+
+		await streamConversation(
+			request("openai"),
+			createRetryingTransport(new BrowserChatTransport(), RETRY_POLICY, { delay }),
+			{ onEvent },
+		);
+
+		expect(fetch).toHaveBeenCalledTimes(1);
+		expect(waits).toEqual([]);
+		expect(events).toHaveLength(1);
+		expect(events[0]).toMatchObject({ type: "error", error: { code: "http_status" } });
+	});
+
+	it("respects the retry bound and then surfaces the failure (browser)", async () => {
+		vi.mocked(fetch).mockImplementation(async () =>
+			fakeErrorResponse('{"error":{"message":"upstream"}}', { status: 500 }),
+		);
+		const { waits, delay } = recordingDelay();
+		const { events, onEvent } = collect();
+
+		await streamConversation(
+			request("openai"),
+			createRetryingTransport(new BrowserChatTransport(), RETRY_POLICY, { delay }),
+			{ onEvent },
+		);
+
+		// Three attempts total (the bound), two backoff waits between them.
+		expect(fetch).toHaveBeenCalledTimes(3);
+		expect(waits).toEqual([500, 1000]);
+		expect(events).toHaveLength(1);
+		expect(events[0]).toMatchObject({ type: "error", error: { code: "http_status" } });
+	});
+
+	it("retries a desktop httpError before any frame, then succeeds", async () => {
+		const { waits, delay } = recordingDelay();
+		const { events, onEvent } = collect();
+
+		const open = streamConversation(
+			request("anthropic"),
+			createRetryingTransport(new TauriChatTransport(), RETRY_POLICY, { delay }),
+			{ onEvent },
+		);
+
+		// Attempt 1: the relay closes with a retriable 503 and no frames.
+		const firstId = await nthStreamId(1);
+		replayTauriFrames(relay, firstId, [], {
+			kind: "httpError",
+			status: 503,
+			message: "temporarily unavailable",
+		});
+
+		// Attempt 2: a fresh stream id, replayed to success.
+		const secondId = await nthStreamId(2);
+		expect(secondId).not.toBe(firstId);
+		replayTauriFrames(relay, secondId, ANTHROPIC_TEXT_STREAM);
+
+		await open;
+
+		expect(events).toEqual(EXPECTED_TEXT_EVENTS);
+		expect(startCalls()).toHaveLength(2);
+		expect(waits).toEqual([500]);
+	});
+});

--- a/src/lib/ai/protocol/contract.test.ts
+++ b/src/lib/ai/protocol/contract.test.ts
@@ -24,9 +24,11 @@ import type { StreamEvent } from "@/lib/ai/protocol/events";
 import type { AiProvider, ProtocolMessage } from "@/lib/ai/protocol/messages";
 import type { SseFrame } from "@/lib/ai/providers/sse";
 import {
+	ANTHROPIC_429_BODY,
 	ANTHROPIC_BAD_TOOL_ARGS_STREAM,
 	ANTHROPIC_INSTREAM_RATE_LIMIT_STREAM,
 	ANTHROPIC_INVALID_JSON_STREAM,
+	ANTHROPIC_NOTICE_THEN_TRUNCATED_STREAM,
 	ANTHROPIC_ORPHAN_TOOL_INPUT_STREAM,
 	ANTHROPIC_TEXT_STREAM,
 	ANTHROPIC_TOOL_STREAM,
@@ -35,6 +37,7 @@ import {
 	EXPECTED_BAD_TOOL_ARGS_EVENTS,
 	EXPECTED_INSTREAM_RATE_LIMIT_EVENTS,
 	EXPECTED_INVALID_JSON_EVENTS,
+	EXPECTED_NOTICE_THEN_TRUNCATED_EVENTS,
 	EXPECTED_ORPHAN_TOOL_INPUT_EVENTS,
 	EXPECTED_TEXT_EVENTS,
 	EXPECTED_TOOL_EVENTS,
@@ -53,6 +56,7 @@ import {
 	EXPECTED_OPENAI_INSTREAM_RATE_LIMIT_EVENTS,
 	EXPECTED_OPENAI_INVALID_JSON_EVENTS,
 	EXPECTED_OPENAI_ORPHAN_FRAGMENT_EVENTS,
+	OPENAI_429_BODY,
 	OPENAI_BAD_TOOL_ARGS_STREAM,
 	OPENAI_INSTREAM_RATE_LIMIT_STREAM,
 	OPENAI_INVALID_JSON_STREAM,
@@ -309,6 +313,21 @@ describe("truncated stream — ends without a terminal event", () => {
 		});
 		expect(events).not.toContainEqual(expect.objectContaining({ type: "message_stop" }));
 	});
+
+	it.each([["browser", runBrowser] as const, ["desktop", runTauri] as const])(
+		"still reports truncation after a non-terminal malformed_stream notice on %s",
+		async (_t, run) => {
+			// A malformed_stream notice is non-terminal (see events.ts). A close with no
+			// message_stop after one is still a truncation, so the turn ends with a second,
+			// terminal malformed_stream — the notice must not suppress it.
+			const events = await run("anthropic", ANTHROPIC_NOTICE_THEN_TRUNCATED_STREAM);
+			expect(events).toEqual(EXPECTED_NOTICE_THEN_TRUNCATED_EVENTS);
+			expect(events[events.length - 1]).toEqual({
+				type: "error",
+				error: { code: "malformed_stream", message: expect.stringContaining("ended before") },
+			});
+		},
+	);
 });
 
 describe("malformed events are reported without aborting the turn", () => {
@@ -432,40 +451,36 @@ describe("in-stream rate limit (a provider error event, after text)", () => {
 });
 
 describe("HTTP rate limit (a 429 response) carries a retry hint and redacted detail", () => {
-	const RATE_LIMIT_BODY_WITH_KEY = JSON.stringify({
-		type: "error",
-		error: {
-			type: "rate_limit_error",
-			message: "Slow down; key sk-ant-live-SECRET99 is over its limit",
+	it.each([["anthropic", ANTHROPIC_429_BODY] as const, ["openai", OPENAI_429_BODY] as const])(
+		"forwards retryAfterMs into the retry schedule and redacts the %s detail",
+		async (provider, body) => {
+			// Every attempt is a 429 with a 1-second retry-after, so the turn exhausts
+			// its retries and the final rate_limited error is what the consumer sees.
+			vi.mocked(fetch).mockImplementation(async () =>
+				fakeErrorResponse(body, { status: 429, headers: { "retry-after": "1" } }),
+			);
+			const { waits, delay } = recordingDelay();
+			const { events, onEvent } = collect();
+
+			await streamConversation(
+				request(provider),
+				createRetryingTransport(new BrowserChatTransport(), RETRY_POLICY, { delay }),
+				{ onEvent },
+			);
+
+			// The provider's 1-second hint is honored on each retry, never shortened.
+			expect(waits).toEqual([1000, 1000]);
+			expect(fetch).toHaveBeenCalledTimes(3);
+			expect(events).toHaveLength(1);
+			const failure = events[0];
+			if (failure.type !== "error") throw new Error("expected a rate_limited error");
+			expect(failure.error.code).toBe("rate_limited");
+			// The canonical 429 fixture bodies embed a key token; it must be redacted.
+			expect(failure.error.providerDetail).toContain("[redacted-key]");
+			expect(failure.error.providerDetail).not.toContain("RL429SECRET");
+			expect(failure.error.providerDetail).not.toMatch(/sk-(ant|proj)/);
 		},
-	});
-
-	it("forwards retryAfterMs into the retry schedule and redacts the surfaced detail", async () => {
-		// Every attempt is a 429 with a 1-second retry-after, so the turn exhausts
-		// its retries and the final rate_limited error is what the consumer sees.
-		vi.mocked(fetch).mockImplementation(async () =>
-			fakeErrorResponse(RATE_LIMIT_BODY_WITH_KEY, { status: 429, headers: { "retry-after": "1" } }),
-		);
-		const { waits, delay } = recordingDelay();
-		const { events, onEvent } = collect();
-
-		await streamConversation(
-			request("anthropic"),
-			createRetryingTransport(new BrowserChatTransport(), RETRY_POLICY, { delay }),
-			{ onEvent },
-		);
-
-		// The provider's 1-second hint is honored on each retry, never shortened.
-		expect(waits).toEqual([1000, 1000]);
-		expect(fetch).toHaveBeenCalledTimes(3);
-		expect(events).toHaveLength(1);
-		const failure = events[0];
-		if (failure.type !== "error") throw new Error("expected a rate_limited error");
-		expect(failure.error.code).toBe("rate_limited");
-		expect(failure.error.providerDetail).toContain("[redacted-key]");
-		expect(failure.error.providerDetail).not.toContain("SECRET99");
-		expect(failure.error.providerDetail).not.toContain("sk-ant");
-	});
+	);
 });
 
 describe("cancellation is a terminal aborted, with no events afterward", () => {
@@ -567,9 +582,14 @@ describe("retry policy predicates and schedule", () => {
 		expect(retryDelayMs(9, tight, 60_000)).toBe(60_000);
 	});
 
+	it("caps an absurd retry-after so a provider cannot park a retry indefinitely", () => {
+		// The chokepoint is self-sufficient: even if a transport failed to clamp the
+		// hint, retryDelayMs bounds it to ten minutes rather than honoring it whole.
+		expect(retryDelayMs(1, RETRY_POLICY, 999_999_999)).toBe(10 * 60 * 1000);
+	});
+
 	it("ships a conservative default policy", () => {
 		expect(DEFAULT_RETRY_POLICY.maxAttempts).toBe(3);
-		expect(DEFAULT_RETRY_POLICY.maxAttempts).toBeGreaterThan(1);
 	});
 });
 

--- a/src/lib/ai/protocol/retry.ts
+++ b/src/lib/ai/protocol/retry.ts
@@ -78,21 +78,31 @@ export function isRetriableTransportReason(reason: TransportFailureReason): bool
 }
 
 /**
+ * Absolute ceiling on a honored `retry-after`, so a hostile or misconfigured
+ * provider cannot park a retry indefinitely. The transport already clamps the
+ * hint, but this chokepoint does not rely on that un-enforced cross-module
+ * invariant — it caps the value itself before honoring it.
+ */
+const MAX_RETRY_AFTER_MS = 10 * 60 * 1000;
+
+/**
  * How long to wait before the retry that follows a given `attempt` (1-based: the
  * wait after the first attempt is computed with `attempt === 1`).
  *
  * A provider `retry-after` hint is honored when present — it is the provider's
- * explicit instruction and has already been clamped to a sane ceiling by the
- * transport — and is never shortened below the computed backoff. Absent a hint,
- * the wait is deterministic exponential backoff with no jitter, so a test can
- * assert the exact schedule.
+ * explicit instruction — but only after being clamped to {@link MAX_RETRY_AFTER_MS},
+ * and it is never shortened below the computed backoff. It may still exceed the
+ * policy's `maxDelayMs`, since ignoring a legitimate hint would just earn another
+ * `429`. Absent a hint, the wait is deterministic exponential backoff with no
+ * jitter, so a test can assert the exact schedule.
  */
 export function retryDelayMs(attempt: number, policy: RetryPolicy, retryAfterMs?: number): number {
 	const backoff = Math.min(policy.baseDelayMs * 2 ** (attempt - 1), policy.maxDelayMs);
 	if (retryAfterMs === undefined) return backoff;
-	// Respect the provider's wait even when it exceeds `maxDelayMs`; ignoring it
-	// would just earn another `429`. But never wait less than our own backoff.
-	return Math.max(retryAfterMs, backoff);
+	const boundedRetryAfter = Math.min(retryAfterMs, MAX_RETRY_AFTER_MS);
+	// Respect the provider's (bounded) wait even when it exceeds `maxDelayMs`; but
+	// never wait less than our own backoff.
+	return Math.max(boundedRetryAfter, backoff);
 }
 
 /**

--- a/src/lib/ai/protocol/retry.ts
+++ b/src/lib/ai/protocol/retry.ts
@@ -1,0 +1,213 @@
+/**
+ * Bounded, before-first-event retry for a streamed conversation turn.
+ *
+ * A BYOK turn is a paid round trip, so a transient failure — a `429`, a `5xx`,
+ * or a dropped connection before the provider has said anything — is worth one
+ * more attempt rather than an immediate error banner. Two constraints make that
+ * safe:
+ *
+ *  1. **Only before the first protocol event of the turn has reached the
+ *     consumer.** The retry lives in a transport decorator, so the earliest
+ *     signal it can observe is the first frame it forwards to the client. A
+ *     frame is at or before the first protocol event the client maps from it, so
+ *     committing on the first forwarded frame is never later than "first protocol
+ *     event": once any output could have reached the consumer, a replay would
+ *     duplicate it, and the decorator refuses to retry. This is the exact reason
+ *     the policy is a transport wrapper and not a store-level loop — the store
+ *     has already rendered the partial turn by the time it would notice.
+ *  2. **Only for failures a retry can fix.** A `429` or `5xx` and a below-HTTP
+ *     `network` failure are transient; a `400`/`401`, a `malformedStream`, a
+ *     `responseTooLarge`, and every up-front refusal (a missing key, a relay
+ *     rejection — the failures `ChatTransport.open` rejects with) are not, and
+ *     are surfaced on the first attempt.
+ *
+ * The decorator is transparent: it forwards exactly one terminal callback per
+ * `open()`, the same contract a bare transport honors, so the client and the
+ * chat store are unchanged by its presence.
+ */
+
+import type {
+	ChatTransport,
+	ProviderStreamRequest,
+	TransportCallbacks,
+	TransportFailureReason,
+	TransportHttpError,
+} from "@/lib/adapters/chat-adapter";
+
+export interface RetryPolicy {
+	/** Total attempts including the first. `1` disables retry entirely. */
+	maxAttempts: number;
+	/** First backoff wait; attempt N waits `baseDelayMs * 2^(N-1)`, capped by `maxDelayMs`. */
+	baseDelayMs: number;
+	/** Ceiling on a single computed backoff wait. A provider `retry-after` may exceed it. */
+	maxDelayMs: number;
+}
+
+/**
+ * Three attempts with exponential backoff. Conservative on purpose: a BYOK user
+ * pays for every attempt, and the failures this retries are transient, so a
+ * short bounded sequence recovers a blip without turning a genuine outage into a
+ * long, expensive retry storm.
+ */
+export const DEFAULT_RETRY_POLICY: RetryPolicy = {
+	maxAttempts: 3,
+	baseDelayMs: 500,
+	maxDelayMs: 10_000,
+};
+
+/**
+ * Whether an HTTP status is worth retrying: `429` (rate limited) and any `5xx`
+ * (a server-side failure). A `4xx` other than `429` describes the request
+ * itself — a bad body, a rejected key, a missing model — and re-sending it
+ * unchanged would fail identically, so those are surfaced at once.
+ */
+export function isRetriableHttpStatus(status: number): boolean {
+	return status === 429 || (status >= 500 && status <= 599);
+}
+
+/**
+ * Whether a below-HTTP failure is worth retrying. Only `network` is: the request
+ * did not reach the provider or the connection dropped, which says nothing about
+ * the request. A `malformedStream` is a framing or contract violation and a
+ * `responseTooLarge` blew a fixed budget — replaying either reproduces it, so
+ * neither retries. This mirrors the `TransportFailureReason` contract in
+ * `src/lib/adapters/chat-adapter.ts`, which is the single source of that split.
+ */
+export function isRetriableTransportReason(reason: TransportFailureReason): boolean {
+	return reason === "network";
+}
+
+/**
+ * How long to wait before the retry that follows a given `attempt` (1-based: the
+ * wait after the first attempt is computed with `attempt === 1`).
+ *
+ * A provider `retry-after` hint is honored when present — it is the provider's
+ * explicit instruction and has already been clamped to a sane ceiling by the
+ * transport — and is never shortened below the computed backoff. Absent a hint,
+ * the wait is deterministic exponential backoff with no jitter, so a test can
+ * assert the exact schedule.
+ */
+export function retryDelayMs(attempt: number, policy: RetryPolicy, retryAfterMs?: number): number {
+	const backoff = Math.min(policy.baseDelayMs * 2 ** (attempt - 1), policy.maxDelayMs);
+	if (retryAfterMs === undefined) return backoff;
+	// Respect the provider's wait even when it exceeds `maxDelayMs`; ignoring it
+	// would just earn another `429`. But never wait less than our own backoff.
+	return Math.max(retryAfterMs, backoff);
+}
+
+/**
+ * A cancellable sleep. Resolves after `ms`, or immediately once `signal` aborts
+ * so the retry loop can turn the stop into a terminal cancellation without
+ * waiting out the backoff.
+ */
+export type DelayFn = (ms: number, signal?: AbortSignal) => Promise<void>;
+
+const realDelay: DelayFn = (ms, signal) =>
+	new Promise((resolve) => {
+		if (signal?.aborted) {
+			resolve();
+			return;
+		}
+		const timer = setTimeout(() => {
+			signal?.removeEventListener("abort", onAbort);
+			resolve();
+		}, ms);
+		function onAbort(): void {
+			clearTimeout(timer);
+			resolve();
+		}
+		signal?.addEventListener("abort", onAbort, { once: true });
+	});
+
+export interface RetryingTransportOptions {
+	/**
+	 * Injected so a test drives the backoff on a deterministic clock without real
+	 * time or fake timers: a test's `delay` resolves at once and records the
+	 * requested milliseconds. Defaults to a real, abort-aware `setTimeout`.
+	 */
+	delay?: DelayFn;
+}
+
+/** What one attempt against the inner transport resolved to, for the retry loop. */
+interface HeldFailure {
+	/** A provider `retry-after` hint, when the held failure was an HTTP error that carried one. */
+	retryAfterMs: number | undefined;
+}
+
+/**
+ * Wrap a transport so a transient, before-first-event failure is retried.
+ *
+ * The returned transport satisfies {@link ChatTransport} and is drop-in for the
+ * platform transport it wraps: `src/lib/adapters/get-chat-transport.ts` wraps the
+ * browser and desktop transports with it so both platforms retry identically,
+ * and the protocol client drives it unaware that retry is happening.
+ */
+export function createRetryingTransport(
+	inner: ChatTransport,
+	policy: RetryPolicy = DEFAULT_RETRY_POLICY,
+	options: RetryingTransportOptions = {},
+): ChatTransport {
+	const delay = options.delay ?? realDelay;
+
+	return {
+		async open(
+			request: ProviderStreamRequest,
+			callbacks: TransportCallbacks,
+			signal?: AbortSignal,
+		): Promise<void> {
+			for (let attempt = 1; ; attempt += 1) {
+				const canRetryAgain = attempt < policy.maxAttempts;
+				// `undefined` means the attempt reached a terminal outcome that was
+				// forwarded to the consumer; a value means it failed retriably before
+				// any frame and the decorator held the failure back for a retry.
+				let heldFailure: HeldFailure | undefined;
+				let committed = false;
+
+				const attemptCallbacks: TransportCallbacks = {
+					onFrame: (frame) => {
+						// The first forwarded frame commits the turn: any later failure can
+						// only be surfaced, never retried, because the consumer may already
+						// hold decoded output that a replay would duplicate.
+						committed = true;
+						callbacks.onFrame(frame);
+					},
+					onHttpError: (error: TransportHttpError) => {
+						if (!committed && canRetryAgain && isRetriableHttpStatus(error.status)) {
+							heldFailure = { retryAfterMs: error.retryAfterMs };
+							return;
+						}
+						callbacks.onHttpError(error);
+					},
+					onTransportError: (failure) => {
+						if (!committed && canRetryAgain && isRetriableTransportReason(failure.reason)) {
+							heldFailure = { retryAfterMs: undefined };
+							return;
+						}
+						callbacks.onTransportError(failure);
+					},
+					onClose: (reason) => {
+						callbacks.onClose(reason);
+					},
+				};
+
+				// A rejection is an up-front refusal the contract marks non-retriable, so
+				// it propagates to the client unchanged rather than being caught here.
+				await inner.open(request, attemptCallbacks, signal);
+
+				if (heldFailure === undefined) return;
+
+				// Held a retriable failure. A stop that arrived during the attempt or the
+				// wait ends the turn as a cancellation instead of spending another attempt.
+				if (signal?.aborted) {
+					callbacks.onClose("cancelled");
+					return;
+				}
+				await delay(retryDelayMs(attempt, policy, heldFailure.retryAfterMs), signal);
+				if (signal?.aborted) {
+					callbacks.onClose("cancelled");
+					return;
+				}
+			}
+		},
+	};
+}

--- a/src/lib/ai/providers/test-fixtures/anthropic-fixtures.ts
+++ b/src/lib/ai/providers/test-fixtures/anthropic-fixtures.ts
@@ -1,0 +1,290 @@
+/**
+ * Hand-authored Anthropic Messages streaming fixtures.
+ *
+ * Every transcript is written from Anthropic's documented streaming event shapes,
+ * not recorded from a live account, and stored as a frame array (`{ event, data }`
+ * pairs, exactly what the SSE decoder emits). Each fixture ships with the exact
+ * `StreamEvent` sequence the mapper must produce, so a test asserts the whole
+ * sequence rather than merely that no exception was thrown.
+ *
+ * The model id and token counts are kept equal to the matching OpenAI fixtures in
+ * `./openai-fixtures.ts` so the two providers' complete-response fixtures decode
+ * to an identical `StreamEvent` sequence — the provider-neutrality contract.
+ */
+
+import type { StreamEvent } from "@/lib/ai/protocol/events";
+import type { SseFrame } from "@/lib/ai/providers/sse";
+
+/** The model id both providers' complete-response fixtures echo. */
+export const FIXTURE_MODEL = "test-model-1";
+
+/** Author one Anthropic frame the way the decoder delivers it. */
+function frame(event: string, payload: unknown): SseFrame {
+	return { event, data: JSON.stringify(payload) };
+}
+
+// ---------------------------------------------------------------------------
+// Complete text response
+// ---------------------------------------------------------------------------
+
+export const ANTHROPIC_TEXT_STREAM: SseFrame[] = [
+	frame("message_start", {
+		type: "message_start",
+		message: { id: "msg_1", model: FIXTURE_MODEL, usage: { input_tokens: 12, output_tokens: 1 } },
+	}),
+	frame("content_block_start", { index: 0, content_block: { type: "text", text: "" } }),
+	frame("content_block_delta", { index: 0, delta: { type: "text_delta", text: "Review " } }),
+	frame("content_block_delta", { index: 0, delta: { type: "text_delta", text: "the gateway." } }),
+	frame("content_block_stop", { index: 0 }),
+	frame("message_delta", {
+		delta: { stop_reason: "end_turn", stop_sequence: null },
+		usage: { output_tokens: 9 },
+	}),
+	frame("message_stop", { type: "message_stop" }),
+];
+
+/** Shared with the OpenAI text fixture: the same logical response, same events. */
+export const EXPECTED_TEXT_EVENTS: StreamEvent[] = [
+	{ type: "message_start", model: FIXTURE_MODEL },
+	{ type: "text_delta", text: "Review " },
+	{ type: "text_delta", text: "the gateway." },
+	{ type: "usage", usage: { inputTokens: 12, outputTokens: 9 } },
+	{ type: "message_stop", stopReason: "end_turn" },
+];
+
+// ---------------------------------------------------------------------------
+// Complete tool-call response
+// ---------------------------------------------------------------------------
+
+export const ANTHROPIC_TOOL_STREAM: SseFrame[] = [
+	frame("message_start", {
+		message: { id: "msg_2", model: FIXTURE_MODEL, usage: { input_tokens: 20, output_tokens: 1 } },
+	}),
+	frame("content_block_start", { index: 0, content_block: { type: "text", text: "" } }),
+	frame("content_block_delta", { index: 0, delta: { type: "text_delta", text: "Adding it." } }),
+	frame("content_block_stop", { index: 0 }),
+	frame("content_block_start", {
+		index: 1,
+		content_block: { type: "tool_use", id: "call_1", name: "add_element", input: {} },
+	}),
+	frame("content_block_delta", {
+		index: 1,
+		delta: { type: "input_json_delta", partial_json: '{"type":"process",' },
+	}),
+	frame("content_block_delta", {
+		index: 1,
+		delta: { type: "input_json_delta", partial_json: '"name":"Gateway"}' },
+	}),
+	frame("content_block_stop", { index: 1 }),
+	frame("message_delta", {
+		delta: { stop_reason: "tool_use", stop_sequence: null },
+		usage: { output_tokens: 15 },
+	}),
+	frame("message_stop", { type: "message_stop" }),
+];
+
+export const EXPECTED_TOOL_EVENTS: StreamEvent[] = [
+	{ type: "message_start", model: FIXTURE_MODEL },
+	{ type: "text_delta", text: "Adding it." },
+	{ type: "tool_call_start", id: "call_1", name: "add_element" },
+	{ type: "tool_call_input_delta", id: "call_1", partialJson: '{"type":"process",' },
+	{ type: "tool_call_input_delta", id: "call_1", partialJson: '"name":"Gateway"}' },
+	{
+		type: "tool_call_complete",
+		id: "call_1",
+		name: "add_element",
+		input: { type: "process", name: "Gateway" },
+	},
+	{ type: "usage", usage: { inputTokens: 20, outputTokens: 15 } },
+	{ type: "message_stop", stopReason: "tool_use" },
+];
+
+// ---------------------------------------------------------------------------
+// Truncated stream — ends without message_stop
+// ---------------------------------------------------------------------------
+
+/**
+ * A stream that delivers text and then simply stops: no `message_delta`, no
+ * `message_stop`. The mapper emits no terminal event, so the client must report
+ * `malformed_stream` rather than let a cut-off answer look finished.
+ */
+export const ANTHROPIC_TRUNCATED_STREAM: SseFrame[] = [
+	frame("message_start", {
+		message: { id: "msg_3", model: FIXTURE_MODEL, usage: { input_tokens: 8, output_tokens: 1 } },
+	}),
+	frame("content_block_start", { index: 0, content_block: { type: "text", text: "" } }),
+	frame("content_block_delta", { index: 0, delta: { type: "text_delta", text: "Half a thou" } }),
+];
+
+export const EXPECTED_TRUNCATED_EVENTS: StreamEvent[] = [
+	{ type: "message_start", model: FIXTURE_MODEL },
+	{ type: "text_delta", text: "Half a thou" },
+	{
+		type: "error",
+		error: {
+			code: "malformed_stream",
+			message: "The AI response ended before it was complete. Please try again.",
+		},
+	},
+];
+
+// ---------------------------------------------------------------------------
+// Malformed events
+// ---------------------------------------------------------------------------
+
+/**
+ * A valid `message_start`, then a known event type whose `data:` is not valid
+ * JSON. The mapper emits one non-terminal `malformed_stream` notice and keeps
+ * going, so the terminal `message_stop` still arrives.
+ */
+export const ANTHROPIC_INVALID_JSON_STREAM: SseFrame[] = [
+	frame("message_start", { message: { model: FIXTURE_MODEL } }),
+	{ event: "content_block_delta", data: '{"index":0,"delta":{"type":"text_de' },
+	frame("message_delta", { delta: { stop_reason: "end_turn" }, usage: null }),
+	frame("message_stop", { type: "message_stop" }),
+];
+
+export const EXPECTED_INVALID_JSON_EVENTS: StreamEvent[] = [
+	{ type: "message_start", model: FIXTURE_MODEL },
+	{
+		type: "error",
+		error: {
+			code: "malformed_stream",
+			message: 'The Anthropic stream sent a "content_block_delta" event that could not be decoded.',
+			// The undecodable frame's payload rides along as redacted providerDetail.
+			providerDetail: '{"index":0,"delta":{"type":"text_de',
+		},
+	},
+	{ type: "message_stop", stopReason: "end_turn" },
+];
+
+/**
+ * An unknown top-level event type (`content_block_flourish`) and a `ping`, both
+ * of which Anthropic documents clients must tolerate: they map to nothing, and
+ * the surrounding real events map normally.
+ */
+export const ANTHROPIC_UNKNOWN_EVENT_STREAM: SseFrame[] = [
+	frame("message_start", { message: { model: FIXTURE_MODEL } }),
+	frame("ping", { type: "ping" }),
+	frame("content_block_flourish", { anything: true }),
+	frame("content_block_start", { index: 0, content_block: { type: "text", text: "" } }),
+	frame("content_block_delta", { index: 0, delta: { type: "text_delta", text: "ok" } }),
+	frame("content_block_stop", { index: 0 }),
+	frame("message_delta", { delta: { stop_reason: "end_turn" }, usage: null }),
+	frame("message_stop", { type: "message_stop" }),
+];
+
+export const EXPECTED_UNKNOWN_EVENT_EVENTS: StreamEvent[] = [
+	{ type: "message_start", model: FIXTURE_MODEL },
+	{ type: "text_delta", text: "ok" },
+	{ type: "message_stop", stopReason: "end_turn" },
+];
+
+/**
+ * A `tool_use` block whose accumulated `input_json_delta` fragments never parse.
+ * The mapper drops that one call with a `malformed_stream` notice — the failed
+ * call's name travels only as redacted `providerDetail` — and the turn still ends
+ * cleanly.
+ */
+export const ANTHROPIC_BAD_TOOL_ARGS_STREAM: SseFrame[] = [
+	frame("message_start", { message: { model: FIXTURE_MODEL } }),
+	frame("content_block_start", {
+		index: 0,
+		content_block: { type: "tool_use", id: "call_bad", name: "add_element", input: {} },
+	}),
+	frame("content_block_delta", {
+		index: 0,
+		delta: { type: "input_json_delta", partial_json: '{"type": "never closed' },
+	}),
+	frame("content_block_stop", { index: 0 }),
+	frame("message_delta", { delta: { stop_reason: "tool_use" }, usage: null }),
+	frame("message_stop", { type: "message_stop" }),
+];
+
+export const EXPECTED_BAD_TOOL_ARGS_EVENTS: StreamEvent[] = [
+	{ type: "message_start", model: FIXTURE_MODEL },
+	{ type: "tool_call_start", id: "call_bad", name: "add_element" },
+	{ type: "tool_call_input_delta", id: "call_bad", partialJson: '{"type": "never closed' },
+	{
+		type: "error",
+		error: {
+			code: "malformed_stream",
+			message: "A tool call sent arguments that were not valid JSON, so the call was dropped.",
+			providerDetail: "add_element",
+		},
+	},
+	{ type: "message_stop", stopReason: "tool_use" },
+];
+
+/**
+ * An `input_json_delta` whose content-block index names a `tool_use` that never
+ * started — the stream-level analog of a tool result with no matching call. The
+ * mapper reports it as `malformed_stream` and continues.
+ */
+export const ANTHROPIC_ORPHAN_TOOL_INPUT_STREAM: SseFrame[] = [
+	frame("message_start", { message: { model: FIXTURE_MODEL } }),
+	frame("content_block_delta", {
+		index: 7,
+		delta: { type: "input_json_delta", partial_json: '{"orphan":true}' },
+	}),
+	frame("message_delta", { delta: { stop_reason: "end_turn" }, usage: null }),
+	frame("message_stop", { type: "message_stop" }),
+];
+
+export const EXPECTED_ORPHAN_TOOL_INPUT_EVENTS: StreamEvent[] = [
+	{ type: "message_start", model: FIXTURE_MODEL },
+	{
+		type: "error",
+		error: {
+			code: "malformed_stream",
+			message: "The Anthropic stream sent tool arguments for a tool call that never started.",
+		},
+	},
+	{ type: "message_stop", stopReason: "end_turn" },
+];
+
+// ---------------------------------------------------------------------------
+// In-stream rate limit (an `error` event, distinct from an HTTP 429 response)
+// ---------------------------------------------------------------------------
+
+/**
+ * A `rate_limit_error` delivered as an in-band `error` event after some text has
+ * streamed. It maps to a terminal `rate_limited` protocol error whose detail is
+ * redacted and key-masked; because it arrives mid-stream, it is surfaced, never
+ * retried.
+ */
+export const ANTHROPIC_INSTREAM_RATE_LIMIT_STREAM: SseFrame[] = [
+	frame("message_start", { message: { model: FIXTURE_MODEL } }),
+	frame("content_block_start", { index: 0, content_block: { type: "text", text: "" } }),
+	frame("content_block_delta", { index: 0, delta: { type: "text_delta", text: "Start" } }),
+	frame("error", {
+		type: "error",
+		error: { type: "rate_limit_error", message: "Rate limit for key sk-ant-abc123DEF456" },
+	}),
+];
+
+export const EXPECTED_INSTREAM_RATE_LIMIT_EVENTS: StreamEvent[] = [
+	{ type: "message_start", model: FIXTURE_MODEL },
+	{ type: "text_delta", text: "Start" },
+	{
+		type: "error",
+		error: {
+			code: "rate_limited",
+			message: "Anthropic rate limit or quota exceeded — wait and try again.",
+			providerDetail: "rate_limit_error: Rate limit for key [redacted-key]",
+		},
+	},
+];
+
+/**
+ * A real Anthropic 429 error body: an HTTP response, not a stream. The submitted
+ * key can be echoed back, so the transport must redact it before it becomes
+ * `providerDetail`.
+ */
+export const ANTHROPIC_429_BODY = JSON.stringify({
+	type: "error",
+	error: {
+		type: "rate_limit_error",
+		message: "Number of request tokens has exceeded your rate limit",
+	},
+});

--- a/src/lib/ai/providers/test-fixtures/anthropic-fixtures.ts
+++ b/src/lib/ai/providers/test-fixtures/anthropic-fixtures.ts
@@ -159,6 +159,36 @@ export const EXPECTED_INVALID_JSON_EVENTS: StreamEvent[] = [
 ];
 
 /**
+ * A `malformed_stream` notice followed by a close with no `message_stop`. The
+ * notice is non-terminal, so the truncation must still be reported: the client
+ * emits a second, terminal `malformed_stream` for the cut-off turn. This is the
+ * discriminator that a non-terminal notice does not suppress truncation.
+ */
+export const ANTHROPIC_NOTICE_THEN_TRUNCATED_STREAM: SseFrame[] = [
+	frame("message_start", { message: { model: FIXTURE_MODEL } }),
+	{ event: "content_block_delta", data: '{"index":0,"delta":{"type":"text_de' },
+];
+
+export const EXPECTED_NOTICE_THEN_TRUNCATED_EVENTS: StreamEvent[] = [
+	{ type: "message_start", model: FIXTURE_MODEL },
+	{
+		type: "error",
+		error: {
+			code: "malformed_stream",
+			message: 'The Anthropic stream sent a "content_block_delta" event that could not be decoded.',
+			providerDetail: '{"index":0,"delta":{"type":"text_de',
+		},
+	},
+	{
+		type: "error",
+		error: {
+			code: "malformed_stream",
+			message: "The AI response ended before it was complete. Please try again.",
+		},
+	},
+];
+
+/**
  * An unknown top-level event type (`content_block_flourish`) and a `ping`, both
  * of which Anthropic documents clients must tolerate: they map to nothing, and
  * the surrounding real events map normally.
@@ -277,14 +307,15 @@ export const EXPECTED_INSTREAM_RATE_LIMIT_EVENTS: StreamEvent[] = [
 ];
 
 /**
- * A real Anthropic 429 error body: an HTTP response, not a stream. The submitted
- * key can be echoed back, so the transport must redact it before it becomes
- * `providerDetail`.
+ * An Anthropic 429 error body: an HTTP response, not a stream. Provider bodies are
+ * assumed to carry key material until proven otherwise (a hostile or misconfigured
+ * proxy can inject one), so the embedded `sk-ant-…RL429SECRET` token exercises the
+ * transport's unconditional redaction before the body becomes `providerDetail`.
  */
 export const ANTHROPIC_429_BODY = JSON.stringify({
 	type: "error",
 	error: {
 		type: "rate_limit_error",
-		message: "Number of request tokens has exceeded your rate limit",
+		message: "Rate limit exceeded for key sk-ant-live-RL429SECRET; retry later",
 	},
 });

--- a/src/lib/ai/providers/test-fixtures/fake-stream.ts
+++ b/src/lib/ai/providers/test-fixtures/fake-stream.ts
@@ -1,0 +1,147 @@
+/**
+ * Deterministic stand-ins for a provider stream, requiring no key and no network.
+ *
+ * Every helper here is pure data plus a `ReadableStream` or an in-memory relay
+ * replay: there are no timers, no randomness, and no live sockets, so a fixture
+ * produces the same bytes and the same frame order on every run. The browser
+ * path is driven with a stubbed `fetch` returning {@link fakeStream}; the desktop
+ * path is driven by replaying the same fixture frames through the real Tauri
+ * relay event shape with {@link replayTauriFrames}. Because both paths consume
+ * one shared fixture corpus, an identical `StreamEvent` sequence on the two
+ * transports is the transport-neutrality proof, exactly as the cross-provider
+ * mapper test is the provider-neutrality proof.
+ *
+ * Imported only by tests (`*.test.ts`), so nothing here reaches the bundle.
+ */
+
+import type { SseFrame } from "@/lib/ai/providers/sse";
+
+const encoder = new TextEncoder();
+
+/**
+ * Serialize decoded frames back to SSE wire text.
+ *
+ * A frame whose event is the SSE default `"message"` — OpenAI's shape, including
+ * its `[DONE]` sentinel — is written as a bare `data:` line with no `event:`
+ * field, matching what the provider sends; any other event name is written as an
+ * `event:`/`data:` pair. The result is what {@link fakeStream} turns into bytes.
+ */
+export function serializeFrames(frames: readonly SseFrame[]): string {
+	let wire = "";
+	for (const frame of frames) {
+		if (frame.event !== "message") {
+			wire += `event: ${frame.event}\n`;
+		}
+		wire += `data: ${frame.data}\n\n`;
+	}
+	return wire;
+}
+
+export interface FakeStreamOptions {
+	/**
+	 * Byte offsets at which to cut the serialized stream into chunks, so a test can
+	 * force a chunk boundary mid-line, mid-JSON, or mid-multi-byte-UTF-8. Offsets
+	 * are into the encoded byte array, applied in order; anything out of range is
+	 * ignored. Omitted delivers the whole stream as one chunk.
+	 */
+	splitAt?: readonly number[];
+	/** Response status; defaults to 200. A non-2xx makes `body` the error body. */
+	status?: number;
+	/** Response headers, e.g. a `retry-after` on a 429. */
+	headers?: Record<string, string>;
+}
+
+/**
+ * A finished `Response` whose body streams the serialized frames as bytes,
+ * optionally split at caller-chosen offsets. Stands in for `fetch` on the
+ * browser transport.
+ */
+export function fakeStream(frames: readonly SseFrame[], options: FakeStreamOptions = {}): Response {
+	const bytes = encoder.encode(serializeFrames(frames));
+	return byteResponse(bytes, options);
+}
+
+/**
+ * A finished `Response` for a raw body string (not frames), used for HTTP-error
+ * fixtures where the provider returns an error document rather than a stream.
+ */
+export function fakeErrorResponse(
+	body: string,
+	options: Omit<FakeStreamOptions, "splitAt"> = {},
+): Response {
+	return byteResponse(encoder.encode(body), options);
+}
+
+function byteResponse(bytes: Uint8Array, options: FakeStreamOptions): Response {
+	const chunks = splitBytes(bytes, options.splitAt);
+	const stream = new ReadableStream<Uint8Array>({
+		start(controller) {
+			for (const chunk of chunks) controller.enqueue(chunk);
+			controller.close();
+		},
+	});
+	const init: ResponseInit = {};
+	if (options.status !== undefined) init.status = options.status;
+	if (options.headers !== undefined) init.headers = options.headers;
+	return new Response(stream, init);
+}
+
+/** Cut a byte array into chunks at the given ascending, in-range offsets. */
+function splitBytes(bytes: Uint8Array, splitAt: readonly number[] | undefined): Uint8Array[] {
+	if (splitAt === undefined || splitAt.length === 0) return [bytes];
+	const chunks: Uint8Array[] = [];
+	let start = 0;
+	for (const offset of splitAt) {
+		if (offset <= start || offset >= bytes.length) continue;
+		chunks.push(bytes.subarray(start, offset));
+		start = offset;
+	}
+	chunks.push(bytes.subarray(start));
+	return chunks;
+}
+
+/**
+ * A terminal outcome a desktop stream can end on, mirroring the `kind` variants of
+ * `StreamClosedPayload.outcome` in `src-tauri/src/ai/types.rs`. Only the two the
+ * corpus drives are modeled — a clean `done` and a retriable `httpError`; the real
+ * `cancelled` and `transportError` outcomes are exercised through the transport's
+ * own tests rather than replayed here.
+ */
+export type TauriStreamOutcome =
+	| { kind: "done" }
+	| {
+			kind: "httpError";
+			status: number;
+			message: string;
+			providerDetail?: string;
+			retryAfterMs?: number;
+	  };
+
+/** The minimal relay surface {@link replayTauriFrames} drives; a test's mock satisfies it. */
+export interface RelayEmitter {
+	emit(name: string, payload: unknown): void;
+}
+
+const STREAM_FRAME_EVENT = "ai:stream-frame";
+const STREAM_CLOSED_EVENT = "ai:stream-closed";
+
+/**
+ * Replay a fixture through the desktop relay's event shape for one stream id.
+ *
+ * Emits one `ai:stream-frame` per fixture frame — the pre-framed `{ streamId,
+ * event, data }` shape the Rust relay produces, so no SSE byte decoding happens
+ * on this path, matching desktop reality — then one terminal `ai:stream-closed`.
+ * Driving the real `TauriChatTransport` this way exercises the shared decoder,
+ * mappers, and client against the same corpus the browser path uses.
+ */
+export function replayTauriFrames(
+	relay: RelayEmitter,
+	streamId: string,
+	frames: readonly SseFrame[],
+	outcome: TauriStreamOutcome = { kind: "done" },
+): void {
+	for (const frame of frames) {
+		relay.emit(STREAM_FRAME_EVENT, { streamId, event: frame.event, data: frame.data });
+	}
+	relay.emit(STREAM_CLOSED_EVENT, { streamId, outcome });
+}

--- a/src/lib/ai/providers/test-fixtures/openai-fixtures.ts
+++ b/src/lib/ai/providers/test-fixtures/openai-fixtures.ts
@@ -259,10 +259,14 @@ export const EXPECTED_OPENAI_INSTREAM_RATE_LIMIT_EVENTS: StreamEvent[] = [
 	},
 ];
 
-/** A real OpenAI 429 error body: an HTTP response, not a stream. */
+/**
+ * An OpenAI 429 error body: an HTTP response, not a stream. The embedded
+ * `sk-proj-…RL429SECRET` token exercises the transport's unconditional redaction
+ * of provider text before it becomes `providerDetail`.
+ */
 export const OPENAI_429_BODY = JSON.stringify({
 	error: {
-		message: "Rate limit reached for requests. Contact us if you keep hitting limits.",
+		message: "Rate limit reached for key sk-proj-RL429SECRET; contact us if this persists",
 		type: "requests",
 		code: "rate_limit_exceeded",
 	},

--- a/src/lib/ai/providers/test-fixtures/openai-fixtures.ts
+++ b/src/lib/ai/providers/test-fixtures/openai-fixtures.ts
@@ -1,0 +1,269 @@
+/**
+ * Hand-authored OpenAI Chat Completions streaming fixtures.
+ *
+ * Each transcript is written from OpenAI's documented `chat.completion.chunk`
+ * shape, not recorded from a live account, and stored as a frame array — OpenAI
+ * streams bare `data:` lines, so every frame's event is the SSE default
+ * `"message"` and the terminal frame is the `[DONE]` sentinel.
+ *
+ * The complete-response fixtures deliberately mirror the matching Anthropic
+ * fixtures in `./anthropic-fixtures.ts` — same model id, same text, same token
+ * counts — so both decode to the shared `EXPECTED_TEXT_EVENTS` /
+ * `EXPECTED_TOOL_EVENTS` / `EXPECTED_TRUNCATED_EVENTS` exported there. That shared
+ * expectation is the provider-neutrality contract. Fixtures whose failure detail
+ * is provider-specific carry their own expected sequence here.
+ */
+
+import type { StreamEvent } from "@/lib/ai/protocol/events";
+import type { SseFrame } from "@/lib/ai/providers/sse";
+import { FIXTURE_MODEL } from "./anthropic-fixtures";
+
+/** Author one OpenAI chunk frame; OpenAI never names its SSE events. */
+function chunk(payload: unknown): SseFrame {
+	return { event: "message", data: JSON.stringify(payload) };
+}
+
+/** OpenAI's terminal sentinel frame. */
+const DONE: SseFrame = { event: "message", data: "[DONE]" };
+
+// ---------------------------------------------------------------------------
+// Complete text response — mirrors ANTHROPIC_TEXT_STREAM
+// ---------------------------------------------------------------------------
+
+export const OPENAI_TEXT_STREAM: SseFrame[] = [
+	chunk({
+		model: FIXTURE_MODEL,
+		choices: [{ index: 0, delta: { role: "assistant", content: "" }, finish_reason: null }],
+	}),
+	chunk({
+		model: FIXTURE_MODEL,
+		choices: [{ index: 0, delta: { content: "Review " }, finish_reason: null }],
+	}),
+	chunk({
+		model: FIXTURE_MODEL,
+		choices: [{ index: 0, delta: { content: "the gateway." }, finish_reason: null }],
+	}),
+	chunk({ model: FIXTURE_MODEL, choices: [{ index: 0, delta: {}, finish_reason: "stop" }] }),
+	chunk({ model: FIXTURE_MODEL, choices: [], usage: { prompt_tokens: 12, completion_tokens: 9 } }),
+	DONE,
+];
+
+// ---------------------------------------------------------------------------
+// Complete tool-call response — mirrors ANTHROPIC_TOOL_STREAM
+// ---------------------------------------------------------------------------
+
+export const OPENAI_TOOL_STREAM: SseFrame[] = [
+	chunk({
+		model: FIXTURE_MODEL,
+		choices: [{ index: 0, delta: { role: "assistant", content: "" }, finish_reason: null }],
+	}),
+	chunk({
+		model: FIXTURE_MODEL,
+		choices: [{ index: 0, delta: { content: "Adding it." }, finish_reason: null }],
+	}),
+	chunk({
+		model: FIXTURE_MODEL,
+		choices: [
+			{
+				index: 0,
+				delta: {
+					tool_calls: [
+						{
+							index: 0,
+							id: "call_1",
+							type: "function",
+							function: { name: "add_element", arguments: "" },
+						},
+					],
+				},
+				finish_reason: null,
+			},
+		],
+	}),
+	chunk({
+		model: FIXTURE_MODEL,
+		choices: [
+			{
+				index: 0,
+				delta: { tool_calls: [{ index: 0, function: { arguments: '{"type":"process",' } }] },
+				finish_reason: null,
+			},
+		],
+	}),
+	chunk({
+		model: FIXTURE_MODEL,
+		choices: [
+			{
+				index: 0,
+				delta: { tool_calls: [{ index: 0, function: { arguments: '"name":"Gateway"}' } }] },
+				finish_reason: null,
+			},
+		],
+	}),
+	chunk({ model: FIXTURE_MODEL, choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }] }),
+	chunk({ model: FIXTURE_MODEL, choices: [], usage: { prompt_tokens: 20, completion_tokens: 15 } }),
+	DONE,
+];
+
+// ---------------------------------------------------------------------------
+// Truncated stream — no [DONE] — mirrors ANTHROPIC_TRUNCATED_STREAM
+// ---------------------------------------------------------------------------
+
+export const OPENAI_TRUNCATED_STREAM: SseFrame[] = [
+	chunk({
+		model: FIXTURE_MODEL,
+		choices: [{ index: 0, delta: { role: "assistant", content: "" }, finish_reason: null }],
+	}),
+	chunk({
+		model: FIXTURE_MODEL,
+		choices: [{ index: 0, delta: { content: "Half a thou" }, finish_reason: null }],
+	}),
+];
+
+// ---------------------------------------------------------------------------
+// Malformed events
+// ---------------------------------------------------------------------------
+
+/** A data line that is not valid JSON, between valid chunks. */
+export const OPENAI_INVALID_JSON_STREAM: SseFrame[] = [
+	chunk({
+		model: FIXTURE_MODEL,
+		choices: [{ index: 0, delta: { role: "assistant", content: "" }, finish_reason: null }],
+	}),
+	{ event: "message", data: '{"choices":[{"del' },
+	chunk({ choices: [{ index: 0, delta: {}, finish_reason: "stop" }] }),
+	DONE,
+];
+
+export const EXPECTED_OPENAI_INVALID_JSON_EVENTS: StreamEvent[] = [
+	{ type: "message_start", model: FIXTURE_MODEL },
+	{
+		type: "error",
+		error: {
+			code: "malformed_stream",
+			message: "The OpenAI stream sent a chunk that could not be decoded.",
+			providerDetail: '{"choices":[{"del',
+		},
+	},
+	{ type: "message_stop", stopReason: "end_turn" },
+];
+
+/** A `tool_calls` first fragment whose accumulated arguments never parse. */
+export const OPENAI_BAD_TOOL_ARGS_STREAM: SseFrame[] = [
+	chunk({
+		model: FIXTURE_MODEL,
+		choices: [{ index: 0, delta: { role: "assistant", content: "" }, finish_reason: null }],
+	}),
+	chunk({
+		model: FIXTURE_MODEL,
+		choices: [
+			{
+				index: 0,
+				delta: {
+					tool_calls: [
+						{
+							index: 0,
+							id: "call_bad",
+							type: "function",
+							function: { name: "add_element", arguments: '{"type": ' },
+						},
+					],
+				},
+				finish_reason: null,
+			},
+		],
+	}),
+	chunk({ model: FIXTURE_MODEL, choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }] }),
+	DONE,
+];
+
+export const EXPECTED_OPENAI_BAD_TOOL_ARGS_EVENTS: StreamEvent[] = [
+	{ type: "message_start", model: FIXTURE_MODEL },
+	{ type: "tool_call_start", id: "call_bad", name: "add_element" },
+	{ type: "tool_call_input_delta", id: "call_bad", partialJson: '{"type": ' },
+	{
+		type: "error",
+		error: {
+			code: "malformed_stream",
+			message: "A tool call sent arguments that were not valid JSON, so the call was dropped.",
+			providerDetail: "add_element",
+		},
+	},
+	{ type: "message_stop", stopReason: "tool_use" },
+];
+
+/** A tool-call fragment that arrives before the call is named — no id, no name. */
+export const OPENAI_ORPHAN_FRAGMENT_STREAM: SseFrame[] = [
+	chunk({
+		model: FIXTURE_MODEL,
+		choices: [{ index: 0, delta: { role: "assistant", content: "" }, finish_reason: null }],
+	}),
+	chunk({
+		model: FIXTURE_MODEL,
+		choices: [
+			{
+				index: 0,
+				delta: { tool_calls: [{ index: 0, function: { arguments: '{"a":1}' } }] },
+				finish_reason: null,
+			},
+		],
+	}),
+	chunk({ choices: [{ index: 0, delta: {}, finish_reason: "stop" }] }),
+	DONE,
+];
+
+export const EXPECTED_OPENAI_ORPHAN_FRAGMENT_EVENTS: StreamEvent[] = [
+	{ type: "message_start", model: FIXTURE_MODEL },
+	{
+		type: "error",
+		error: {
+			code: "malformed_stream",
+			message: "The OpenAI stream sent a tool-call fragment before naming the call.",
+		},
+	},
+	{ type: "message_stop", stopReason: "end_turn" },
+];
+
+// ---------------------------------------------------------------------------
+// In-stream rate limit (an `error` chunk, distinct from an HTTP 429 response)
+// ---------------------------------------------------------------------------
+
+export const OPENAI_INSTREAM_RATE_LIMIT_STREAM: SseFrame[] = [
+	chunk({
+		model: FIXTURE_MODEL,
+		choices: [{ index: 0, delta: { role: "assistant", content: "" }, finish_reason: null }],
+	}),
+	chunk({
+		model: FIXTURE_MODEL,
+		choices: [{ index: 0, delta: { content: "Start" }, finish_reason: null }],
+	}),
+	chunk({
+		error: {
+			message: "Rate limit reached for key sk-proj-abc123",
+			type: "requests",
+			code: "rate_limit_exceeded",
+		},
+	}),
+];
+
+export const EXPECTED_OPENAI_INSTREAM_RATE_LIMIT_EVENTS: StreamEvent[] = [
+	{ type: "message_start", model: FIXTURE_MODEL },
+	{ type: "text_delta", text: "Start" },
+	{
+		type: "error",
+		error: {
+			code: "rate_limited",
+			message: "OpenAI rate limit or quota exceeded — wait and try again.",
+			providerDetail: "requests: rate_limit_exceeded: Rate limit reached for key [redacted-key]",
+		},
+	},
+];
+
+/** A real OpenAI 429 error body: an HTTP response, not a stream. */
+export const OPENAI_429_BODY = JSON.stringify({
+	error: {
+		message: "Rate limit reached for requests. Contact us if you keep hitting limits.",
+		type: "requests",
+		code: "rate_limit_exceeded",
+	},
+});


### PR DESCRIPTION
## Summary

Closes #61 — the last two steps of the provider-neutral AI conversation & tool protocol (steps 1–10 already merged). Completes epic #46's groundwork.

- **Step 11 — fixtures + retry.** A deterministic, no-key/no-network contract corpus (`src/lib/ai/protocol/contract.test.ts` + `test-fixtures/`): hand-authored SSE transcripts for both providers, each paired with its exact `StreamEvent` sequence, covering partial streams, mid-line/mid-JSON/mid-UTF-8 splits, cancellation, malformed events, rate limits, and truncation — driven through the **real** browser and desktop transports (only `fetch`/Tauri IPC mocked). A bounded transient-only retry policy (`retry.ts`, wired at the transport layer in `get-chat-transport.ts`): retries only `429`/`5xx`/`network`, **never after the first forwarded frame** (so a replay can't duplicate output), default 3 attempts with exp backoff, and a self-clamped `retry-after` (≤ 10 min, abort-cancellable).
- **Step 12 — knowledge doc** (`docs/knowledge/ai-protocol.md`): the shipped protocol (types, events, transports, client, retry, the fenced legacy boundary, the trust model) so #62/#64 build from spec.
- Also closes step 10's deferred gap: an unterminated stream (`done` close, no terminal event) now emits `malformed_stream`, not a silent end.

## Preflight convergence

Three lanes (pr-review, slop, security) — **zero must-fix**. Applied:
- **should-fix (pr-review/slop):** `client.ts` no longer treats a non-terminal `malformed_stream` **notice** as the end of the turn (it contradicted the `events.ts` terminality contract and would hide truncation from #62's tool loop) — narrowed + a discriminating notice-then-truncate fixture.
- **should-fix (slop/pr-review):** corrected the doc's SSE-decoder description — byte-level framing is **two mirrored fail-closed twins** (TS `sse.ts` + Rust `SseFrameSplitter`); the single shared layer is the mapper pair.
- **should-fix (slop):** wired the previously-dead `*_429_BODY` fixtures into the HTTP-429 test (OpenAI 429 gains coverage; redaction preserved).
- **consider (security + pr-review):** the retry decorator now self-clamps `retry-after` to `MAX_RETRY_AFTER_MS` rather than trusting each transport to clamp — the chokepoint is self-bounding. Plus a retry-wiring factory test and a nit.

Security lane: security-clean — the provider-controlled `retry-after` is bounded and abort-cancellable, retries preserve the #153 key boundary and redirect refusal, auth failures aren't retried, and the error surface stays redacted/authored.

## Verification

- `tsc` 0 · `biome` 0 · `vitest` **1082** full suite (contract corpus 55; `src/lib/ai` 319) · doc links resolve.
- No Rust/dependency changes. Release-build gates (`ci:local`, `ci:docker`/Playwright) run in CI.

## Owner validation (deferred, not waived)

CI cannot cover: a live BYOK conversation on both providers/platforms (streaming, retry-on-429, stop, error text, truncation), the relay-frames tradeoff, and prompt fidelity — the plan's `#61` validation items.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>