### PR TITLE
fix(canvas): remove important handle hover override (#134)

### DIFF
--- a/e2e/canvas-handles.spec.ts
+++ b/e2e/canvas-handles.spec.ts
@@ -1,0 +1,82 @@
+import { addPaletteItem, createModel, expect, test } from "./fixtures";
+
+/**
+ * Regression coverage for #134: connection handles must be hidden idle and revealed on node
+ * hover using a cascade-correct (non-`!important`) utility combination, and must stay visible
+ * on every node — not just the one under the pointer — for the duration of a connection drag.
+ */
+test.describe("Canvas Connection Handles", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto("/app");
+		await createModel(page);
+	});
+
+	test("handle opacity is 0 idle and 1 on node hover", async ({ page }) => {
+		await addPaletteItem(page, "palette-item-web-server");
+
+		const node = page.locator("[data-testid^='node-']").first();
+		const handle = node.locator(".react-flow__handle").first();
+
+		await expect(handle).toHaveCSS("opacity", "0");
+
+		await node.hover();
+		await expect(handle).toHaveCSS("opacity", "1");
+
+		// Moving away drops the hover-driven visibility back to idle.
+		await page.mouse.move(0, 0);
+		await expect(handle).toHaveCSS("opacity", "0");
+	});
+
+	test("handles on an unhovered node stay visible for the duration of a connection drag", async ({
+		page,
+	}) => {
+		await addPaletteItem(page, "palette-item-web-server");
+		await addPaletteItem(page, "palette-item-sql-database");
+
+		const nodes = page.locator("[data-testid^='node-']");
+		const sourceNode = nodes.first();
+		const targetNode = nodes.nth(1);
+
+		// Both palette double-clicks drop their node at the canvas center, so the two nodes
+		// land stacked on top of each other. Drag the second one clear of the first via
+		// ReactFlow's own node-drag gesture so the connection-drag gesture below cannot land
+		// on it by coincidence — that would make the "unhovered" premise false.
+		const targetBoxBefore = await targetNode.boundingBox();
+		if (!targetBoxBefore) throw new Error("target node has no bounding box");
+		await page.mouse.move(
+			targetBoxBefore.x + targetBoxBefore.width / 2,
+			targetBoxBefore.y + targetBoxBefore.height / 2,
+		);
+		await page.mouse.down();
+		await page.mouse.move(targetBoxBefore.x + 400, targetBoxBefore.y + 250, { steps: 10 });
+		await page.mouse.up();
+
+		const targetBoxAfter = await targetNode.boundingBox();
+		if (!targetBoxAfter) throw new Error("target node has no bounding box after drag");
+		expect(targetBoxAfter.x).toBeGreaterThan(targetBoxBefore.x + 200);
+
+		// A handle on the node the drag starts from.
+		const sourceHandle = sourceNode.locator(".react-flow__handle").first();
+		// A handle on the OTHER (now clearly separated, never hovered) node — used to prove
+		// visibility is driven by the global `isConnecting` state, not by that node's own hover.
+		const otherHandle = targetNode.locator(".react-flow__handle").nth(3);
+
+		await expect(otherHandle).toHaveCSS("opacity", "0");
+
+		const box = await sourceHandle.boundingBox();
+		if (!box) throw new Error("source handle has no bounding box");
+
+		await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+		await page.mouse.down();
+		// Real pointer movement away from the source handle, staying clear of the target
+		// node — this is what ReactFlow's onConnectStart/connection-line gesture requires to
+		// enter connecting state, not a sleep or a store write.
+		await page.mouse.move(box.x + 60, box.y + 40, { steps: 10 });
+
+		await expect(otherHandle).toHaveCSS("opacity", "1");
+
+		// Release over empty canvas to cancel the connection instead of creating an edge, so
+		// the gesture does not leak into other tests via a persisted edge/document state.
+		await page.mouse.up();
+	});
+});

