### PR TITLE
fix(ai): sanitize API key command errors (#168)

### DIFF
--- a/src-tauri/src/ai/keychain.rs
+++ b/src-tauri/src/ai/keychain.rs
@@ -194,6 +194,21 @@ impl KeyStorage {
 }
 
 #[cfg(test)]
+impl KeyStorage {
+    /// Poison the internal keys mutex so the next lock returns a `KeyStorage`
+    /// fault carrying the poison payload. Exists only so the IPC-boundary tests
+    /// in `commands::ai_commands` can drive the real lock-poison error path for
+    /// `has_key`, which never touches the filesystem and so cannot be faulted
+    /// through the public API otherwise.
+    pub(crate) fn poison_keys_lock_for_test(&self) {
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = self.keys.lock().expect("lock is not yet poisoned");
+            panic!("poison the keys lock for a boundary test");
+        }));
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/src-tauri/src/commands/ai_commands.rs
+++ b/src-tauri/src/commands/ai_commands.rs
@@ -11,9 +11,7 @@ pub fn set_api_key(
     provider: AiProvider,
     key: String,
 ) -> Result<(), String> {
-    storage
-        .store_key(&provider, &key)
-        .map_err(|e| e.to_string())
+    store_api_key(&storage, &provider, &key)
 }
 
 /// Check whether an API key exists for a given provider (returns bool, NOT the key)
@@ -22,16 +20,44 @@ pub fn get_api_key_status(
     storage: State<'_, KeyStorage>,
     provider: AiProvider,
 ) -> Result<bool, String> {
-    storage.has_key(&provider).map_err(|e| e.to_string())
+    api_key_status(&storage, &provider)
 }
 
 /// Delete an API key for a given provider
 #[tauri::command]
 pub fn delete_api_key(storage: State<'_, KeyStorage>, provider: AiProvider) -> Result<(), String> {
-    storage.delete_key(&provider).map_err(|e| e.to_string())
+    remove_api_key(&storage, &provider)
 }
 
-/// Map a key-storage failure to the refusal `start_ai_stream` returns.
+// The three command bodies are split into these `&KeyStorage` seams so the
+// sanitized boundary mapping can be exercised against a real `KeyStorage`
+// fault in tests — `State` has no public constructor to build the command
+// directly. Each mirrors the `get_key` path in `start_ai_stream`: the only
+// thing crossing the IPC boundary is a `key_refusal` sentence, never the
+// storage error's internal `Display`.
+
+/// Boundary body of [`set_api_key`].
+fn store_api_key(storage: &KeyStorage, provider: &AiProvider, key: &str) -> Result<(), String> {
+    storage
+        .store_key(provider, key)
+        .map_err(|e| key_refusal(&e).to_string())
+}
+
+/// Boundary body of [`get_api_key_status`].
+fn api_key_status(storage: &KeyStorage, provider: &AiProvider) -> Result<bool, String> {
+    storage
+        .has_key(provider)
+        .map_err(|e| key_refusal(&e).to_string())
+}
+
+/// Boundary body of [`delete_api_key`].
+fn remove_api_key(storage: &KeyStorage, provider: &AiProvider) -> Result<(), String> {
+    storage
+        .delete_key(provider)
+        .map_err(|e| key_refusal(&e).to_string())
+}
+
+/// Map a key-storage failure to the authored refusal every AI key IPC command returns.
 ///
 /// `ThreatForgeError`'s `Display` is internal: it names the provider's storage
 /// key, a poisoned lock's payload, or a filesystem path, none of which may
@@ -164,5 +190,106 @@ mod tests {
             message: "Failed to read encrypted file".to_string(),
         };
         assert_ne!(key_refusal(&fault), RelayError::NoApiKey);
