### PR TITLE
docs: add the 2026-07-23 session handoff

### DIFF
--- a/handoff-2026-07-23-1706.md
+++ b/handoff-2026-07-23-1706.md
@@ -1,0 +1,133 @@
+# Session handoff — ThreatForge, 2026-07-23 17:06 EDT
+
+Written to resume work from a different machine. Everything of value is on `origin`;
+nothing is stranded locally except one branch of yours, flagged below.
+
+## State at handoff
+
+- `main` = `94a3950`, identical to `origin/main`. Working tree clean.
+- **One open PR: #178** (issue #62) — converged and verified, CI in flight. See "Pick this up first".
+- All agent worktrees pruned. Local branches reduced to `main`, `feat/62-bounded-tool-loop`
+  (pushed), and your two `shreyasdbz-*` branches. 34 merged-PR remnants deleted.
+- ⚠️ **`shreyasdbz-hostinger-runner-smoke` exists only on the old machine** (no `origin` copy,
+  checked out in `~/Dev/repos/copilot-worktrees/`). It is yours and untouched — **push it before
+  wiping the machine** if you want to keep it.
+
+## Landed this session — 8 PRs merged
+
+| PR | What | Closed |
+|---|---|---|
+| #167 | Canonical repository documentation refresh | #159 |
+| #153 | Typed chat transports + type-enforced key boundary (#61 step 9) | — |
+| #165 | MCP `add_element` schema advertises the `text` element type | #165 |
+| #166 | AI provider / key-storage copy corrected across user surfaces | #166 |
+| #156 | Web build Content-Security-Policy (+ desktop CSP hardening) | #156 |
+| #173 | Protocol client + chat-store rewire onto typed events (#61 step 10) | — |
+| #174 | **Multi-tab document workspace** | **#54** |
+| #176 | Provider contract fixtures, bounded retry, protocol knowledge doc (#61 steps 11–12) | **#61** |
+
+**Two epics' worth of work finished: #54 (multi-tab workspace) and #61 (the entire
+provider-neutral AI conversation & tool protocol, steps 9–12 this session).**
+
+Every merge went through the same gate: implementation → three independent review lanes
+(pr-reviewer, slop-auditor, security-auditor) → all must-fix *and* should-fix resolved →
+verification green → CI green → squash-merge with `--admin`, with deferred owner-validation
+recorded in the PR body.
+
+## Pick this up first — PR #178 (issue #62, bounded tool-call loop)
+
+**Status: converged, verified, ready to merge once CI is green.** At handoff CI was 6 passed /
+2 pending (the slow Build jobs).
+
+```bash
+gh pr checks 178          # confirm all green
+gh pr merge 178 --squash --admin --delete-branch   # closes #62
+```
+
+What it contains: the bounded AI tool-call loop over #61's protocol — a pure turn-machine
+bounded at 8 iterations / 32 tool calls / 300 s, a single-use authorization-grant ledger
+(digest-bound to `{callId,toolName,input,iteration}`), transactional one-snapshot-per-turn undo,
+the twelve existing actions adapted as tools, an 11-case adversarial injection suite, approval UI,
+E2E, and a knowledge doc + ADR-011.
+
+Review outcome (all three lanes ran):
+- **Security: sound, 0 must-fix / 0 should-fix.** It traced grant provenance (no path from model
+  text, tool results, or document content to an approval grant), digest binding, and undo
+  transactionality, and judged the injection suite genuinely adversarial.
+- **pr-review found one must-fix — now fixed:** the turn store was a process-global singleton whose
+  `resetTurn()` had no production caller, which broke "New chat" and let one document's
+  conversation bleed into another document's provider request. Now reset on document switch and
+  new/switch session, with cross-document and new-chat regression tests.
+- Also applied: the undo-affordance should-fix and five cleanups (dead `usage`/`modelId` fields,
+  unused injectable runner seams, a vacuous test helper, a weak e2e assertion, a misleading
+  turn-deadline comment).
+
+Convergence commit `ce72fc5`; verified locally after the fixes: `tsc` 0, **625 tests** across
+loop/stores/panels.
+
+## Follow-ups filed this session (all labelled + milestoned)
+
+| Issue | What |
+|---|---|
+| #168 | AI key commands (`set`/`get-status`/`delete_api_key`) stringify `ThreatForgeError` directly |
+| #172 | Proxy the GitHub release lookup through the app origin so the downloads page works under the CSP |
+| #175 | Bound and sanitize document display titles before they reach labels / the OS window title |
+| #177 | Delimit untrusted `.thf` content in the AI system prompt (prompt-injection steering) |
+
+## Next actions, in priority order
+
+1. **Merge #178** (above) — closes #62.
+2. **#63** (persist document-scoped AI conversations) and **#64** (native graph tool registry).
+   Together with #62 these finish epic **#46**. Note **#64 is `XL` and undecomposed** — decompose
+   into executable sub-issues before coding. #63 should not build on a global conversation history
+   (see #62's fix) and its persisted unit is the settled turn's `messages`.
+3. **#55** (browser workspace recovery / import / export / migrations) — finishes epic **#48**.
+   ⚠️ **Size `M` with no committed plan** — an independent planner must write
+   `docs/plans/55-*.md` before implementation, per AGENTS.md.
+4. **Architecture epic #47:** #58 and #59 have committed plans; #60 (templates) does not.
+5. **E2E epic #45:** #65, #66, #67, #68. (#66 carries a known gap: a flaky run is *green*, so
+   `if: failure()` never fires and the retry trace is discarded.)
+6. **Docs:** #160, #161, #162 (handbook + wiki + README landing page), #163 (release tagging).
+7. **M3 polish:** #134, #141, #142, #143, #175, #34, #35, #37.
+
+## Needs you (HITL — deliberately untouched)
+
+- **Release signing:** #44 (epic), #49 Tauri updater signing, #50 Windows Azure signing,
+  #51 macOS Developer ID + notarization, #52 release protection. All need secrets/accounts.
+- **#69** Cloudflare Worker deploy automation; **#72** Vercel decommission (dashboard-only:
+  uninstall the GitHub App, delete the project, revoke tokens — it still fails on every PR).
+- **#108** truncated `.tm7` import bug; **#133** browser BYOK key-at-rest decision;
+  **#144** wiki publish.
+
+## Owner validation debt (deferred, never waived)
+
+Everything merged under deferred validation; each PR body lists what a reviewer could not verify.
+The ones worth doing soon:
+
+- **#156 (CSP) — most important:** confirm the header is actually served, since a `_headers` file
+  silently doing nothing is the likely failure mode:
+  `curl -sI https://threatforge.dev | grep -i content-security-policy`.
+  Also decide on HSTS (deliberately not added — it is hard to reverse; check whether Cloudflare
+  already sets it at the zone level).
+- **#54:** the plan's 8 validation items (right-neighbour close, the two-of-four indicators call,
+  isolation-not-amnesia, the replace-on-open habit change, unpersisted order/pin, close-guard
+  proportionality, screen-reader quality, new-issue judgement), plus a live WKWebView build to
+  confirm tab drag-reorder, and the screenshot / keyboard-walkthrough artifacts.
+- **#61:** a live BYOK conversation on both providers and both platforms (streaming, retry-on-429,
+  stop, error text, truncation) and prompt fidelity.
+- **#62 (once merged):** a live approve → apply → undo turn; the "one undo entry per turn vs per
+  batch" product decision; and the read-only auto-approval staging (all twelve shipped tools are
+  `mutate`, so that path is dormant until #64).
+
+## Operating notes for the next run
+
+- **Merge authorization is per-run and must be restated.** AGENTS.md is explicit that
+  `--admin` merge authority "is never inferred from repository permissions." This session's
+  authorization does **not** carry over — grant it again explicitly if you want the same autonomy.
+- The workflow that worked well: delegate implementation to a `feature-implementer` in an isolated
+  worktree against the committed plan → run the three review lanes in parallel with fresh context →
+  resolve every must-fix and should-fix → re-verify → PR with the convergence recorded → CI →
+  squash-merge → file discovered work as linked issues rather than expanding scope.
+- Two judgement calls worth knowing: the web CSP deliberately **omits** `api.github.com` from
+  `connect-src` (it is a usable exfiltration drop for the BYOK key), which is why #172 exists; and
+  #62's read-only auto-approval landed before its first consumer, which is deliberate sequencing.


### PR DESCRIPTION
Session handoff for resuming from another machine: the 8 PRs merged (closing #54 and #61), the converged-and-CI-pending PR #178 for #62, the follow-ups filed (#168/#172/#175/#177), prioritized next actions, HITL items, and the deferred owner-validation debt.

Docs-only.