### PR TITLE
fix(ci): retain artifacts for flaky E2E runs (#183)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,12 +164,15 @@ jobs:
         run: npx playwright test
 
       - name: Summarize E2E results
+        id: summarize
         if: always()
         run: node scripts/summarize-playwright.mjs
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: failure()
+        # `failure()` alone must keep gating upload even if the summarize step above is
+        # skipped or itself fails, so failure evidence is never lost to an unset output.
+        if: failure() || steps.summarize.outputs['has-flaky'] == 'true'
         with:
           name: playwright-report
           path: |

--- a/docs/runbooks/diagnosing-ci-failures.md
+++ b/docs/runbooks/diagnosing-ci-failures.md
@@ -180,20 +180,26 @@ The counts line reports `passed`, `failed`, `timed out`, `flaky`, `skipped`, and
 - **"No usable JSON report at `test-results/results.json`"** means the run did not get far
   enough to write a report at all. Go to the job log.
 
-The summary is advisory: it always exits 0 and can never turn the job red. A write failure
-prints a `::warning::` rather than failing.
+Writing the Markdown summary is advisory: a failure there prints a `::warning::` rather than
+turning the job red. The same script also writes a trusted `has-flaky=true|false` step output.
+That output controls evidence retention, so its write fails closed: if GitHub cannot receive the
+output, the summarize step fails and the upload step's independent `failure()` branch preserves
+the diagnostic bundle.
 
-### Artifacts, and the gap you need to know about
+### Artifacts for failed and flaky runs
 
-The `playwright-report` artifact is uploaded **only on failure** (`if: failure()` on the upload
-step), contains both `playwright-report/` (the HTML report) and `test-results/` (traces,
-screenshots, videos, and `results.json`), and is retained for **7 days**. `playwright.config.ts`
-sets `trace: "on-first-retry"`, `screenshot: "only-on-failure"`, and `video: "retain-on-failure"`.
+The `playwright-report` artifact is uploaded when the job failed **or** the parsed report contains
+any flaky test. The upload condition combines `failure()` with the summary step's `has-flaky`
+output, so a missing or failed summary cannot suppress evidence from a red run. The artifact
+contains both `playwright-report/` (the HTML report) and `test-results/` (traces, screenshots,
+videos, and `results.json`) and is retained for **7 days**. `playwright.config.ts` sets
+`trace: "on-first-retry"`, `screenshot: "only-on-failure"`, and `video: "retain-on-failure"`.
 
-The gap: **a flaky run is green, so no artifact is uploaded.** `trace: "on-first-retry"` did
-record a trace for the retried test, but it was written to `test-results/` on the runner and
-discarded with it. When you see a flaky row, the summary table is all the evidence you get after
-the fact. Reproduce it locally:
+When the summary contains a flaky row, download `playwright-report` from that run and inspect the
+retry trace before rerunning. If the row exists but the artifact does not, inspect the
+`Summarize E2E results` and `Upload Playwright report` step logs first; that indicates the output
+or upload contract failed. Local repetition is still useful after preserving the original
+evidence:
 
 ```bash
 npx playwright test e2e/<spec>.spec.ts --repeat-each=10 --workers=1

--- a/scripts/summarize-playwright.mjs
+++ b/scripts/summarize-playwright.mjs
@@ -1,16 +1,22 @@
-// Summarizes a Playwright JSON report into the GitHub Actions run summary.
+// Summarizes a Playwright JSON report into the GitHub Actions run summary and exposes a
+// `has-flaky` step output for the workflow to gate diagnostic-artifact upload on.
 //
 // Playwright retries failed tests in CI (playwright.config.ts), so a test that fails once
 // and passes on retry is reported as flaky and does not fail the run. Without this summary
 // those retried passes — and the specs skipped on CI — are invisible outside the HTML report,
-// which is only uploaded on failure.
+// which is only uploaded on failure. The `has-flaky` output lets the workflow upload that
+// report for a flaky-but-green run too, without re-parsing the JSON report in shell — this
+// script stays the only place that reads the report shape.
 //
 // Usage:
 //   node scripts/summarize-playwright.mjs [report-path] [--stdout]
 //
-// Writes Markdown to $GITHUB_STEP_SUMMARY when that variable is set. Without it the script is
+// Writes Markdown to $GITHUB_STEP_SUMMARY when that variable is set, and `has-flaky=true` or
+// `has-flaky=false` to $GITHUB_OUTPUT when that variable is set. Without either, the script is
 // a no-op unless --stdout is passed, which prints the same Markdown for local inspection.
-// It is advisory and never a gate: it always exits 0.
+// Summary rendering stays advisory. Writing the workflow output fails closed: if GitHub cannot
+// receive the flaky signal, the step fails and the workflow's `failure()` upload path retains the
+// diagnostic bundle instead of silently losing it.
 //
 // The report shape is @playwright/test's `JSONReport` (node_modules/playwright/types/
 // testReporter.d.ts). Fields read here: `stats.duration`; `suites[].specs[].tests[].status`
@@ -319,8 +325,9 @@ const main = () => {
 	const args = process.argv.slice(2);
 	const reportPath = args.find((arg) => !arg.startsWith("--")) ?? DEFAULT_REPORT_PATH;
 	const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+	const outputPath = process.env.GITHUB_OUTPUT;
 
-	if (!summaryPath && !args.includes("--stdout")) {
+	if (!summaryPath && !outputPath && !args.includes("--stdout")) {
 		return;
 	}
 
@@ -332,10 +339,17 @@ const main = () => {
 		report = JSON.parse(readFileSync(reportPath, "utf8"));
 	} catch (error) {
 		writeSummary(renderUnavailable(reportPath, error));
+		// The report couldn't be read, so whether any test was flaky is unknown rather
+		// than false. This still defaults to "no upload" on an otherwise green job — a
+		// job that failed for another reason is covered by the workflow's own
+		// `failure()` check, which does not depend on this output.
+		writeHasFlakyOutput(false);
 		return;
 	}
 
-	writeSummary(renderSummary(summarizeReport(report)));
+	const summary = summarizeReport(report);
+	writeSummary(renderSummary(summary));
+	writeHasFlakyOutput(summary.flaky > 0);
 };
 
 /**
@@ -356,6 +370,24 @@ const writeSummary = (markdown) => {
 		const reason = error instanceof Error ? error.message : String(error);
 		process.stdout.write(`::warning::Playwright run summary could not be written: ${reason}\n`);
 	}
+};
+
+/**
+ * Writes the `has-flaky` step output the workflow reads to decide whether to upload the
+ * Playwright diagnostic bundle for an otherwise-green run. This is the only place that
+ * derives the value, so the workflow never re-parses the JSON report in shell.
+ *
+ * @param {boolean} hasFlaky
+ * @returns {void}
+ */
+const writeHasFlakyOutput = (hasFlaky) => {
+	const outputPath = process.env.GITHUB_OUTPUT;
+	if (!outputPath) {
+		return;
+	}
+	// Unlike the Markdown summary, this output controls evidence retention. Let a write error fail
+	// the step: the following upload step's `failure()` branch then preserves the bundle.
+	appendFileSync(outputPath, `has-flaky=${hasFlaky}\n`);
 };
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/scripts/summarize-playwright.test.mjs
+++ b/scripts/summarize-playwright.test.mjs
@@ -338,11 +338,17 @@ describe("renderSummary", () => {
 describe("summarize-playwright CLI", () => {
 	let workDir = "";
 
-	/** Runs the script and asserts it stayed advisory: it must always exit 0. */
+	/**
+	 * Runs the script and asserts it stayed advisory: it must always exit 0. Both
+	 * GitHub Actions file-command variables default to unset so a test that does not
+	 * pass one stays isolated from the real files this repo's own CI step exports —
+	 * without this, an inherited `GITHUB_OUTPUT` would let the script append into the
+	 * live step's output file instead of the test's throwaway one.
+	 */
 	const run = (args, env) => {
 		const result = spawnSync(process.execPath, [scriptPath, ...args], {
 			encoding: "utf8",
-			env: { ...process.env, GITHUB_STEP_SUMMARY: "", ...env },
+			env: { ...process.env, GITHUB_STEP_SUMMARY: "", GITHUB_OUTPUT: "", ...env },
 		});
 
 		expect(result.stderr).toBe("");
@@ -353,6 +359,7 @@ describe("summarize-playwright CLI", () => {
 	beforeAll(() => {
 		workDir = mkdtempSync(join(tmpdir(), "summarize-playwright-"));
 		writeFileSync(join(workDir, "results.json"), JSON.stringify(oneFlakyReport));
+		writeFileSync(join(workDir, "all-pass.json"), JSON.stringify(allPassReport));
 		writeFileSync(join(workDir, "malformed.json"), "{ not json");
 	});
 
@@ -395,5 +402,53 @@ describe("summarize-playwright CLI", () => {
 		run([join(workDir, "malformed.json")], { GITHUB_STEP_SUMMARY: summaryFile });
 
 		expect(readFileSync(summaryFile, "utf8")).toContain("No usable JSON report at");
+	});
+
+	it("writes has-flaky=true to the GitHub output file when the report has a flaky test", () => {
+		const outputFile = join(workDir, "flaky-output.txt");
+
+		run([join(workDir, "results.json")], { GITHUB_OUTPUT: outputFile });
+
+		// Exact GitHub Actions `key=value` file-command format: the workflow reads this
+		// same output the summary is derived from, so it never re-parses the report.
+		expect(readFileSync(outputFile, "utf8")).toBe("has-flaky=true\n");
+	});
+
+	it("writes has-flaky=false to the GitHub output file for a fully passing run", () => {
+		const outputFile = join(workDir, "clean-output.txt");
+
+		run([join(workDir, "all-pass.json")], { GITHUB_OUTPUT: outputFile });
+
+		expect(readFileSync(outputFile, "utf8")).toBe("has-flaky=false\n");
+	});
+
+	it("writes has-flaky=false when the report can't be read, deferring to the job's own failure() check", () => {
+		const outputFile = join(workDir, "missing-report-output.txt");
+
+		run([join(workDir, "absent.json")], { GITHUB_OUTPUT: outputFile });
+
+		expect(readFileSync(outputFile, "utf8")).toBe("has-flaky=false\n");
+	});
+
+	it("appends the output alongside an existing GitHub output file", () => {
+		const outputFile = join(workDir, "existing-output.txt");
+		writeFileSync(outputFile, "other-step-output=already-here\n");
+
+		run([join(workDir, "results.json")], { GITHUB_OUTPUT: outputFile });
+
+		const written = readFileSync(outputFile, "utf8");
+		expect(written).toContain("other-step-output=already-here\n");
+		expect(written).toContain("has-flaky=true\n");
+	});
+
+	it("fails closed when the GitHub output cannot be written", () => {
+		const result = spawnSync(process.execPath, [scriptPath, join(workDir, "results.json")], {
+			encoding: "utf8",
+			// A directory cannot receive the file-command append. The non-zero step result makes the
+			// workflow's `failure()` condition upload the diagnostics instead of losing flaky evidence.
+			env: { ...process.env, GITHUB_STEP_SUMMARY: "", GITHUB_OUTPUT: workDir },
+		});
+
+		expect(result.status).not.toBe(0);
 	});
 });


### PR DESCRIPTION
## Summary

Closes #183.

- expose `has-flaky=true|false` from the existing Playwright JSON summarizer
- derive the workflow signal from the same parsed summary that renders the CI Markdown
- upload the existing Playwright bundle when the E2E job failed or any test passed only after retry
- keep clean, non-flaky runs free of unnecessary diagnostic uploads
- fail closed when `$GITHUB_OUTPUT` cannot be written so the independent `failure()` branch still preserves evidence
- retain exact check names, permissions, SHA pins, artifact paths, and seven-day retention
- update the CI failure runbook to describe failed-or-flaky evidence retention and the new diagnostic path

## Verification

Final verification at `c68b400`:

- `npm run ci:local` — passed
- Vitest — 102 files, 1,260 tests passed
- Playwright summary CLI tests — 25 passed
- Cargo — 161 unit tests plus 2 integration tests passed
- `actionlint .github/workflows/*.yml` — passed
- TypeScript, Biome, Clippy, Rustfmt, web build, and Cloudflare Worker dry run — passed
- `git diff --check` — passed

## Preflight record

Self-review fixed one fail-open edge before independent review: an unwritable `$GITHUB_OUTPUT` previously only warned and exited success, which could still lose flaky evidence on a green run. The output write now fails the summarize step so `failure()` triggers upload.

Initial independent lanes:

- PR reviewer: workflow behavior correct; must-fix runbook still described the old always-exit-zero / failure-only behavior
- slop auditor: same must-fix documentation drift; implementation otherwise minimal and sound
- security auditor: zero must-fix and zero should-fix; trusted boolean output, file-command injection resistance, permissions, pins, retention, and fail-closed paths verified

Revision and convergence:

- updated `docs/runbooks/diagnosing-ci-failures.md` to distinguish advisory Markdown writes from fail-closed output writes and document artifact upload on failure or flaky outcomes
- reran PR reviewer, slop auditor, and security auditor: all converged with zero must-fix and zero should-fix findings

Residual considerations only: a hypothetical future unknown green Playwright status currently lands in `other` rather than triggering upload; Markdown escaping of hostile test-title structure is pre-existing and GitHub-sanitized; neither affects the trusted output boundary or current contract.

## Deferred owner validation

Owner validation is deferred under the explicitly authorized autonomous merge run and is not waived. Validate from this PR record:

- inspect one intentionally flaky CI run and confirm `playwright-report` is present and its retry trace is navigable
- inspect one clean run and confirm no diagnostic bundle is uploaded
- confirm a red E2E or summarize-output failure still uploads the same bundle
- decide whether future unknown green Playwright statuses should also retain diagnostics