--- a/src/components/canvas/nodes/dfd-element-node.test.tsx
+++ b/src/components/canvas/nodes/dfd-element-node.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import type { NodeProps } from "@xyflow/react";
+import { describe, expect, it, vi } from "vitest";
+import type { DfdNodeData } from "@/stores/canvas-store";
+import { DfdElementNode } from "./dfd-element-node";
+
+// `Handle` only needs to render something inert here — this file asserts on the wrapper's
+// ancestry, not on handle visibility (covered by shared-handles.test.tsx).
+vi.mock("@xyflow/react", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@xyflow/react")>();
+	return {
+		...actual,
+		Handle: ({ id }: { id: string }) => <div data-testid={`handle-${id}`} />,
+	};
+});
+
+function makeProps(elementType: string): NodeProps {
+	const data: DfdNodeData = {
+		label: "Test Element",
+		elementType,
+		trustZone: "",
+		description: "",
+		technologies: [],
+	};
+	return {
+		id: "n1",
+		data,
+		type: "dfdElement",
+		dragging: false,
+		zIndex: 0,
+		selectable: true,
+		deletable: true,
+		selected: false,
+		draggable: true,
+		isConnectable: true,
+		positionAbsoluteX: 0,
+		positionAbsoluteY: 0,
+	};
+}
+
+describe("DfdElementNode group ancestor", () => {
+	it("wraps the rounded/rect shape branch's handles in a .group ancestor", () => {
+		// "generic" resolves to the default "rounded" shape — the non-hexagon branch.
+		render(<DfdElementNode {...makeProps("generic")} />);
+
+		const handle = screen.getByTestId("handle-top-target");
+		expect(handle.closest(".group")).not.toBeNull();
+	});
+
+	it("wraps the hexagon shape branch's handles in a .group ancestor", () => {
+		// "load_balancer" is defined with shape: "hexagon" in the component library.
+		render(<DfdElementNode {...makeProps("load_balancer")} />);
+
+		const handle = screen.getByTestId("handle-top-target");
+		expect(handle.closest(".group")).not.toBeNull();
+	});
+});

--- a/src/components/canvas/nodes/shared-handles.test.tsx
+++ b/src/components/canvas/nodes/shared-handles.test.tsx
@@ -1,0 +1,106 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// `Handle` is stubbed to a plain element that forwards `id`/`className` so we can assert on
+// the exact classes NodeHandles computes, without needing a ReactFlow/store provider tree.
+vi.mock("@xyflow/react", () => ({
+	Handle: ({ id, className }: { id: string; className?: string }) => (
+		<div data-testid={`handle-${id}`} className={className} />
+	),
+	Position: { Top: "top", Bottom: "bottom", Left: "left", Right: "right" },
+}));
+
+import { useCanvasInstanceStore } from "@/stores/canvas-instance-store";
+import { NodeHandles } from "./shared-handles";
+
+const HANDLE_IDS = [
+	"top-target",
+	"top-source",
+	"bottom-target",
+	"bottom-source",
+	"left-target",
+	"left-source",
+	"right-target",
+	"right-source",
+	"top-left-target",
+	"top-left-source",
+	"top-right-target",
+	"top-right-source",
+	"bottom-left-target",
+	"bottom-left-source",
+	"bottom-right-target",
+	"bottom-right-source",
+];
+
+function classTokens(id: string): string[] {
+	return (screen.getByTestId(`handle-${id}`).className ?? "").split(/\s+/).filter(Boolean);
+}
+
+afterEach(() => {
+	useCanvasInstanceStore.setState({ isConnecting: false });
+});
+
+describe("NodeHandles", () => {
+	it("hides every handle idle with a plain opacity-0 utility (no !important)", () => {
+		render(<NodeHandles />);
+
+		for (const id of HANDLE_IDS) {
+			const classes = classTokens(id);
+			expect(classes).toContain("opacity-0");
+			expect(classes).not.toContain("!opacity-0");
+			expect(classes).not.toContain("opacity-100");
+			expect(classes).not.toContain("!opacity-100");
+		}
+	});
+
+	it("reveals every handle via a plain group-hover:opacity-100 utility (no !important)", () => {
+		render(<NodeHandles />);
+
+		for (const id of HANDLE_IDS) {
+			const classes = classTokens(id);
+			expect(classes).toContain("group-hover:opacity-100");
+			expect(classes).not.toContain("!group-hover:opacity-100");
+		}
+	});
+
+	it("forces every handle visible with a plain opacity-100 utility while isConnecting", () => {
+		render(<NodeHandles />);
+
+		act(() => {
+			useCanvasInstanceStore.setState({ isConnecting: true });
+		});
+
+		for (const id of HANDLE_IDS) {
+			const classes = classTokens(id);
+			expect(classes).toContain("opacity-100");
+			expect(classes).not.toContain("!opacity-100");
+			// The idle classes must not linger once isConnecting takes over — they would
+			// otherwise tie in specificity with the connecting class on the same element.
+			expect(classes).not.toContain("opacity-0");
+			expect(classes).not.toContain("group-hover:opacity-100");
+		}
+	});
+
+	it("preserves pointer targeting, size, color, and transition classes in both states", () => {
+		render(<NodeHandles />);
+		const idleClasses = classTokens("top-target");
+
+		act(() => {
+			useCanvasInstanceStore.setState({ isConnecting: true });
+		});
+		const connectingClasses = classTokens("top-target");
+
+		for (const shared of [
+			"!w-1.5",
+			"!h-1.5",
+			"!border-none",
+			"!bg-muted-foreground",
+			"!pointer-events-auto",
+			"transition-opacity",
+			"duration-150",
+		]) {
+			expect(idleClasses).toContain(shared);
+			expect(connectingClasses).toContain(shared);
+		}
+	});
+});

