### PR TITLE
fix(ui): sanitize document display titles (#175)

### DIFF
--- a/src/components/layout/document-tab.test.tsx
+++ b/src/components/layout/document-tab.test.tsx
@@ -168,6 +168,28 @@ describe("DocumentTab", () => {
 		fireEvent.click(screen.getByRole("button", { name: "Unpin Alpha" }));
 		expect(onPin).toHaveBeenCalledWith("doc-a", false);
 	});
+
+	it("strips a bidi override from the label and from the raw path re-appended in the tooltip (#175)", () => {
+		// The label comes from the sanitized title/basename; the tooltip then appends the *raw*
+		// `filePath` after it — the exact caller the issue warns can leak a hostile character back
+		// out through a tooltip even though the label alone is clean.
+		const hostilePath = "/home/jane/secret\u202Efolder/payments.thf";
+		const stores = seedBundle("Ignored", hostilePath);
+		render(
+			<DocumentTab
+				documentId={"doc-a" as DocumentId}
+				stores={stores}
+				selected
+				focused
+				pinned={false}
+				{...noop}
+			/>,
+		);
+
+		const tab = screen.getByRole("tab", { name: "payments" });
+		expect(tab).toHaveAttribute("title", `payments\n${hostilePath.replace("\u202E", "")}`);
+		expect(tab.getAttribute("title")).not.toContain("\u202E");
+	});
 });
 
 describe("RestoredDocumentTab (un-hydrated, #56)", () => {
@@ -204,6 +226,36 @@ describe("RestoredDocumentTab (un-hydrated, #56)", () => {
 			/>,
 		);
 		expect(screen.getByRole("tab", { name: "payments" })).toBeInTheDocument();
+	});
+
+	it("strips control characters from a cached title, matching the hydrated tab's sanitization (#175)", () => {
+		render(
+			<RestoredDocumentTab
+				documentId={"doc-r" as DocumentId}
+				title={"Cached\u0000Title"}
+				filePath={null}
+				selected={false}
+				focused={false}
+				{...noop}
+			/>,
+		);
+		expect(screen.getByRole("tab", { name: "CachedTitle" })).toBeInTheDocument();
+	});
+
+	it("strips a bidi override from the raw path re-appended in a restored tab's tooltip (#175)", () => {
+		const hostilePath = "/home/jane/secret\u202Efolder/payments.thf";
+		render(
+			<RestoredDocumentTab
+				documentId={"doc-r" as DocumentId}
+				title="Ignored"
+				filePath={hostilePath}
+				selected={false}
+				focused={false}
+				{...noop}
+			/>,
+		);
+		const tab = screen.getByRole("tab", { name: "payments" });
+		expect(tab.getAttribute("title")).not.toContain("\u202E");
 	});
 
 	it("activates and closes through the same callbacks the strip drives for a live tab", () => {

--- a/src/components/layout/document-tab.tsx
+++ b/src/components/layout/document-tab.tsx
@@ -1,6 +1,10 @@
 import { Pin, X } from "lucide-react";
 import { useStore } from "zustand";
-import { documentDisplayTitle, resolveDisplayTitle } from "@/lib/document-display-title";
+import {
+	documentDisplayTitle,
+	resolveDisplayTitle,
+	sanitizeDisplayText,
+} from "@/lib/document-display-title";
 import { cn } from "@/lib/utils";
 import type { DocumentStores } from "@/stores/document-stores";
 import { useSettingsStore } from "@/stores/settings-store";
@@ -195,7 +199,10 @@ export function DocumentTab({ documentId, stores, pinned, ...handlers }: Documen
 
 	const title = documentDisplayTitle(model, filePath);
 	// The hover tooltip carries the full title and the path the truncated label may be hiding (D3).
-	const tooltip = filePath ? `${title}\n${filePath}` : title;
+	// `filePath` is untrusted display text just like the title, so it goes through the same
+	// sanitizer (`#175`) — the sanitized `title` alone does not stop a control/bidi character
+	// hiding in the *directory* portion of the path from reaching this tooltip.
+	const tooltip = filePath ? `${title}\n${sanitizeDisplayText(filePath)}` : title;
 
 	return (
 		<DocumentTabView
@@ -235,7 +242,9 @@ export function RestoredDocumentTab({
 	...handlers
 }: RestoredDocumentTabProps) {
 	const label = resolveDisplayTitle(title, filePath);
-	const tooltip = filePath ? `${label}\n${filePath}` : label;
+	// Same sanitized-path rule as the hydrated tab above: the label alone does not cover a raw
+	// path re-appended after it (`#175`).
+	const tooltip = filePath ? `${label}\n${sanitizeDisplayText(filePath)}` : label;
 
 	return (
 		<DocumentTabView

--- a/src/components/layout/status-bar.test.tsx
+++ b/src/components/layout/status-bar.test.tsx
@@ -77,6 +77,20 @@ describe("StatusBar across a document switch (plan step 9)", () => {
 		expect(bar).toHaveTextContent("Undo: 3 / Redo: 0");
 		expect(bar).toHaveTextContent("/a.thf");
 	});
+
+	it("strips bidi controls from the displayed file path and tooltip (#175)", () => {
+		useDocumentRegistry.getState().createDocument({
+			model: createTestModel("Path display"),
+			filePath: "/home/jane/secret\u202Efolder/payments.thf",
+			pendingLayout: null,
+		});
+
+		render(<StatusBar />);
+
+		const displayedPath = screen.getByTitle("/home/jane/secretfolder/payments.thf");
+		expect(displayedPath).toHaveTextContent("/home/jane/secretfolder/payments.thf");
+		expect(displayedPath.getAttribute("title")).not.toContain("\u202E");
+	});
 });
 
 /**

--- a/src/components/layout/status-bar.tsx
+++ b/src/components/layout/status-bar.tsx
@@ -1,3 +1,4 @@
+import { sanitizeDisplayText } from "@/lib/document-display-title";
 import type { DocumentPersistenceState, WorkspaceUnavailableReason } from "@/lib/persistence/types";
 import { useDocumentRegistry } from "@/stores/document-registry";
 import { useHistoryStore } from "@/stores/history-store";
@@ -103,6 +104,7 @@ export function StatusBar() {
 		unavailableReason,
 		persistenceState,
 	);
+	const displayFilePath = filePath ? sanitizeDisplayText(filePath) : null;
 
 	function renderSaveStatus() {
 		if (isDirty) {
@@ -154,11 +156,11 @@ export function StatusBar() {
 				{localPersistence?.attention ? localPersistence.detail : ""}
 			</span>
 
-			{model && filePath && (
+			{model && displayFilePath && (
 				<>
 					<div className="flex-1" />
-					<span className="truncate max-w-64 text-right" title={filePath}>
-						{filePath}
+					<span className="truncate max-w-64 text-right" title={displayFilePath}>
+						{displayFilePath}
 					</span>
 				</>
 			)}

--- a/src/components/layout/top-menu-bar.test.tsx
+++ b/src/components/layout/top-menu-bar.test.tsx
@@ -57,6 +57,19 @@ describe("TopMenuBar title", () => {
 
 		expect(screen.getByText("Draft *")).toBeInTheDocument();
 	});
+
+	it("strips a bidi override from a hostile metadata title (#175)", () => {
+		useDocumentRegistry.getState().createDocument({
+			model: createTestModel("Evil\u202Etitle"),
+			filePath: null,
+			pendingLayout: null,
+		});
+
+		render(<TopMenuBar />);
+
+		expect(screen.getByText("Eviltitle")).toBeInTheDocument();
+		expect(screen.queryByText(/\u202E/)).not.toBeInTheDocument();
+	});
 });
 
 describe("TopMenuBar canvas count badge", () => {

--- a/src/hooks/use-close-guard.test.tsx
+++ b/src/hooks/use-close-guard.test.tsx
@@ -168,6 +168,24 @@ describe("useCloseGuard desktop guard", () => {
 		expect(tauriWindow.destroy).toHaveBeenCalledTimes(1);
 	});
 
+	it("lists a dirty document's sanitized title, not a raw bidi override, in the close summary (#175)", async () => {
+		const hostile = open("Evil\u202Etitle");
+		act(() => {
+			requireStores(hostile).model.getState().markDirty();
+		});
+
+		render(<Harness />);
+		await waitFor(() => expect(tauriWindow.getHandler()).toBeTruthy());
+
+		await act(async () => {
+			await tauriWindow.getHandler()?.({ preventDefault: vi.fn() });
+		});
+
+		const modal = screen.getByTestId("close-guard-modal");
+		expect(within(modal).getByText("Eviltitle")).toBeInTheDocument();
+		expect(within(modal).queryByText(/\u202E/)).not.toBeInTheDocument();
+	});
+
 	it("cancels the close without destroying the window", async () => {
 		const a = open("Alpha");
 		act(() => {

--- a/src/hooks/use-window-title.test.ts
+++ b/src/hooks/use-window-title.test.ts
@@ -1,0 +1,76 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MAX_DISPLAY_LENGTH } from "@/lib/document-display-title";
+import { useModelStore } from "@/stores/model-store";
+import type { ThreatModel } from "@/types/threat-model";
+import { useWindowTitle } from "./use-window-title";
+
+// Mock only the Tauri window boundary the hook crosses via `setTitle`. `isTauri()` reads
+// `window.__TAURI_INTERNALS__` directly, so it is exercised for real rather than mocked.
+const setTitle = vi.fn().mockResolvedValue(undefined);
+vi.mock("@tauri-apps/api/window", () => ({
+	getCurrentWindow: () => ({ setTitle }),
+}));
+
+function makeModel(title: string): ThreatModel {
+	return {
+		version: "1.0",
+		metadata: { title, author: "", created: "", modified: "", description: "" },
+		elements: [],
+		data_flows: [],
+		trust_boundaries: [],
+		threats: [],
+		diagrams: [],
+	};
+}
+
+async function flushMicrotasks(): Promise<void> {
+	await waitFor(() => expect(setTitle).toHaveBeenCalled());
+}
+
+beforeEach(() => {
+	setTitle.mockClear();
+	Object.defineProperty(window, "__TAURI_INTERNALS__", {
+		configurable: true,
+		value: {},
+	});
+});
+
+afterEach(() => {
+	Reflect.deleteProperty(window, "__TAURI_INTERNALS__");
+	useModelStore.getState().clearModel();
+	document.title = "";
+});
+
+describe("useWindowTitle IPC boundary (#175)", () => {
+	it("sends the sanitized, bounded title to both document.title and the native setTitle IPC call", async () => {
+		const hostileTitle = `Evil\u202E${"x".repeat(MAX_DISPLAY_LENGTH + 50)}`;
+		useModelStore.getState().setModel(makeModel(hostileTitle), null);
+
+		renderHook(() => useWindowTitle());
+		await flushMicrotasks();
+		expect(document.title).not.toContain("\u202E");
+		expect(document.title.startsWith("Threat Forge - Evil")).toBe(true);
+
+		expect(setTitle).toHaveBeenCalledTimes(1);
+		const [nativeTitle] = setTitle.mock.calls[0] as [string];
+		expect(nativeTitle).toBe(document.title);
+		expect(nativeTitle).not.toContain("\u202E");
+
+		// "Threat Forge - " (15 chars) + the capped label must not exceed the documented bound.
+		const label = nativeTitle.replace("Threat Forge - ", "");
+		expect(Array.from(label)).toHaveLength(MAX_DISPLAY_LENGTH);
+		expect(label.endsWith("\u2026")).toBe(true);
+	});
+
+	it("sends a sanitized title built from a malicious file basename to the native window", async () => {
+		const hostilePath = "/home/jane/invoice\u202Egpj.exe.thf";
+		useModelStore.getState().setModel(makeModel("Ignored"), hostilePath);
+
+		renderHook(() => useWindowTitle());
+		await flushMicrotasks();
+
+		expect(setTitle).toHaveBeenCalledWith("Threat Forge - invoicegpj.exe");
+		expect(document.title).toBe("Threat Forge - invoicegpj.exe");
+	});
+});

--- a/src/lib/command-registry.test.ts
+++ b/src/lib/command-registry.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { resolveDisplayTitle } from "@/lib/document-display-title";
 import type { DocumentId } from "@/types/document";
 import { buildCommands, fuzzyMatch, searchCommands } from "./command-registry";
 
@@ -143,6 +144,23 @@ describe("command-registry", () => {
 			expect(commands.find((c) => c.id === "file:next-document")).toBeUndefined();
 			expect(commands.find((c) => c.id === "file:close-document")).toBeDefined();
 			expect(commands.filter((c) => c.id.startsWith("file:switch-to:"))).toHaveLength(1);
+		});
+
+		it("renders the sanitized document title in the command label, not a raw hostile one (#175)", () => {
+			// `command-palette.tsx` builds `openDocuments` from `documentDisplayTitle`/
+			// `resolveDisplayTitle`, so the title here is exactly what those already sanitize —
+			// this proves the command label built on top of it carries no bidi override into the
+			// text the palette renders directly as `cmd.label`.
+			const openDocuments = [
+				{
+					id: "doc-a" as DocumentId,
+					title: resolveDisplayTitle(null, "/tmp/invoice\u202Egpj.exe.thf"),
+				},
+			];
+			const commands = buildCommands({ ...mockDeps, openDocuments });
+			const switchCommand = commands.find((c) => c.id === "file:switch-to:doc-a");
+			expect(switchCommand?.label).toBe("Switch to: invoicegpj.exe");
+			expect(switchCommand?.label).not.toContain("\u202E");
 		});
 	});
 

--- a/src/lib/document-display-title.test.ts
+++ b/src/lib/document-display-title.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { ThreatModel } from "@/types/threat-model";
-import { documentDisplayTitle, resolveDisplayTitle } from "./document-display-title";
+import {
+	documentDisplayTitle,
+	MAX_DISPLAY_LENGTH,
+	resolveDisplayTitle,
+	sanitizeDisplayText,
+} from "./document-display-title";
 
 function makeModel(title: string): ThreatModel {
 	return {
@@ -53,5 +58,125 @@ describe("resolveDisplayTitle (cached-title path for un-hydrated tabs, #56)", ()
 
 	it("falls back to the app name when a persisted document cached no title and has no path", () => {
 		expect(resolveDisplayTitle(null, null)).toBe("Threat Forge");
+	});
+
+	it("sanitizes a cached title the same way documentDisplayTitle sanitizes a model title (#175)", () => {
+		const hostileTitle = "Evil\u202Eexe.gpj";
+		expect(resolveDisplayTitle(hostileTitle, null)).toBe(
+			documentDisplayTitle(makeModel(hostileTitle), null),
+		);
+	});
+});
+
+describe("sanitizeDisplayText (#175)", () => {
+	it("strips every C0 control character (U+0000\u2013U+001F)", () => {
+		const withControls = `A\u0000B\u0001C\u001FD`;
+		expect(sanitizeDisplayText(withControls)).toBe("ABCD");
+	});
+
+	it("strips every C1 control character (U+007F\u2013U+009F)", () => {
+		const withControls = `A\u007FB\u0080C\u009FD`;
+		expect(sanitizeDisplayText(withControls)).toBe("ABCD");
+	});
+
+	it("strips the bidi embedding/override range (U+202A\u2013U+202E)", () => {
+		const withBidi = "A\u202AB\u202BC\u202CD\u202DE\u202EF";
+		expect(sanitizeDisplayText(withBidi)).toBe("ABCDEF");
+	});
+
+	it("strips the bidi isolate range (U+2066\u2013U+2069)", () => {
+		const withIsolates = "A\u2066B\u2067C\u2068D\u2069E";
+		expect(sanitizeDisplayText(withIsolates)).toBe("ABCDE");
+	});
+
+	it("strips the LRM/RLM marks (U+200E, U+200F)", () => {
+		expect(sanitizeDisplayText("A\u200EB\u200FC")).toBe("ABC");
+	});
+
+	it("strips the Arabic Letter Mark (U+061C)", () => {
+		expect(sanitizeDisplayText("A\u061CB")).toBe("AB");
+	});
+
+	it("strips mixed control and bidi characters wherever they appear, keeping the rest intact", () => {
+		// A right-to-left override followed by a reversed extension spoofs a document as a
+		// different file type (the classic `cod.exe\u202Egpj` -> visually "cod.exe.jpg" attack).
+		const spoofed = "invoice\u202Efdp.exe";
+		expect(sanitizeDisplayText(spoofed)).toBe("invoicefdp.exe");
+		const withTab = "quarterly\treport\n2026";
+		expect(sanitizeDisplayText(withTab)).toBe("quarterlyreport2026");
+	});
+
+	it("caps very long text at MAX_DISPLAY_LENGTH code points with a visible ellipsis", () => {
+		const long = "a".repeat(MAX_DISPLAY_LENGTH + 500);
+		const result = sanitizeDisplayText(long);
+		expect(Array.from(result)).toHaveLength(MAX_DISPLAY_LENGTH);
+		expect(result.endsWith("\u2026")).toBe(true);
+		expect(result.startsWith("a".repeat(MAX_DISPLAY_LENGTH - 1))).toBe(true);
+	});
+
+	it("leaves text at exactly MAX_DISPLAY_LENGTH untouched (no ellipsis, no truncation)", () => {
+		const exact = "a".repeat(MAX_DISPLAY_LENGTH);
+		expect(sanitizeDisplayText(exact)).toBe(exact);
+	});
+
+	it("truncates text one code point over the boundary", () => {
+		const overByOne = "a".repeat(MAX_DISPLAY_LENGTH + 1);
+		const result = sanitizeDisplayText(overByOne);
+		expect(Array.from(result)).toHaveLength(MAX_DISPLAY_LENGTH);
+		expect(result).toBe(`${"a".repeat(MAX_DISPLAY_LENGTH - 1)}\u2026`);
+	});
+
+	it("counts astral (surrogate-pair) code points as one unit and never splits a pair", () => {
+		// U+1F600 GRINNING FACE is a surrogate pair in UTF-16 (two code units, one code point).
+		const emoji = "\u{1F600}";
+		const long = emoji.repeat(MAX_DISPLAY_LENGTH + 10);
+		const result = sanitizeDisplayText(long);
+		expect(Array.from(result)).toHaveLength(MAX_DISPLAY_LENGTH);
+		// Every retained code unit pair is a complete surrogate pair, and the string ends in the
+		// plain ellipsis character, not a dangling lone surrogate.
+		expect(result.endsWith("\u2026")).toBe(true);
+		const withoutEllipsis = result.slice(0, -1);
+		expect(withoutEllipsis).toBe(emoji.repeat(MAX_DISPLAY_LENGTH - 1));
+		expect(Array.from(withoutEllipsis).every((cp) => cp === emoji)).toBe(true);
+	});
+
+	it("returns an empty string when the input is entirely control/bidi characters", () => {
+		expect(sanitizeDisplayText("\u0000\u202E\u200F\u007F")).toBe("");
+	});
+});
+
+describe("resolveDisplayTitle sanitization fallthrough (#175)", () => {
+	it("falls through a basename that strips to nothing to the metadata title", () => {
+		// The whole basename (before the extension) is control/bidi characters.
+		expect(resolveDisplayTitle("Safe Title", "/tmp/\u0000\u202E.thf")).toBe("Safe Title");
+	});
+
+	it("falls through a basename and a title that both strip to nothing to the app name", () => {
+		expect(resolveDisplayTitle("\u202E\u200F", "/tmp/\u0000\u0001.thf")).toBe("Threat Forge");
+	});
+
+	it("strips a bidi override hidden in a malicious POSIX basename", () => {
+		// Renders visually as something like "cod.exe.jpg" while the real extension is `.exe`.
+		const hostilePath = "/home/jane/invoice\u202Egpj.exe.thf";
+		expect(resolveDisplayTitle(null, hostilePath)).toBe("invoicegpj.exe");
+	});
+
+	it("strips a bidi override hidden in a malicious Windows basename", () => {
+		const hostilePath = "C:\\Users\\jane\\invoice\u202Egpj.exe.thf";
+		expect(resolveDisplayTitle(null, hostilePath)).toBe("invoicegpj.exe");
+	});
+
+	it("caps an oversized metadata title used as the display label", () => {
+		const longTitle = "T".repeat(MAX_DISPLAY_LENGTH + 50);
+		const result = resolveDisplayTitle(longTitle, null);
+		expect(Array.from(result)).toHaveLength(MAX_DISPLAY_LENGTH);
+		expect(result.endsWith("\u2026")).toBe(true);
+	});
+
+	it("caps an oversized file basename used as the display label", () => {
+		const longName = `${"n".repeat(MAX_DISPLAY_LENGTH + 50)}.thf`;
+		const result = resolveDisplayTitle(null, `/tmp/${longName}`);
+		expect(Array.from(result)).toHaveLength(MAX_DISPLAY_LENGTH);
+		expect(result.endsWith("\u2026")).toBe(true);
 	});
 });

--- a/src/lib/document-display-title.ts
+++ b/src/lib/document-display-title.ts
@@ -1,5 +1,55 @@
 import type { ThreatModel } from "@/types/threat-model";
 
+const APP_NAME = "Threat Forge";
+
+/**
+ * Longest display label kept for a tab, tooltip, menu-bar title, command-palette entry, close
+ * prompt, browser document title, or native window title (`#175`). Counted in Unicode code
+ * points, not UTF-16 code units, so an astral character (outside the BMP) is never split into a
+ * dangling lone surrogate. 200 comfortably fits any realistic filename or metadata title while
+ * bounding what a maliciously oversized `.thf` title can push into a DOM attribute, a native
+ * tooltip, or the `setTitle` IPC call — mirroring `PROVIDER_DETAIL_MAX_LENGTH` in
+ * `src/lib/ai/protocol/errors.ts`, the repo's existing length-cap convention for untrusted text.
+ */
+export const MAX_DISPLAY_LENGTH = 200;
+
+const ELLIPSIS = "\u2026";
+
+/**
+ * C0 controls (`U+0000–001F`), C1 controls (`U+007F–009F`), and the bidirectional-formatting
+ * characters (`U+061C`, `U+202A–202E`, `U+2066–2069`, `U+200E`, `U+200F`) that can visually
+ * spoof a label — for example a right-to-left override making `cod.exe.gpj` render as
+ * `jpg.exe.doc` (`#175`, surfaced by the `#54` security preflight in PR #174).
+ */
+function isUnsafeDisplayCodePoint(value: string): boolean {
+	const codePoint = value.codePointAt(0);
+	if (codePoint === undefined) return false;
+	return (
+		codePoint <= 0x001f ||
+		(codePoint >= 0x007f && codePoint <= 0x009f) ||
+		codePoint === 0x061c ||
+		codePoint === 0x200e ||
+		codePoint === 0x200f ||
+		(codePoint >= 0x202a && codePoint <= 0x202e) ||
+		(codePoint >= 0x2066 && codePoint <= 0x2069)
+	);
+}
+
+/**
+ * Make arbitrary untrusted text safe to render as a document label or tooltip line: strip control
+ * and bidi-override characters, then cap the length at {@link MAX_DISPLAY_LENGTH} code points,
+ * appending a visible ellipsis when truncated so the cut is never mistaken for the whole value.
+ *
+ * This is the single place {@link resolveDisplayTitle} sanitizes a title/basename candidate, and
+ * the one a caller must reach for too if it appends more untrusted text (such as a raw file path)
+ * after an already-sanitized title — see `document-tab.tsx`'s tooltip, which does exactly that.
+ */
+export function sanitizeDisplayText(text: string): string {
+	const codePoints = Array.from(text).filter((value) => !isUnsafeDisplayCodePoint(value));
+	if (codePoints.length <= MAX_DISPLAY_LENGTH) return codePoints.join("");
+	return `${codePoints.slice(0, MAX_DISPLAY_LENGTH - 1).join("")}${ELLIPSIS}`;
+}
+
 /**
  * The name a document shows to the user, resolved from one place so the tab, the window/tab
  * title, and the menu-bar title cannot drift (`#54` D2).
@@ -22,6 +72,12 @@ export function documentDisplayTitle(model: ThreatModel | null, filePath: string
  * memory yet: the workspace manifest caches only the `metadata.title` string, so a restored tab
  * resolves its label identically to the hydrated one — path basename first, then the cached
  * title, then the app name — and the two cannot drift when the document is finally hydrated.
+ *
+ * Every candidate is sanitized with {@link sanitizeDisplayText} before it can win (`#175`): a
+ * basename or title that strips down to nothing (for example, a name made entirely of control
+ * characters) falls through to the next candidate rather than returning an empty label. The
+ * `filePath` and `title` values themselves — used elsewhere for file I/O and `.thf` metadata —
+ * are never mutated; only the string returned for display is sanitized.
  */
 export function resolveDisplayTitle(title: string | null, filePath: string | null): string {
 	if (filePath) {
@@ -29,7 +85,14 @@ export function resolveDisplayTitle(title: string | null, filePath: string | nul
 			.split(/[/\\]/)
 			.pop()
 			?.replace(/\.[^.]+$/, "");
-		if (basename) return basename;
+		if (basename) {
+			const safeBasename = sanitizeDisplayText(basename);
+			if (safeBasename) return safeBasename;
+		}
 	}
-	return title ?? "Threat Forge";
+	if (title) {
+		const safeTitle = sanitizeDisplayText(title);
+		if (safeTitle) return safeTitle;
+	}
+	return APP_NAME;
 }


### PR DESCRIPTION
## Summary

Closes #175.

- centralize passive document-title/path sanitization in `document-display-title.ts`
- strip C0/C1 controls and the complete Unicode Bidi_Control set, including U+061C ALM
- cap display strings at 200 Unicode code points with an in-bound visible ellipsis
- preserve POSIX/Windows basename resolution, extension removal, precedence, and app-name fallback
- fall through when a basename/title sanitizes to empty instead of rendering a blank label
- sanitize tab/ARIA labels, tab tooltips, status-bar path, menu title, command palette, close prompts, browser title, and Tauri `setTitle` IPC
- keep raw `.thf` metadata and file paths unchanged for editing and file I/O
- add Unicode boundary and downstream surface regression coverage

## Verification

Final verification at `56abde4`:

- `npm run ci:local` — passed
- Vitest — 106 files, 1,314 tests passed
- targeted title/surface suites — 84 tests passed
- Cargo — 168 library tests plus 3 integration tests passed
- TypeScript, Biome (284 files, zero warnings), Rustfmt, Clippy, web build, Worker dry run, and `git diff --check` — passed

## Preflight record

Self-review fixed two gaps before independent review: removed a prohibited test double-cast and routed the status bar's raw passive file-path text/tooltip through the same sanitizer.

Initial independent lanes:

- PR reviewer: zero must-fix and zero should-fix; strip ranges, Unicode cap, fallthrough, precedence, all passive sinks, IPC, non-mutation, and tests verified
- slop auditor: zero must-fix and zero should-fix; boundary tests are discriminating and centralization is complete
- security auditor: one low should-fix — U+061C Arabic Letter Mark was missing from the bidi-control set

Revision and convergence:

- added U+061C coverage and replaced the control-character regex/suppression with an explicit code-point predicate
- reran full verification and all three lanes; correctness, slop, and security converged with zero must-fix and zero should-fix findings

Residual considerations only: U+2028/U+2029 separators and zero-width characters remain out of the stated bidi-control scope; the raw rename input intentionally preserves editable metadata instead of silently rewriting it; an all-unsafe status path disappears rather than showing a fallback path label.

## Deferred owner validation

Owner validation is deferred under the explicitly authorized autonomous merge run and is not waived. Validate from this PR record:

- open files/titles containing bidi controls and confirm every passive label/tooltip/window surface is visually honest
- confirm long astral-Unicode titles truncate cleanly without broken glyphs
- confirm editing and saving preserves the original raw metadata/path rather than mutating `.thf` content
- decide whether future hardening should strip line separators or zero-width characters too