+    }
+
+    /// Build a `KeyStorage` whose data directory has been removed, so any write
+    /// path (`store_key`/`delete_key` → `flush`) fails with a real filesystem
+    /// error carrying internal implementation detail.
+    fn storage_with_broken_writes() -> (tempfile::TempDir, KeyStorage) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let storage =
+            KeyStorage::new(tmp.path().to_path_buf()).expect("KeyStorage::new should succeed");
+        std::fs::remove_dir_all(tmp.path()).expect("remove data dir to break future writes");
+        (tmp, storage)
+    }
+
+    #[test]
+    fn set_api_key_maps_a_real_write_fault_to_the_safe_sentence_and_hides_the_key() {
+        let (tmp, storage) = storage_with_broken_writes();
+        let dir = tmp.path().to_string_lossy().into_owned();
+
+        // Precondition: the underlying storage error really does carry internal
+        // detail, so the assertions below are pinning sanitization, not a no-op.
+        let raw = storage
+            .store_key(&AiProvider::Anthropic, "sk-ant-secret-value")
+            .expect_err("writing into a removed data dir must fail")
+            .to_string();
+        assert!(
+            raw.contains("Failed to write"),
+            "precondition: raw storage error should carry internal detail: {raw}"
+        );
+
+        let refused = store_api_key(&storage, &AiProvider::Anthropic, "sk-ant-secret-value")
+            .expect_err("the command must surface the storage fault");
+
+        assert_eq!(refused, "the stored API key could not be read");
+        for leaked in [
+            dir.as_str(),
+            "Failed to write",
+            "keys.enc",
+            "sk-ant-secret-value",
+        ] {
+            assert!(
+                !refused.contains(leaked),
+                "internal detail {leaked:?} reached the boundary: {refused}"
+            );
+        }
+    }
+
+    #[test]
+    fn delete_api_key_maps_a_real_write_fault_to_the_safe_sentence() {
+        let (tmp, storage) = storage_with_broken_writes();
+        let dir = tmp.path().to_string_lossy().into_owned();
+
+        let raw = storage
+            .delete_key(&AiProvider::Anthropic)
+            .expect_err("flushing into a removed data dir must fail")
+            .to_string();
+        assert!(
+            raw.contains("Failed to"),
+            "precondition: raw storage error should carry internal detail: {raw}"
+        );
+
+        let refused = remove_api_key(&storage, &AiProvider::Anthropic)
+            .expect_err("the command must surface the storage fault");
+
+        assert_eq!(refused, "the stored API key could not be read");
+        for leaked in [dir.as_str(), "Failed to", "keys.enc"] {
+            assert!(
+                !refused.contains(leaked),
+                "internal detail {leaked:?} reached the boundary: {refused}"
+            );
+        }
+    }
+
+    #[test]
+    fn get_api_key_status_maps_a_poisoned_lock_without_echoing_its_payload() {
+        // `has_key` never touches the filesystem, so a poisoned lock is its only
+        // reachable failure — and the poison payload is exactly the internal
+        // detail that must not cross the boundary.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let storage =
+            KeyStorage::new(tmp.path().to_path_buf()).expect("KeyStorage::new should succeed");
+        storage.poison_keys_lock_for_test();
+
+        let raw = storage
+            .has_key(&AiProvider::Anthropic)
+            .expect_err("a poisoned lock must fail")
+            .to_string();
+        assert!(
+            raw.contains("Lock poisoned"),
+            "precondition: raw storage error should carry the poison payload: {raw}"
+        );
+
+        let refused = api_key_status(&storage, &AiProvider::Anthropic)
+            .expect_err("the command must surface the poisoned lock");
+
+        assert_eq!(refused, "the stored API key could not be read");
+        for leaked in ["Lock poisoned", "PoisonError", "poison"] {
+            assert!(
+                !refused.contains(leaked),
+                "internal detail {leaked:?} reached the boundary: {refused}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #168.

- route `set_api_key`, `get_api_key_status`, and `delete_api_key` failures through the existing authored `key_refusal` / `RelayError` mapping
- preserve command signatures and the reachable missing-key vs. unavailable distinction
- ensure provider names, filesystem paths, poisoned-lock payloads, and key values never cross the IPC boundary
- add real-fault boundary coverage for encrypted-file write failures and mutex poisoning
- keep the lock-poison test seam `#[cfg(test)]` so it cannot ship

## Verification

Final verification at `922b59d`:

- `npm run ci:local` — passed
- `cargo test --lib commands::ai_commands` — 6 tests passed
- keychain tests — 17 tests passed
- `cargo clippy --all-targets -- -D warnings` — passed
- Rustfmt, TypeScript, Biome, web build, and Cloudflare Worker dry run — passed
- `git diff --check` — passed

## Preflight record

Self-review confirmed the change is limited to safe IPC error mapping and updated stale mapper documentation. Real write-failure tests exposed a separate transactional mutation defect, filed and triaged as #186 rather than expanded into this patch.

Independent lanes:

- PR reviewer: zero must-fix and zero should-fix; command wiring, signatures, mapper semantics, real-fault tests, and #186 scope separation verified
- slop auditor: zero must-fix and zero should-fix; private `&KeyStorage` seams and `#[cfg(test)]` lock-poison helper are justified boundary-test infrastructure
- security auditor: zero must-fix and zero should-fix; all reachable set/status/delete failures sanitize through fixed authored sentences, no key/log/path/provider leakage, test seam proven non-shippable

All lanes converged on the initial pass.

Residual considerations only: the shared `KeyUnavailable` sentence says the stored key could not be "read" even for write/delete failures; exact-equality assertions make the additional leak-token loops defensive rather than independently discriminating; the caught poison panic still emits a test-only panic-hook line under `--nocapture`.

## Deferred owner validation

Owner validation is deferred under the explicitly authorized autonomous merge run and is not waived. Validate from this PR record:

- force a key save/status/delete storage failure and confirm the UI shows only the authored safe sentence
- confirm no provider name, local path, lock payload, or key value appears in the webview or logs
- decide whether a future distinct authored write-failure sentence would be clearer than the shared read-oriented `KeyUnavailable` text
- review #186 separately for transactional in-memory behavior after a failed encrypted-file flush