### PR TITLE
feat(threats): copy individual threats as YAML (#37)

### DIFF
--- a/e2e/stride-analysis.spec.ts
+++ b/e2e/stride-analysis.spec.ts
@@ -14,7 +14,7 @@ test.describe("STRIDE Analysis", () => {
 		await expect(btn).toBeDisabled();
 	});
 
-	test("generates threats after adding elements", async ({ page }) => {
+	test("generates threats and copies one as YAML", async ({ page }) => {
 		// Add two elements so STRIDE rules can fire
 		await addPaletteItem(page, "palette-item-web-server");
 		await addPaletteItem(page, "palette-item-sql-database");
@@ -28,5 +28,19 @@ test.describe("STRIDE Analysis", () => {
 		// Wait for threats to appear (analysis is fast for local STRIDE rules).
 		// Assert at least 1 threat generated (match 1+ digit, not just "0").
 		await expect(page.getByTestId("tab-threats")).toContainText(/[1-9]\d*/);
+
+		const threatCard = page.getByTestId("threat-card").first();
+		await expect(threatCard).toBeVisible();
+		await page.context().grantPermissions(["clipboard-read", "clipboard-write"], {
+			origin: "http://localhost:3000",
+		});
+		await threatCard.click({ button: "right" });
+		await page.getByRole("button", { name: "Copy as YAML" }).click();
+
+		const copied = await page.evaluate(() => navigator.clipboard.readText());
+		expect(copied).toMatch(/^- id: .+\n/);
+		expect(copied).toContain("\n  title: ");
+		expect(copied).toContain("\n  category: ");
+		expect(copied).not.toContain("\nthreats:");
 	});
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.2.0",
 			"dependencies": {
 				"@tauri-apps/api": "2.11.1",
+				"@tauri-apps/plugin-clipboard-manager": "2.3.2",
 				"@tauri-apps/plugin-dialog": "2.7.2",
 				"@tauri-apps/plugin-opener": "2.5.4",
 				"@xyflow/react": "^12.10.1",
@@ -2226,6 +2227,15 @@
 			],
 			"engines": {
 				"node": ">= 10"
+			}
+		},
+		"node_modules/@tauri-apps/plugin-clipboard-manager": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/plugin-clipboard-manager/-/plugin-clipboard-manager-2.3.2.tgz",
+			"integrity": "sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ==",
+			"license": "MIT OR Apache-2.0",
+			"dependencies": {
+				"@tauri-apps/api": "^2.8.0"
 			}
 		},
 		"node_modules/@tauri-apps/plugin-dialog": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 	},
 	"dependencies": {
 		"@tauri-apps/api": "2.11.1",
+		"@tauri-apps/plugin-clipboard-manager": "2.3.2",
 		"@tauri-apps/plugin-dialog": "2.7.2",
 		"@tauri-apps/plugin-opener": "2.5.4",
 		"@xyflow/react": "^12.10.1",

--- a/scripts/check-tauri-version-alignment.mjs
+++ b/scripts/check-tauri-version-alignment.mjs
@@ -7,12 +7,14 @@ const packageLock = JSON.parse(readFileSync("package-lock.json", "utf8"));
 
 const versionPairs = [
 	["@tauri-apps/api", "tauri"],
+	["@tauri-apps/plugin-clipboard-manager", "tauri-plugin-clipboard-manager"],
 	["@tauri-apps/plugin-dialog", "tauri-plugin-dialog"],
 	["@tauri-apps/plugin-opener", "tauri-plugin-opener"],
 ];
 
 const directNpmPackages = [
 	"@tauri-apps/api",
+	"@tauri-apps/plugin-clipboard-manager",
 	"@tauri-apps/plugin-dialog",
 	"@tauri-apps/plugin-opener",
 	"@tauri-apps/cli",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -92,6 +92,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,6 +409,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,6 +576,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,6 +712,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -965,6 +1007,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,6 +1138,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,6 +1169,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1151,6 +1211,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1446,6 +1512,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1652,6 +1728,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1976,6 +2063,20 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "tiff",
 ]
 
 [[package]]
@@ -2357,6 +2458,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2412,6 +2523,15 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "num-conv"
@@ -2470,6 +2590,7 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
 ]
 
@@ -2699,6 +2820,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "osakit"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2783,6 +2914,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+]
 
 [[package]]
 name = "phf"
@@ -3163,6 +3305,18 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -4516,6 +4670,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-clipboard-manager"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206dc20af4ed210748ba945c2774e60fd0acd52b9a73a028402caf809e9b6ecf"
+dependencies = [
+ "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4805,6 +4974,7 @@ dependencies = [
  "serde_yaml",
  "tauri",
  "tauri-build",
+ "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tauri-plugin-updater",
@@ -4813,6 +4983,20 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "uuid",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -5149,6 +5333,17 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom",
+ "petgraph",
 ]
 
 [[package]]
@@ -5511,6 +5706,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016ccf01d1c58b6f8999612813e17c9b2390f7d70671428869913310f83f54b8"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
+dependencies = [
+ "bitflags 2.11.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.41.0",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5639,6 +5904,12 @@ dependencies = [
  "windows",
  "windows-core",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"
@@ -6160,6 +6431,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6229,6 +6518,23 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xattr"
@@ -6421,6 +6727,21 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
 
 [[package]]
 name = "zvariant"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
+tauri-plugin-clipboard-manager = "2"
 tauri-plugin-updater = "2"
 rmcp = { version = "2.2", features = ["server", "transport-io"] }
 schemars = "1"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -9,6 +9,7 @@
     "core:window:allow-destroy",
     "opener:default",
     "dialog:default",
+    "clipboard-manager:allow-write-text",
     "updater:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,6 +20,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .setup(|app| {
             let menu = menu::build_menu(app)?;

--- a/src/components/panels/threats-tab.test.tsx
+++ b/src/components/panels/threats-tab.test.tsx
@@ -1,0 +1,157 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { copyTextToClipboard } from "@/lib/platform";
+import { createDocumentStores, setActiveStores } from "@/stores/document-stores";
+import { useModelStore } from "@/stores/model-store";
+import type { Threat, ThreatModel } from "@/types/threat-model";
+import { ThreatsTab } from "./threats-tab";
+
+vi.mock("@/lib/platform", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/lib/platform")>();
+	return {
+		...actual,
+		copyTextToClipboard: vi.fn(),
+	};
+});
+
+const mockedCopyTextToClipboard = vi.mocked(copyTextToClipboard);
+
+function makeModel(threats: Threat[]): ThreatModel {
+	return {
+		version: "1.0",
+		metadata: {
+			title: "Test Model",
+			author: "Test Author",
+			created: "2026-03-15",
+			modified: "2026-03-15",
+			description: "",
+		},
+		elements: [
+			{
+				id: "api-gateway",
+				type: "process",
+				name: "API Gateway",
+				trust_zone: "internal",
+				description: "",
+				technologies: [],
+			},
+		],
+		data_flows: [],
+		trust_boundaries: [],
+		threats,
+		diagrams: [],
+	};
+}
+
+const threatWithMitigation: Threat = {
+	id: "threat-1",
+	title: "SQL Injection on payment queries",
+	category: "Tampering",
+	element: "api-gateway",
+	severity: "high",
+	description: "Unsanitized input reaches the payment query builder.",
+	mitigation: {
+		status: "mitigated",
+		description: "Parameterized queries via ORM",
+	},
+};
+
+beforeEach(() => {
+	setActiveStores(createDocumentStores());
+	mockedCopyTextToClipboard.mockReset();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("ThreatsTab context menu", () => {
+	it("exposes a Copy as YAML action on right-click and copies only that threat's YAML", async () => {
+		useModelStore.setState({ model: makeModel([threatWithMitigation]) });
+		mockedCopyTextToClipboard.mockResolvedValue(undefined);
+
+		render(<ThreatsTab />);
+
+		fireEvent.contextMenu(screen.getByText("SQL Injection on payment queries"));
+
+		const menuItem = await screen.findByText("Copy as YAML");
+		fireEvent.click(menuItem);
+
+		expect(mockedCopyTextToClipboard).toHaveBeenCalledExactlyOnceWith(
+			`- id: threat-1
+  title: SQL Injection on payment queries
+  category: Tampering
+  element: api-gateway
+  severity: high
+  description: Unsanitized input reaches the payment query builder.
+  mitigation:
+    status: mitigated
+    description: Parameterized queries via ORM
+`,
+		);
+	});
+
+	it("does not expose Copy as YAML before a right-click", () => {
+		useModelStore.setState({ model: makeModel([threatWithMitigation]) });
+
+		render(<ThreatsTab />);
+
+		expect(screen.queryByText("Copy as YAML")).not.toBeInTheDocument();
+	});
+
+	it("preserves the native context menu for editable threat fields", () => {
+		useModelStore.setState({
+			model: makeModel([threatWithMitigation]),
+			selectedThreatId: threatWithMitigation.id,
+		});
+
+		render(<ThreatsTab />);
+
+		fireEvent.contextMenu(screen.getByRole("textbox", { name: "Title" }));
+
+		expect(screen.queryByText("Copy as YAML")).not.toBeInTheDocument();
+	});
+
+	it("closes the menu and leaves other threats' clipboard payload untouched when copying one of several", async () => {
+		const other: Threat = {
+			id: "threat-2",
+			title: "Unrelated threat",
+			category: "Spoofing",
+			severity: "low",
+			description: "Some other threat description",
+		};
+		useModelStore.setState({ model: makeModel([threatWithMitigation, other]) });
+		mockedCopyTextToClipboard.mockResolvedValue(undefined);
+
+		render(<ThreatsTab />);
+
+		fireEvent.contextMenu(screen.getByText("Unrelated threat"));
+		fireEvent.click(await screen.findByText("Copy as YAML"));
+
+		expect(mockedCopyTextToClipboard).toHaveBeenCalledExactlyOnceWith(
+			expect.stringContaining("id: threat-2"),
+		);
+		expect(mockedCopyTextToClipboard.mock.calls[0][0]).not.toContain("threat-1");
+		// Menu closes after the action fires.
+		expect(screen.queryByText("Copy as YAML")).not.toBeInTheDocument();
+	});
+
+	it("surfaces a clipboard failure with window.alert instead of swallowing it", async () => {
+		useModelStore.setState({ model: makeModel([threatWithMitigation]) });
+		mockedCopyTextToClipboard.mockRejectedValue(new Error("Clipboard write was denied"));
+		const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+
+		render(<ThreatsTab />);
+
+		fireEvent.contextMenu(screen.getByText("SQL Injection on payment queries"));
+		fireEvent.click(await screen.findByText("Copy as YAML"));
+
+		await vi.waitFor(() => {
+			expect(alertSpy).toHaveBeenCalledExactlyOnceWith(
+				"Copy failed. Check clipboard permissions and try again.",
+			);
+		});
+
+		alertSpy.mockRestore();
+	});
+});

--- a/src/components/panels/threats-tab.tsx
+++ b/src/components/panels/threats-tab.tsx
@@ -2,13 +2,17 @@ import {
 	AlertTriangle,
 	ChevronDown,
 	ChevronRight,
+	Copy,
 	Loader2,
 	Shield,
 	Trash2,
 	Zap,
 } from "lucide-react";
 import { useState } from "react";
+import { CanvasContextMenu, type ContextMenuItem } from "@/components/canvas/canvas-context-menu";
 import { getComponentByType } from "@/lib/component-library";
+import { copyTextToClipboard } from "@/lib/platform";
+import { serializeThreatYaml } from "@/lib/thf-yaml";
 import { cn } from "@/lib/utils";
 import { useModelStore } from "@/stores/model-store";
 import { useUiStore } from "@/stores/ui-store";
@@ -147,15 +151,36 @@ function ThreatCard({
 	const setSelectedElement = useModelStore((s) => s.setSelectedElement);
 	const setRightPanelTab = useUiStore((s) => s.setRightPanelTab);
 	const model = useModelStore((s) => s.model);
+	const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
 
 	const linkedElement = model?.elements.find((e) => e.id === threat.element);
 
+	const handleCopyAsYaml = async () => {
+		try {
+			await copyTextToClipboard(serializeThreatYaml(threat));
+		} catch {
+			window.alert("Copy failed. Check clipboard permissions and try again.");
+		}
+	};
+
+	const contextMenuItems: ContextMenuItem[] = [
+		{ label: "Copy as YAML", icon: Copy, onClick: () => void handleCopyAsYaml() },
+	];
+
 	return (
 		<div
+			data-testid="threat-card"
 			className={cn(
 				"rounded-md border text-xs transition-colors",
 				isSelected ? "border-primary bg-primary/5" : "border-border hover:bg-accent",
 			)}
+			onContextMenu={(event) => {
+				if (event.target instanceof Element && event.target.closest("input, textarea, select")) {
+					return;
+				}
+				event.preventDefault();
+				setContextMenu({ x: event.clientX, y: event.clientY });
+			}}
 		>
 			{/* Header - clickable to expand/collapse */}
 			<button type="button" onClick={onSelect} className="flex w-full items-start gap-2 p-2">
@@ -192,6 +217,15 @@ function ThreatCard({
 
 			{/* Expanded detail editor */}
 			{isSelected && <ThreatEditor threat={threat} />}
+
+			{contextMenu && (
+				<CanvasContextMenu
+					x={contextMenu.x}
+					y={contextMenu.y}
+					items={contextMenuItems}
+					onClose={() => setContextMenu(null)}
+				/>
+			)}
 		</div>
 	);
 }

--- a/src/lib/adapters/tauri-clipboard-adapter.test.ts
+++ b/src/lib/adapters/tauri-clipboard-adapter.test.ts
@@ -1,0 +1,29 @@
+import { writeText } from "@tauri-apps/plugin-clipboard-manager";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { writeTextToTauriClipboard } from "./tauri-clipboard-adapter";
+
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+	writeText: vi.fn(),
+}));
+
+const mockedWriteText = vi.mocked(writeText);
+
+describe("writeTextToTauriClipboard", () => {
+	beforeEach(() => {
+		mockedWriteText.mockReset();
+	});
+
+	it("writes through the official clipboard plugin", async () => {
+		mockedWriteText.mockResolvedValue(undefined);
+
+		await writeTextToTauriClipboard("- id: threat-1\n");
+
+		expect(mockedWriteText).toHaveBeenCalledExactlyOnceWith("- id: threat-1\n");
+	});
+
+	it("propagates plugin failures to the platform boundary", async () => {
+		mockedWriteText.mockRejectedValue(new Error("plugin failed"));
+
+		await expect(writeTextToTauriClipboard("text")).rejects.toThrow("plugin failed");
+	});
+});

--- a/src/lib/adapters/tauri-clipboard-adapter.ts
+++ b/src/lib/adapters/tauri-clipboard-adapter.ts
@@ -1,0 +1,5 @@
+import { writeText } from "@tauri-apps/plugin-clipboard-manager";
+
+export async function writeTextToTauriClipboard(text: string): Promise<void> {
+	await writeText(text);
+}

--- a/src/lib/platform.test.ts
+++ b/src/lib/platform.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { writeTextToTauriClipboard } from "./adapters/tauri-clipboard-adapter";
+import { copyTextToClipboard } from "./platform";
+
+vi.mock("./adapters/tauri-clipboard-adapter", () => ({
+	writeTextToTauriClipboard: vi.fn(),
+}));
+
+const mockedWriteTextToTauriClipboard = vi.mocked(writeTextToTauriClipboard);
+
+describe("copyTextToClipboard", () => {
+	beforeEach(() => {
+		mockedWriteTextToTauriClipboard.mockReset();
+	});
+
+	afterEach(() => {
+		Reflect.deleteProperty(window, "__TAURI_INTERNALS__");
+		vi.unstubAllGlobals();
+	});
+
+	it("writes through the browser Clipboard API outside Tauri", async () => {
+		const writeText = vi.fn().mockResolvedValue(undefined);
+		vi.stubGlobal("navigator", { clipboard: { writeText } });
+
+		await copyTextToClipboard("- id: threat-1\n");
+
+		expect(writeText).toHaveBeenCalledExactlyOnceWith("- id: threat-1\n");
+	});
+
+	it("uses the Tauri clipboard plugin instead of the browser API on desktop", async () => {
+		Object.defineProperty(window, "__TAURI_INTERNALS__", {
+			configurable: true,
+			value: {},
+		});
+		const browserWriteText = vi.fn().mockResolvedValue(undefined);
+		vi.stubGlobal("navigator", { clipboard: { writeText: browserWriteText } });
+		mockedWriteTextToTauriClipboard.mockResolvedValue(undefined);
+
+		await copyTextToClipboard("- id: threat-1\n");
+
+		expect(mockedWriteTextToTauriClipboard).toHaveBeenCalledExactlyOnceWith("- id: threat-1\n");
+		expect(browserWriteText).not.toHaveBeenCalled();
+	});
+
+	it("maps a browser clipboard rejection to a user-safe error", async () => {
+		const writeText = vi.fn().mockRejectedValue(new Error("denied"));
+		vi.stubGlobal("navigator", { clipboard: { writeText } });
+
+		await expect(copyTextToClipboard("text")).rejects.toThrow(
+			"Unable to copy text to the clipboard.",
+		);
+	});
+
+	it("throws a user-safe error when the Clipboard API is unavailable", async () => {
+		vi.stubGlobal("navigator", {});
+
+		await expect(copyTextToClipboard("text")).rejects.toThrow(
+			"Unable to copy text to the clipboard.",
+		);
+	});
+
+	it("maps a Tauri plugin rejection to the same user-safe error", async () => {
+		Object.defineProperty(window, "__TAURI_INTERNALS__", {
+			configurable: true,
+			value: {},
+		});
+		mockedWriteTextToTauriClipboard.mockRejectedValue(new Error("raw platform failure"));
+
+		await expect(copyTextToClipboard("text")).rejects.toThrow(
+			"Unable to copy text to the clipboard.",
+		);
+	});
+});

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -24,3 +24,27 @@ export async function openExternalUrl(url: string): Promise<void> {
 		window.open(url, "_blank", "noopener,noreferrer");
 	}
 }
+
+/**
+ * Copy text to the system clipboard.
+ *
+ * Desktop builds use Tauri's clipboard plugin because browser clipboard support varies across
+ * embedded webviews. Browser builds use the standard Clipboard API. Both paths fail with the same
+ * user-safe error rather than exposing raw platform details.
+ */
+export async function copyTextToClipboard(text: string): Promise<void> {
+	try {
+		if (isTauri()) {
+			const { writeTextToTauriClipboard } = await import("./adapters/tauri-clipboard-adapter");
+			await writeTextToTauriClipboard(text);
+			return;
+		}
+
+		if (!navigator.clipboard?.writeText) {
+			throw new Error("Clipboard API unavailable");
+		}
+		await navigator.clipboard.writeText(text);
+	} catch {
+		throw new Error("Unable to copy text to the clipboard.");
+	}
+}

--- a/src/lib/thf-yaml.test.ts
+++ b/src/lib/thf-yaml.test.ts
@@ -1,9 +1,10 @@
 import { load, YAML11_SCHEMA } from "js-yaml";
 import { describe, expect, it } from "vitest";
-import type { ThreatModel } from "@/types/threat-model";
+import type { Threat, ThreatModel } from "@/types/threat-model";
 import {
 	parseThreatModelYaml,
 	serializeThreatModelYaml,
+	serializeThreatYaml,
 	THF_YAML_DUMP_SCHEMA,
 	THF_YAML_SCHEMA,
 } from "./thf-yaml";
@@ -181,5 +182,70 @@ describe("serializeThreatModelYaml", () => {
 		const reparsed = parseThreatModelYaml(serializeThreatModelYaml(model));
 		expect(reparsed.metadata.created).toBe("2026-06-01");
 		expect(reparsed.metadata.modified).toBe("2026-06-02");
+	});
+});
+
+describe("serializeThreatYaml", () => {
+	it("renders a threat with nested mitigation as a one-item YAML sequence", () => {
+		const threat: Threat = {
+			id: "threat-1",
+			title: "SQL Injection on payment queries",
+			category: "Tampering",
+			element: "api-gateway",
+			severity: "high",
+			description: "Unsanitized input reaches the payment query builder.",
+			mitigation: {
+				status: "mitigated",
+				description: "Parameterized queries via ORM",
+			},
+		};
+
+		const yaml = serializeThreatYaml(threat);
+
+		// Renders as a sequence item, matching the shape a `.thf` `threats:` section uses.
+		expect(yaml.startsWith("- id: threat-1\n")).toBe(true);
+		expect(yaml).toContain("title: SQL Injection on payment queries\n");
+		expect(yaml).toContain("category: Tampering\n");
+		expect(yaml).toContain("element: api-gateway\n");
+		expect(yaml).toContain("severity: high\n");
+		expect(yaml).toContain("mitigation:\n");
+		expect(yaml).toContain("status: mitigated\n");
+		expect(yaml).toContain("description: Parameterized queries via ORM\n");
+
+		// The dumped text parses back to a single-entry sequence equal to the source threat —
+		// proving the canonical dump options are reused rather than a hand-built subset.
+		const reparsed = load(yaml, { schema: THF_YAML_SCHEMA });
+		expect(reparsed).toEqual([threat]);
+	});
+
+	it("escapes YAML-sensitive text the same way the full-document writer does", () => {
+		const threat: Threat = {
+			id: "threat-2",
+			title: 'Title with "quotes", a: colon, and\na newline',
+			category: "Spoofing",
+			severity: "low",
+			description: "desc",
+		};
+
+		const yaml = serializeThreatYaml(threat);
+		const reparsed = load(yaml, { schema: THF_YAML_SCHEMA });
+
+		expect(reparsed).toEqual([threat]);
+	});
+
+	it("omits unset optional fields rather than emitting them as null", () => {
+		const threat: Threat = {
+			id: "threat-3",
+			title: "No element or mitigation yet",
+			category: "Denial of Service",
+			severity: "medium",
+			description: "",
+		};
+
+		const yaml = serializeThreatYaml(threat);
+
+		expect(yaml).not.toContain("element:");
+		expect(yaml).not.toContain("flow:");
+		expect(yaml).not.toContain("mitigation:");
 	});
 });

--- a/src/lib/thf-yaml.ts
+++ b/src/lib/thf-yaml.ts
@@ -11,7 +11,7 @@ import {
 	setTag,
 	YAML11_SCHEMA,
 } from "js-yaml";
-import type { ThreatModel } from "@/types/threat-model";
+import type { Threat, ThreatModel } from "@/types/threat-model";
 
 /** The YAML 1.1 type that resolves an unquoted `2026-03-15` scalar to a JavaScript `Date`. */
 const TIMESTAMP_TAG = "tag:yaml.org,2002:timestamp";
@@ -115,6 +115,16 @@ export function parseThreatModelYaml(text: string): ThreatModel {
 /** Serialize a `ThreatModel` to `.thf` text the desktop reader accepts. */
 export function serializeThreatModelYaml(model: ThreatModel): string {
 	return dump(model, THF_YAML_DUMP_OPTIONS);
+}
+
+/**
+ * Serialize a single `Threat` as a one-item `.thf` YAML sequence — the same shape it takes
+ * inside a document's `threats:` section, ready to paste into an issue, PR, or doc. Reuses the
+ * document dump options so escaping, enum casing, and nested `mitigation` match the canonical
+ * writer exactly rather than a hand-built subset.
+ */
+export function serializeThreatYaml(threat: Threat): string {
+	return dump([threat], THF_YAML_DUMP_OPTIONS);
 }
 
 function assertThreatModelShape(value: unknown): asserts value is ThreatModel {


### PR DESCRIPTION
## Summary

Closes #37.

- add `Copy as YAML` to each threat card's right-click menu
- serialize exactly one threat as a canonical one-item YAML sequence, including nested mitigation and safe escaping
- preserve native context menus inside editable threat fields
- use the browser Clipboard API on the web and Tauri's official clipboard plugin on desktop
- grant only `clipboard-manager:allow-write-text`; no clipboard-read capability
- enforce npm/Cargo clipboard-plugin version alignment in the existing dependency gate

## Verification

Final verification at `d83d724`:

- `npm run ci:local` — passed
- Vitest — 99 files, 1,214 tests passed
- Cargo tests — 161 passed / 1 ignored, plus 2 MCP stdio and 1 prompt-ownership test passed
- `cargo clippy --all-targets -- -D warnings` — passed
- `npm run test:e2e` — 56 tests passed
- `npx tsc --noEmit` — passed
- Biome and `git diff --check` — passed
- web build and Cloudflare Worker dry run — passed
- npm lockfile registry/integrity and Tauri JS/Rust alignment gates — passed

## Preflight record

Self anti-slop review fixed:

- replaced an unsupported all-webview browser-clipboard assumption with deliberate browser/Tauri paths
- sanitized browser and plugin errors before they reach the UI
- preserved native context menus on threat editor inputs, textareas, and selects
- removed test non-null assertions
- added a real browser right-click/clipboard E2E path

Initial independent lanes:

- PR reviewer: zero must-fix and zero should-fix; converged
- slop auditor: one should-fix — use the official JS plugin wrapper and include it in the JS/Rust alignment gate instead of hand-rolling the invoke contract
- security auditor: zero must-fix and zero should-fix; write-only capability, error containment, CSP, and Cargo provenance verified
- threat-model expert: zero must-fix and zero should-fix; canonical one-item YAML shape, enum casing, optional omission, and round-trip verified

Revision and convergence:

- added exact `@tauri-apps/plugin-clipboard-manager` 2.3.2 with canonical registry SHA-512 lock integrity
- replaced raw invoke with the package's typed `writeText` export
- added the npm/Cargo pair to `check-tauri-version-alignment.mjs`
- reran every lane: PR reviewer, slop auditor, security auditor, and threat-model expert all converged with zero must-fix and zero should-fix findings

## Deferred owner validation

Owner validation is deferred under the explicitly authorized autonomous merge run and is not waived. Validate from this PR record:

- exercise copy on packaged Windows, macOS, and Linux builds; CI verifies compilation and capability wiring but not each live system clipboard
- confirm browser permission denial produces understandable failure feedback
- confirm the copied fragment is convenient when pasted into an issue, PR, or document
- confirm right-click behavior and keyboard/screen-reader ergonomics are acceptable with the existing shared context-menu component