--- a/src/components/canvas/nodes/shared-handles.tsx
+++ b/src/components/canvas/nodes/shared-handles.tsx
@@ -2,15 +2,30 @@ import { Handle, Position } from "@xyflow/react";
 import { useCanvasInstanceStore } from "@/stores/canvas-instance-store";
 
 /**
- * Base handle style: small dot, hidden by default, smooth fade transition.
- * Visible on parent node hover or during connection drag (CSS handles hover,
- * `isConnecting` prop handles drag state).
+ * Base handle style: small dot, smooth fade transition. Opacity is deliberately
+ * excluded here — it is applied per-render below so the idle and connecting
+ * states never emit conflicting same-specificity utilities on the same element.
  *
- * The larger pointer-events hitbox (12×12) is maintained even when the visible
- * dot is small, ensuring easy click targeting.
+ * Pointer events remain enabled while the dot is transparent, so the handle
+ * stays available as a connection target in its idle state.
  */
 const HANDLE_STYLE =
-	"!w-1.5 !h-1.5 !border-none !bg-muted-foreground !opacity-0 transition-opacity duration-150 !pointer-events-auto";
+	"!w-1.5 !h-1.5 !border-none !bg-muted-foreground !pointer-events-auto transition-opacity duration-150";
+
+/**
+ * Idle visibility: hidden until the ancestor `.group` node wrapper is hovered.
+ * Plain (non-`!important`) utilities — `group-hover:opacity-100` naturally
+ * outranks a bare `opacity-0` in specificity (descendant + `:hover` vs. a single
+ * class), so no `!important` is needed to reveal handles on hover. See #134.
+ */
+const HANDLE_IDLE_CLASS = "opacity-0 group-hover:opacity-100";
+
+/**
+ * Connecting visibility: forces all handles visible during a connection drag.
+ * Applied instead of, never alongside, `HANDLE_IDLE_CLASS` so the two never
+ * compete for the same element at the same specificity.
+ */
+const HANDLE_CONNECTING_CLASS = "opacity-100";
 
 /**
  * Shared bidirectional handles for all DFD element nodes.
@@ -18,13 +33,12 @@ const HANDLE_STYLE =
  * Each point has both a source and target handle for bidirectional connections.
  *
  * Handles are invisible by default and appear on:
- * 1. Parent node hover (via CSS: `.react-flow__node:hover .react-flow__handle`)
+ * 1. Parent node hover (via `group-hover:opacity-100`, requires a `.group` ancestor)
  * 2. During connection drag (via `isConnecting` store state)
  */
 export function NodeHandles() {
 	const isConnecting = useCanvasInstanceStore((s) => s.isConnecting);
-	const visibleClass = isConnecting ? "!opacity-100" : "";
-	const cls = `${HANDLE_STYLE} ${visibleClass}`;
+	const cls = `${HANDLE_STYLE} ${isConnecting ? HANDLE_CONNECTING_CLASS : HANDLE_IDLE_CLASS}`;
 
 	return (
 		<>

--- a/src/styles.css
+++ b/src/styles.css
@@ -171,27 +171,6 @@ html.light {
 		width: 100%;
 	}
 
-	/*
-	 * Show connection handles on node hover.
-	 *
-	 * Do NOT remove the !important here, and do NOT move this rule out of @layer base.
-	 * Biome 2.5.5's noImportantStyles warns on it (a warning, not a gate failure), and
-	 * both of its obvious "fixes" break handle visibility. Tracked in #134.
-	 *
-	 * Handles are hidden by this repo's own Tailwind utility, not by ReactFlow — see
-	 * HANDLE_STYLE in src/components/canvas/nodes/shared-handles.tsx, whose `!opacity-0`
-	 * emits `opacity: 0 !important` into @layer utilities. ReactFlow itself declares no
-	 * opacity on handles at all. Among !important declarations the cascade reverses layer
-	 * order, so this rule wins only because it is both !important and in the earlier
-	 * layer: dropping !important loses to the utility, and moving this rule unlayered
-	 * also loses, because unlayered !important ranks below any layered !important.
-	 * The cascade-correct fix is to stop emitting `opacity: 0 !important` in
-	 * shared-handles.tsx, which is what #134 should do.
-	 */
-	.react-flow__node:hover .react-flow__handle {
-		opacity: 1 !important;
-	}
-
 	/* Ensure edge labels render above connector lines */
 	.react-flow__edgelabel-renderer {
 		z-index: 5;


### PR DESCRIPTION
## Summary

Closes #134.

- remove `!opacity-0` from shared ReactFlow handle styles
- replace the global `styles.css` `opacity: 1 !important` override with cascade-correct `opacity-0 group-hover:opacity-100`
- keep connection-drag visibility through a mutually exclusive plain `opacity-100` state
- preserve size, color, transition, pointer targeting, cardinal/corner handles, and source/target behavior
- lock both DFD node shape branches to the required `.group` ancestor
- add real Chromium computed-opacity coverage for idle, hover, and cross-node connection-drag visibility
- remove the obsolete warning comment and all `noImportantStyles` findings without suppression

## Verification

Final verification at `1cc1a3f`:

- `npm run ci:local` — passed
- Biome — 283 files checked, zero warnings/findings
- Vitest — 105 files, 1,286 tests passed
- targeted handle/node component tests — 6 passed
- targeted canvas Playwright — 12 tests passed
- new handle E2E — 2 passed and repeated without flake
- existing five macOS visual baselines — matched unchanged; no snapshots regenerated
- TypeScript, Rustfmt, Clippy, Cargo tests, web build, Worker dry run, and `git diff --check` — passed

## Preflight record

Self-review removed stale 12×12-hitbox documentation and trimmed an unrelated cardinal/source-target mapping test while preserving all visibility regression coverage.

Independent lanes:

- PR reviewer: zero must-fix and zero should-fix; compiled Tailwind specificity, both shape branches, hover/connection states, pointer behavior, themes, Chromium gestures, and unchanged baselines verified
- slop auditor: zero must-fix and zero should-fix; tests are proportionate to the measured regression and use real computed styles/gestures rather than mocks or sleeps

Both lanes converged on the initial pass.

Residual considerations only: the cross-node E2E selects one target handle by index although any handle proves the same global state; dark-theme hover is not separately automated because opacity is now theme-independent, while existing dark/light idle baselines remain unchanged.

## Deferred owner validation

Owner validation is deferred under the explicitly authorized autonomous merge run and is not waived. Validate from this PR record:

- hover several node shapes in both light and dark themes and confirm handles fade in cleanly
- start and cancel a connection drag and confirm all eligible handles remain visible for the gesture
- confirm the 6px visible handle remains easy enough to target; a larger hidden hitbox is not currently implemented