### PR TITLE
feat(canvas): add model summary badge (#34)

### DIFF
--- a/e2e/app-launch.spec.ts
+++ b/e2e/app-launch.spec.ts
@@ -27,14 +27,18 @@ test.describe("App Launch", () => {
 		await page.setViewportSize({ width: 900, height: 700 });
 		await createModel(page);
 
-		await page.getByTitle("Double-click to rename").dblclick();
+		await page.getByTitle("Untitled Threat Model - Double-click to rename").dblclick();
 		const titleInput = page.getByTestId("top-menu-bar").locator("input");
-		await titleInput.fill("Customer Identity Access Model");
+		await titleInput.fill("Customer Identity Access Model Customer Identity Access Model");
 		const download = page.waitForEvent("download");
 		await titleInput.press("Enter");
 		await download;
 
-		await expect(page.getByTestId("canvas-count-badge")).toBeVisible();
+		await expect(
+			page.getByRole("region", {
+				name: "Canvas summary: 0 components, 0 data flows, 0 identified threats, 0 mitigated threats",
+			}),
+		).toBeVisible();
 		await expect(page.getByTestId("btn-settings-dialog")).toBeInViewport({ ratio: 1 });
 	});
 });

--- a/e2e/app-launch.spec.ts
+++ b/e2e/app-launch.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "./fixtures";
+import { createModel, expect, test } from "./fixtures";
 
 test.describe("App Launch", () => {
 	test.beforeEach(async ({ page }) => {
@@ -19,5 +19,22 @@ test.describe("App Launch", () => {
 
 	test("has status bar at bottom", async ({ page }) => {
 		await expect(page.getByTestId("status-bar")).toBeVisible();
+	});
+
+	test("keeps top-menu controls visible with a long document title at minimum width", async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 900, height: 700 });
+		await createModel(page);
+
+		await page.getByTitle("Double-click to rename").dblclick();
+		const titleInput = page.getByTestId("top-menu-bar").locator("input");
+		await titleInput.fill("Customer Identity Access Model");
+		const download = page.waitForEvent("download");
+		await titleInput.press("Enter");
+		await download;
+
+		await expect(page.getByTestId("canvas-count-badge")).toBeVisible();
+		await expect(page.getByTestId("btn-settings-dialog")).toBeInViewport({ ratio: 1 });
 	});
 });

--- a/src/components/layout/status-bar.test.tsx
+++ b/src/components/layout/status-bar.test.tsx
@@ -42,7 +42,7 @@ beforeEach(() => {
  * re-subscribe on a switch rather than serve a stale snapshot.
  */
 describe("StatusBar across a document switch (plan step 9)", () => {
-	it("case 10 - reflects the active document's counts and file path across switches", () => {
+	it("case 10 - reflects the active document's save, history, and file state across switches", () => {
 		const registry = useDocumentRegistry.getState();
 
 		// Document A: two elements, one flow, three history pushes, saved at /a.thf.
@@ -57,8 +57,7 @@ describe("StatusBar across a document switch (plan step 9)", () => {
 
 		render(<StatusBar />);
 		const bar = screen.getByTestId("status-bar");
-		expect(bar).toHaveTextContent("2 elements");
-		expect(bar).toHaveTextContent("1 flow");
+		expect(bar).toHaveTextContent("Unsaved changes");
 		expect(bar).toHaveTextContent("Undo: 3 / Redo: 0");
 		expect(bar).toHaveTextContent("/a.thf");
 
@@ -66,17 +65,15 @@ describe("StatusBar across a document switch (plan step 9)", () => {
 		act(() => {
 			registry.createDocument({ model: createTestModel("B"), filePath: null, pendingLayout: null });
 		});
-		expect(bar).toHaveTextContent("0 elements");
-		expect(bar).toHaveTextContent("0 flows");
+		expect(bar).toHaveTextContent("Saved");
 		expect(bar).not.toHaveTextContent("Undo:");
 		expect(bar).not.toHaveTextContent("/a.thf");
 
-		// Returning to A restores its rendered counts and file path — a stale snapshot would not.
+		// Returning to A restores its rendered state and file path — a stale snapshot would not.
 		act(() => {
 			registry.activateDocument(a);
 		});
-		expect(bar).toHaveTextContent("2 elements");
-		expect(bar).toHaveTextContent("1 flow");
+		expect(bar).toHaveTextContent("Unsaved changes");
 		expect(bar).toHaveTextContent("Undo: 3 / Redo: 0");
 		expect(bar).toHaveTextContent("/a.thf");
 	});

--- a/src/components/layout/status-bar.tsx
+++ b/src/components/layout/status-bar.tsx
@@ -96,10 +96,6 @@ export function StatusBar() {
 		activeDocumentId ? s.persistence[activeDocumentId] : undefined,
 	);
 
-	const elementCount = model?.elements.length ?? 0;
-	const threatCount = model?.threats.length ?? 0;
-	const flowCount = model?.data_flows.length ?? 0;
-
 	// The file save status and the local persistence status are distinct: one tracks the on-disk
 	// `.thf` file, the other the browser workspace copy.
 	const localPersistence = describeLocalPersistence(
@@ -122,18 +118,6 @@ export function StatusBar() {
 		>
 			{model ? (
 				<>
-					<span>
-						{elementCount} element{elementCount !== 1 ? "s" : ""}
-					</span>
-					<Separator />
-					<span>
-						{flowCount} flow{flowCount !== 1 ? "s" : ""}
-					</span>
-					<Separator />
-					<span>
-						{threatCount} threat{threatCount !== 1 ? "s" : ""}
-					</span>
-					<Separator />
 					<span>{renderSaveStatus()}</span>
 					{(pastLength > 0 || futureLength > 0) && (
 						<>

--- a/src/components/layout/top-menu-bar.test.tsx
+++ b/src/components/layout/top-menu-bar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { useDocumentRegistry } from "@/stores/document-registry";
 import { createDocumentStores, setActiveStores } from "@/stores/document-stores";
@@ -61,6 +61,7 @@ describe("TopMenuBar title", () => {
 
 describe("TopMenuBar canvas count badge", () => {
 	it("shows component, data-flow, and identified / mitigated threat totals", () => {
+		const registry = useDocumentRegistry.getState();
 		const model = createTestModel("Overview", {
 			elements: Array.from({ length: 2 }, (_, index) => ({
 				id: `component-${index + 1}`,
@@ -107,7 +108,7 @@ describe("TopMenuBar canvas count badge", () => {
 				},
 			],
 		});
-		useDocumentRegistry.getState().createDocument({
+		const overviewId = registry.createDocument({
 			model,
 			filePath: null,
 			pendingLayout: null,
@@ -115,12 +116,29 @@ describe("TopMenuBar canvas count badge", () => {
 
 		render(<TopMenuBar />);
 
-		const badge = screen.getByTestId("canvas-count-badge");
+		const badge = screen.getByRole("region", {
+			name: "Canvas summary: 2 components, 1 data flow, 3 identified threats, 1 mitigated threat",
+		});
 		expect(badge).toHaveTextContent("Components 2");
 		expect(badge).toHaveTextContent("Data flows 1");
 		expect(badge).toHaveTextContent("Threats 3 / 1");
-		expect(badge).toHaveAccessibleName(
-			"Canvas summary: 2 components, 1 data flow, 3 identified threats, 1 mitigated threat",
+
+		act(() => {
+			registry.createDocument({
+				model: createTestModel("Empty"),
+				filePath: null,
+				pendingLayout: null,
+			});
+		});
+		expect(screen.getByTestId("canvas-count-badge")).toHaveTextContent(
+			"Components 0Data flows 0Threats 0 / 0",
+		);
+
+		act(() => {
+			registry.activateDocument(overviewId);
+		});
+		expect(screen.getByTestId("canvas-count-badge")).toHaveTextContent(
+			"Components 2Data flows 1Threats 3 / 1",
 		);
 	});
 });

--- a/src/components/layout/top-menu-bar.test.tsx
+++ b/src/components/layout/top-menu-bar.test.tsx
@@ -6,7 +6,7 @@ import { useModelStore } from "@/stores/model-store";
 import type { ThreatModel } from "@/types/threat-model";
 import { TopMenuBar } from "./top-menu-bar";
 
-function createTestModel(title: string): ThreatModel {
+function createTestModel(title: string, overrides: Partial<ThreatModel> = {}): ThreatModel {
 	return {
 		version: "1.0",
 		metadata: {
@@ -21,6 +21,7 @@ function createTestModel(title: string): ThreatModel {
 		trust_boundaries: [],
 		threats: [],
 		diagrams: [],
+		...overrides,
 	};
 }
 
@@ -55,5 +56,71 @@ describe("TopMenuBar title", () => {
 		render(<TopMenuBar />);
 
 		expect(screen.getByText("Draft *")).toBeInTheDocument();
+	});
+});
+
+describe("TopMenuBar canvas count badge", () => {
+	it("shows component, data-flow, and identified / mitigated threat totals", () => {
+		const model = createTestModel("Overview", {
+			elements: Array.from({ length: 2 }, (_, index) => ({
+				id: `component-${index + 1}`,
+				type: "process",
+				name: `Component ${index + 1}`,
+				trust_zone: "",
+				description: "",
+				technologies: [],
+			})),
+			data_flows: [
+				{
+					id: "flow-1",
+					name: "Request",
+					from: "component-1",
+					to: "component-2",
+					protocol: "HTTPS",
+					data: [],
+					authenticated: true,
+				},
+			],
+			threats: [
+				{
+					id: "threat-1",
+					title: "Mitigated threat",
+					category: "Spoofing",
+					severity: "high",
+					description: "",
+					mitigation: { status: "mitigated", description: "Fixed" },
+				},
+				{
+					id: "threat-2",
+					title: "Accepted threat",
+					category: "Tampering",
+					severity: "medium",
+					description: "",
+					mitigation: { status: "accepted", description: "Risk accepted" },
+				},
+				{
+					id: "threat-3",
+					title: "Open threat",
+					category: "Repudiation",
+					severity: "low",
+					description: "",
+				},
+			],
+		});
+		useDocumentRegistry.getState().createDocument({
+			model,
+			filePath: null,
+			pendingLayout: null,
+		});
+
+		render(<TopMenuBar />);
+
+		const badge = screen.getByTestId("canvas-count-badge");
+		expect(badge).toHaveTextContent("Components 2");
+		expect(badge).toHaveTextContent("Data flows 1");
+		expect(badge).toHaveTextContent("Threats 3 / 1");
+		expect(badge).toHaveAccessibleName(
+			"Canvas summary: 2 components, 1 data flow, 3 identified threats, 1 mitigated threat",
+		);
 	});
 });

--- a/src/components/layout/top-menu-bar.tsx
+++ b/src/components/layout/top-menu-bar.tsx
@@ -84,7 +84,7 @@ export function TopMenuBar() {
 						onDoubleClick={() => {
 							if (model) setEditingTitle(true);
 						}}
-						title={model ? "Double-click to rename" : undefined}
+						title={model ? `${displayTitle} - Double-click to rename` : undefined}
 					>
 						{displayTitle}
 					</span>
@@ -128,19 +128,21 @@ export function TopMenuBar() {
 			<div className="flex-1" />
 
 			{model && (
-				<dl
+				<section
 					aria-label={`Canvas summary: ${countLabel(componentCount, "component")}, ${countLabel(dataFlowCount, "data flow")}, ${countLabel(threatCount, "identified threat")}, ${countLabel(mitigatedThreatCount, "mitigated threat")}`}
 					data-testid="canvas-count-badge"
 					className="flex shrink-0 items-center divide-x divide-border rounded-full border border-border bg-muted/40 px-2.5 py-1 text-[11px] text-muted-foreground shadow-sm"
 				>
-					<CountItem label="Components" value={componentCount} />
-					<CountItem label="Data flows" value={dataFlowCount} />
-					<CountItem
-						label="Threats"
-						value={`${threatCount} / ${mitigatedThreatCount}`}
-						title="Threats: identified / mitigated"
-					/>
-				</dl>
+					<dl className="flex items-center divide-x divide-border">
+						<CountItem label="Components" value={componentCount} />
+						<CountItem label="Data flows" value={dataFlowCount} />
+						<CountItem
+							label="Threats"
+							value={`${threatCount} / ${mitigatedThreatCount}`}
+							title="Threats: identified / mitigated"
+						/>
+					</dl>
+				</section>
 			)}
 
 			{/* Divider */}

--- a/src/components/layout/top-menu-bar.tsx
+++ b/src/components/layout/top-menu-bar.tsx
@@ -63,8 +63,8 @@ export function TopMenuBar() {
 			className="flex h-10 shrink-0 items-center border-b border-border bg-card px-3"
 		>
 			{/* App title / branding */}
-			<div className="flex items-center gap-2">
-				<img src="/logo_square.png" alt="Threat Forge" className="h-5 w-5" />
+			<div className="flex min-w-0 items-center gap-2">
+				<img src="/logo_square.png" alt="Threat Forge" className="h-5 w-5 shrink-0" />
 				{editingTitle && model ? (
 					<input
 						ref={titleInputRef}
@@ -80,7 +80,7 @@ export function TopMenuBar() {
 					/>
 				) : (
 					<span
-						className="text-sm font-semibold tracking-tight cursor-default"
+						className="min-w-0 truncate text-sm font-semibold tracking-tight cursor-default"
 						onDoubleClick={() => {
 							if (model) setEditingTitle(true);
 						}}

--- a/src/components/layout/top-menu-bar.tsx
+++ b/src/components/layout/top-menu-bar.tsx
@@ -20,6 +20,11 @@ import { Keytip } from "../ui/keytip";
 export function TopMenuBar() {
 	const isDirty = useModelStore((s) => s.isDirty);
 	const model = useModelStore((s) => s.model);
+	const componentCount = model?.elements.length ?? 0;
+	const dataFlowCount = model?.data_flows.length ?? 0;
+	const threatCount = model?.threats.length ?? 0;
+	const mitigatedThreatCount =
+		model?.threats.filter((threat) => threat.mitigation?.status === "mitigated").length ?? 0;
 	const filePath = useModelStore((s) => s.filePath);
 	const toggleLeftPanel = useUiStore((s) => s.toggleLeftPanel);
 	const toggleRightPanel = useUiStore((s) => s.toggleRightPanel);
@@ -122,6 +127,25 @@ export function TopMenuBar() {
 			{/* Spacer */}
 			<div className="flex-1" />
 
+			{model && (
+				<dl
+					aria-label={`Canvas summary: ${countLabel(componentCount, "component")}, ${countLabel(dataFlowCount, "data flow")}, ${countLabel(threatCount, "identified threat")}, ${countLabel(mitigatedThreatCount, "mitigated threat")}`}
+					data-testid="canvas-count-badge"
+					className="flex shrink-0 items-center divide-x divide-border rounded-full border border-border bg-muted/40 px-2.5 py-1 text-[11px] text-muted-foreground shadow-sm"
+				>
+					<CountItem label="Components" value={componentCount} />
+					<CountItem label="Data flows" value={dataFlowCount} />
+					<CountItem
+						label="Threats"
+						value={`${threatCount} / ${mitigatedThreatCount}`}
+						title="Threats: identified / mitigated"
+					/>
+				</dl>
+			)}
+
+			{/* Divider */}
+			{model && <div className="mx-1.5 h-4 w-px bg-border" />}
+
 			{/* View toggles */}
 			<div className="flex items-center gap-0.5">
 				<MenuButton
@@ -191,4 +215,24 @@ function MenuButton({
 			{keytip && <Keytip shortcut={keytip} />}
 		</span>
 	);
+}
+
+function CountItem({
+	label,
+	value,
+	title,
+}: {
+	label: string;
+	value: number | string;
+	title?: string;
+}) {
+	return (
+		<div className="flex gap-1 whitespace-nowrap px-2 first:pl-0 last:pr-0" title={title}>
+			<dt>{label}</dt> <dd className="font-semibold tabular-nums text-foreground">{value}</dd>
+		</div>
+	);
+}
+
+function countLabel(count: number, noun: string): string {
+	return `${count} ${noun}${count === 1 ? "" : "s"}`;
 }


### PR DESCRIPTION
## Summary

Closes #34.

- add a compact canvas summary badge to the top controls
- show total components, data flows, and threats as identified / mitigated
- expose the complete summary as a named accessibility region
- count only threats whose mitigation status is exactly `mitigated`
- consolidate the counts into this canonical surface instead of duplicating them in the status bar
- truncate long document titles with the full title retained in the hover affordance so controls remain visible at the supported 900px minimum width

## Verification

Final verification at commit `2290a07`:

- `npm run ci:local` — passed
- Vitest — 96 files, 1,199 tests passed
- Cargo — 164 tests passed
- `npm run test:e2e` — 56 tests passed
- `npx tsc --noEmit` — passed
- `npx biome check .` — passed for the change; one unrelated pre-existing `src/styles.css` warning remains
- web build and Cloudflare Worker dry run — passed
- `git diff --check` — passed
- working tree remained clean after verification

## Preflight record

Self anti-slop review: clean; no must-fix or should-fix findings.

Initial PR-reviewer lane:

- no must-fix findings
- should-fix: long titles plus the non-shrinking badge could push Settings off-screen at 900px — fixed with title shrinking/truncation and a browser regression test
- consider: make `identified / mitigated` even more explicit visually; the tooltip and accessibility name are explicit, but this remains an owner-validation consideration

Initial slop-auditor lane:

- must-fix: the `<dl>` label was not exposed reliably in Chromium — fixed by exposing the badge as a named `<section>` region and asserting it in Playwright
- must-fix: 60-character titles could push controls off-screen — fixed and covered at 900px with a 61-character title plus a full-name tooltip
- should-fix: component/flow/threat totals duplicated the status bar and were placed in two surfaces — fixed by making the new toolbar badge canonical and retaining save/history/persistence state in the status bar

Fresh convergence passes at `2290a07`:

- PR-reviewer: zero must-fix and zero should-fix findings; lane converged
- slop-auditor: zero must-fix and zero should-fix findings; clean and converged
- residual considerations only: very large count widths are not separately stress-tested, and the visible `Threats N / M` label relies on its tooltip and accessible name to explain identified / mitigated order

Security and threat-model specialist lanes do not apply: this is a local presentation-only change with no trust-boundary, IPC, file-format, STRIDE, or threat-generation behavior.

## Deferred owner validation

Owner validation is deferred under the explicitly authorized autonomous merge run and is not waived. Validate from this PR record:

- confirm the badge remains readable without crowding top controls at supported window widths
- confirm component and data-flow totals update as the graph changes
- confirm the threat total uses `identified / mitigated` order and updates with mitigation status changes
- confirm the named summary region is understandable with a screen reader
- decide whether the visible `Threats N / M` label needs expanded wording despite the width tradeoff
- exercise unusually large count values if that scale is representative of real models