### PR TITLE
fix(onboarding): replay welcome guide under StrictMode

### DIFF
--- a/docs/runbooks/diagnosing-ci-failures.md
+++ b/docs/runbooks/diagnosing-ci-failures.md
@@ -240,8 +240,8 @@ a saturated runner defeats.
   global `expect` or per-test timeout in `playwright.config.ts`** — #111 forbids it, and a
   node that is never added still has to fail.
 
-Guide auto-start is not currently covered by unit tests either; that gap is tracked in #141.
-A related dev/production divergence in the `welcome` guide is tracked in #142.
+Hook-level tests cover guide auto-start timers, eligibility, and the `welcome` guide's StrictMode
+replay. Real-browser auto-start coverage remains tracked in #141.
 
 ### A test that stays flaky gets quarantined, visibly
 

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -53,11 +53,11 @@ export async function addPaletteItem(page: Page, testId: string) {
 /**
  * The guides that have auto-start triggers, and can therefore block a test.
  *
- * `use-onboarding-triggers.ts:42,63` computes `alreadySeen` from `completedGuideIds` /
- * `dismissedGuideIds` and skips scheduling the timer at all, so seeding an id here suppresses
- * that guide regardless of its `showOnce` value. (`showOnce` gates `startGuide`, which governs
- * only *manual* starts from the guide picker — it is not part of auto-start suppression.) Add
- * any new auto-start guide id here; nothing else is required.
+ * `use-onboarding-triggers.ts` checks `completedGuideIds` and `dismissedGuideIds` before
+ * scheduling and before starting a guide, so seeding an id here suppresses that guide regardless
+ * of its `showOnce` value. (`showOnce` gates `startGuide`, which governs only *manual* starts from
+ * the guide picker — it is not part of auto-start suppression.) Add any new auto-start guide id
+ * here; nothing else is required.
  *
  * `stride-analysis` and `ai-assistant` have no auto-start trigger and are deliberately absent.
  */
@@ -79,16 +79,13 @@ const AUTO_START_GUIDE_IDS = ["welcome", "dfd-basics"];
  *    remove. Measured against the pre-fix seeding: after `New Model`, `guide-overlay` is
  *    present and `palette-item-generic.dblclick()` times out.
  *
- *    `welcome` (500ms after mount) is seeded too, but is inert in this environment: `main.tsx`
- *    enables StrictMode, whose double-invoked effect cancels the 500ms timer while the
- *    `firstLaunchChecked` ref prevents rescheduling. It is suppressed anyway because that is a
- *    dev-only accident, not a guarantee — a production-like build would fire it, since seeding
- *    the What's New key makes `isWhatsNewVisible()` return false and thereby *enables* it.
+ *    `welcome` (500ms after mount) is also active in this environment. Under StrictMode, effect
+ *    cleanup cancels the first timer and effect replay schedules its replacement. Seeding the
+ *    guide id prevents that replacement from blocking E2E interaction.
  *
- * This does remove E2E coverage of guide auto-start, and that behavior is not covered by unit
- * tests either: `guide-overlay.test.tsx` tests only the presentational component, and
- * `use-onboarding-triggers.test.ts` calls `startGuide` directly rather than rendering the hook.
- * The timers and `isWhatsNewVisible()` are untested in both lanes. Tracked in #141.
+ * This removes E2E coverage of guide auto-start. Hook-level tests cover the timers, StrictMode
+ * replay, live eligibility checks, and What's New suppression; real-browser auto-start coverage
+ * remains tracked in #141.
  */
 export async function suppressFirstRunOverlays(page: Page) {
 	await page.addInitScript((guideIds: string[]) => {

--- a/src/hooks/use-onboarding-triggers.test.ts
+++ b/src/hooks/use-onboarding-triggers.test.ts
@@ -1,109 +1,287 @@
+import { act, renderHook } from "@testing-library/react";
+import { StrictMode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useModelStore } from "@/stores/model-store";
 import { useOnboardingStore } from "@/stores/onboarding-store";
+import type { ThreatModel } from "@/types/threat-model";
+import { useOnboardingTriggers } from "./use-onboarding-triggers";
 
-// We test the trigger logic by simulating state changes directly,
-// since the hook relies on React effects that are hard to test in isolation.
+const WHATS_NEW_STORAGE_KEY = "threatforge-last-seen-version";
 
-describe("onboarding trigger logic", () => {
+const mockModel: ThreatModel = {
+	version: "1.0",
+	metadata: {
+		title: "Test Model",
+		author: "Test Author",
+		created: "2026-03-15",
+		modified: "2026-03-15",
+		description: "",
+	},
+	elements: [],
+	data_flows: [],
+	trust_boundaries: [],
+	threats: [],
+	diagrams: [{ id: "main-dfd", name: "Level 0 DFD" }],
+};
+
+/** Marks the What's New overlay as already seen, so it does not block the welcome guide. */
+function markWhatsNewSeen(): void {
+	localStorage.setItem(WHATS_NEW_STORAGE_KEY, "1.0.0");
+}
+
+// Zustand shallow-merges action spies into later snapshots, so restoreAllMocks cannot restore
+// this action. Capture the implementation once and install a fresh wrapper per test.
+const realStartGuide = useOnboardingStore.getState().startGuide;
+
+function spyOnStartGuide(): ReturnType<typeof vi.fn> {
+	const spy = vi.fn(realStartGuide);
+	useOnboardingStore.setState({ startGuide: spy });
+	return spy;
+}
+
+describe("useOnboardingTriggers", () => {
 	beforeEach(() => {
+		vi.useFakeTimers();
 		localStorage.clear();
 		useOnboardingStore.getState().resetAll();
-		useModelStore.getState().clearModel();
+		useOnboardingStore.setState({ startGuide: realStartGuide });
+		useModelStore.setState({ model: null, filePath: null });
 	});
 
 	afterEach(() => {
+		vi.useRealTimers();
 		vi.restoreAllMocks();
 	});
 
-	it("welcome guide can be started when never seen before", () => {
-		const { completedGuideIds, dismissedGuideIds } = useOnboardingStore.getState();
-		expect(completedGuideIds).not.toContain("welcome");
-		expect(dismissedGuideIds).not.toContain("welcome");
+	describe("welcome guide", () => {
+		it("starts exactly once, 500ms after an ordinary (non-StrictMode) mount", () => {
+			markWhatsNewSeen();
+			const startGuideSpy = spyOnStartGuide();
 
-		useOnboardingStore.getState().startGuide("welcome");
-		expect(useOnboardingStore.getState().activeGuide?.id).toBe("welcome");
+			renderHook(() => useOnboardingTriggers());
+
+			expect(useOnboardingStore.getState().activeGuide).toBeNull();
+			act(() => {
+				vi.advanceTimersByTime(500);
+			});
+
+			expect(startGuideSpy).toHaveBeenCalledOnce();
+			expect(startGuideSpy).toHaveBeenCalledWith("welcome");
+			expect(useOnboardingStore.getState().activeGuide?.id).toBe("welcome");
+		});
+
+		it("replays under StrictMode's mount -> cleanup -> remount and still starts exactly once", () => {
+			markWhatsNewSeen();
+			const startGuideSpy = spyOnStartGuide();
+
+			// StrictMode synchronously mounts, cleans up, and remounts on the initial commit.
+			// The first effect run's timer must be cancelled by that cleanup, and the replay
+			// must schedule a replacement — not silently skip scheduling.
+			renderHook(() => useOnboardingTriggers(), { wrapper: StrictMode });
+
+			act(() => {
+				vi.advanceTimersByTime(500);
+			});
+
+			expect(startGuideSpy).toHaveBeenCalledOnce();
+			expect(startGuideSpy).toHaveBeenCalledWith("welcome");
+			expect(useOnboardingStore.getState().activeGuide?.id).toBe("welcome");
+		});
+
+		it("does not fire again well past the delay, under StrictMode", () => {
+			markWhatsNewSeen();
+			const startGuideSpy = spyOnStartGuide();
+
+			renderHook(() => useOnboardingTriggers(), { wrapper: StrictMode });
+
+			act(() => {
+				vi.advanceTimersByTime(5000);
+			});
+
+			expect(startGuideSpy).toHaveBeenCalledOnce();
+		});
+
+		it("does not fire when the welcome guide was already completed", () => {
+			markWhatsNewSeen();
+			useOnboardingStore.setState({ completedGuideIds: ["welcome"] });
+			const startGuideSpy = spyOnStartGuide();
+
+			renderHook(() => useOnboardingTriggers());
+			act(() => {
+				vi.advanceTimersByTime(500);
+			});
+
+			expect(startGuideSpy).not.toHaveBeenCalled();
+			expect(useOnboardingStore.getState().activeGuide).toBeNull();
+		});
+
+		it("does not fire when the welcome guide was already dismissed", () => {
+			markWhatsNewSeen();
+			useOnboardingStore.setState({ dismissedGuideIds: ["welcome"] });
+			const startGuideSpy = spyOnStartGuide();
+
+			renderHook(() => useOnboardingTriggers());
+			act(() => {
+				vi.advanceTimersByTime(500);
+			});
+
+			expect(startGuideSpy).not.toHaveBeenCalled();
+		});
+
+		it("does not fire while the What's New overlay is visible", () => {
+			// beforeEach clears localStorage, so threatforge-last-seen-version is absent and
+			// isWhatsNewVisible() is true — the exact interaction that caused #111.
+			const startGuideSpy = spyOnStartGuide();
+
+			renderHook(() => useOnboardingTriggers());
+			act(() => {
+				vi.advanceTimersByTime(500);
+			});
+
+			expect(startGuideSpy).not.toHaveBeenCalled();
+			expect(useOnboardingStore.getState().activeGuide).toBeNull();
+		});
+
+		it("does not fire when another guide is already active at effect setup", () => {
+			markWhatsNewSeen();
+			useOnboardingStore.getState().startGuide("stride-analysis");
+			const startGuideSpy = spyOnStartGuide();
+
+			renderHook(() => useOnboardingTriggers());
+			act(() => {
+				vi.advanceTimersByTime(500);
+			});
+
+			expect(startGuideSpy).not.toHaveBeenCalledWith("welcome");
+			expect(useOnboardingStore.getState().activeGuide?.id).toBe("stride-analysis");
+		});
+
+		it("re-checks live state at fire time: a guide activated mid-delay is not overwritten", () => {
+			markWhatsNewSeen();
+			renderHook(() => useOnboardingTriggers());
+
+			// Halfway through the welcome delay, something else starts a different guide.
+			act(() => {
+				vi.advanceTimersByTime(250);
+			});
+			act(() => {
+				useOnboardingStore.getState().startGuide("ai-assistant");
+			});
+			act(() => {
+				vi.advanceTimersByTime(500);
+			});
+
+			expect(useOnboardingStore.getState().activeGuide?.id).toBe("ai-assistant");
+		});
+
+		it("re-checks live state at fire time: a completion mid-delay suppresses the stale schedule", () => {
+			markWhatsNewSeen();
+			renderHook(() => useOnboardingTriggers());
+
+			act(() => {
+				vi.advanceTimersByTime(250);
+			});
+			act(() => {
+				useOnboardingStore.setState({ completedGuideIds: ["welcome"] });
+			});
+			act(() => {
+				vi.advanceTimersByTime(500);
+			});
+
+			expect(useOnboardingStore.getState().activeGuide).toBeNull();
+		});
+
+		it("cancels the pending timer on a real unmount and never starts the guide", () => {
+			markWhatsNewSeen();
+			const startGuideSpy = spyOnStartGuide();
+
+			const { unmount } = renderHook(() => useOnboardingTriggers());
+			unmount();
+
+			act(() => {
+				vi.advanceTimersByTime(5000);
+			});
+
+			expect(startGuideSpy).not.toHaveBeenCalled();
+		});
 	});
 
-	it("welcome guide is blocked after completion", () => {
-		useOnboardingStore.getState().startGuide("welcome");
-		// Walk through all steps to complete it
-		const guide = useOnboardingStore.getState().activeGuide;
-		if (guide) {
-			for (let i = 0; i < guide.steps.length; i++) {
-				useOnboardingStore.getState().nextStep();
-			}
-		}
-		expect(useOnboardingStore.getState().completedGuideIds).toContain("welcome");
+	describe("dfd-basics guide", () => {
+		it("starts 800ms after the model transitions from null to non-null", () => {
+			renderHook(() => useOnboardingTriggers());
 
-		// Try to start again — should be blocked because showOnce: true
-		useOnboardingStore.getState().startGuide("welcome");
-		expect(useOnboardingStore.getState().activeGuide).toBeNull();
-	});
+			act(() => {
+				useModelStore.setState({ model: mockModel, filePath: null });
+			});
+			act(() => {
+				vi.advanceTimersByTime(800);
+			});
 
-	it("welcome guide is blocked after dismissal", () => {
-		useOnboardingStore.getState().startGuide("welcome");
-		useOnboardingStore.getState().dismissGuide();
-		expect(useOnboardingStore.getState().dismissedGuideIds).toContain("welcome");
+			expect(useOnboardingStore.getState().activeGuide?.id).toBe("dfd-basics");
+		});
 
-		useOnboardingStore.getState().startGuide("welcome");
-		expect(useOnboardingStore.getState().activeGuide).toBeNull();
-	});
+		it("does not fire again on a later model change once already handled", () => {
+			renderHook(() => useOnboardingTriggers());
 
-	it("dfd-basics guide can be started when model is created", () => {
-		useOnboardingStore.getState().startGuide("dfd-basics");
-		expect(useOnboardingStore.getState().activeGuide?.id).toBe("dfd-basics");
-	});
+			act(() => {
+				useModelStore.setState({ model: mockModel, filePath: null });
+			});
+			act(() => {
+				vi.advanceTimersByTime(800);
+			});
+			useOnboardingStore.getState().dismissGuide();
 
-	it("stride-analysis guide can be restarted (showOnce: false)", () => {
-		useOnboardingStore.getState().startGuide("stride-analysis");
-		// Complete it
-		const guide = useOnboardingStore.getState().activeGuide;
-		if (guide) {
-			for (let i = 0; i < guide.steps.length; i++) {
-				useOnboardingStore.getState().nextStep();
-			}
-		}
-		expect(useOnboardingStore.getState().completedGuideIds).toContain("stride-analysis");
+			const startGuideSpy = spyOnStartGuide();
+			act(() => {
+				useModelStore.setState({
+					model: { ...mockModel, metadata: { ...mockModel.metadata, title: "Renamed" } },
+					filePath: null,
+				});
+			});
+			act(() => {
+				vi.advanceTimersByTime(800);
+			});
 
-		// Can start again because showOnce: false
-		useOnboardingStore.getState().startGuide("stride-analysis");
-		expect(useOnboardingStore.getState().activeGuide?.id).toBe("stride-analysis");
-	});
+			expect(startGuideSpy).not.toHaveBeenCalled();
+		});
 
-	it("ai-assistant guide can be restarted (showOnce: false)", () => {
-		useOnboardingStore.getState().startGuide("ai-assistant");
-		expect(useOnboardingStore.getState().activeGuide?.id).toBe("ai-assistant");
+		it("re-checks live state at fire time: a guide activated during its 800ms delay is not overwritten", () => {
+			renderHook(() => useOnboardingTriggers());
 
-		// Dismiss it
-		useOnboardingStore.getState().dismissGuide();
+			act(() => {
+				useModelStore.setState({ model: mockModel, filePath: null });
+			});
 
-		// Can start again because showOnce: false
-		useOnboardingStore.getState().startGuide("ai-assistant");
-		expect(useOnboardingStore.getState().activeGuide?.id).toBe("ai-assistant");
-	});
+			// Halfway through the dfd-basics delay, something else takes the active guide slot.
+			act(() => {
+				vi.advanceTimersByTime(400);
+			});
+			act(() => {
+				useOnboardingStore.getState().startGuide("stride-analysis");
+			});
+			act(() => {
+				vi.advanceTimersByTime(400);
+			});
 
-	it("ALL_GUIDES contains all 4 guides", async () => {
-		const { ALL_GUIDES } = await import("@/lib/onboarding/guides");
-		expect(ALL_GUIDES).toHaveLength(4);
-		expect(ALL_GUIDES.map((g) => g.id)).toEqual([
-			"welcome",
-			"dfd-basics",
-			"stride-analysis",
-			"ai-assistant",
-		]);
-	});
+			expect(useOnboardingStore.getState().activeGuide?.id).toBe("stride-analysis");
+		});
 
-	it("STRIDE analysis guide has 3 steps targeting threats tab", async () => {
-		const { STRIDE_ANALYSIS_GUIDE } = await import("@/lib/onboarding/guides");
-		expect(STRIDE_ANALYSIS_GUIDE.steps).toHaveLength(3);
-		expect(STRIDE_ANALYSIS_GUIDE.steps[0].targetSelector).toContain("tab-threats");
-		expect(STRIDE_ANALYSIS_GUIDE.steps[1].targetSelector).toContain("btn-stride-analyze");
-	});
+		it.each(["completedGuideIds", "dismissedGuideIds"] as const)(
+			"does not fire when dfd-basics is recorded in %s",
+			(stateKey) => {
+				useOnboardingStore.setState({ [stateKey]: ["dfd-basics"] });
+				const startGuideSpy = spyOnStartGuide();
 
-	it("AI assistant guide has 3 steps targeting AI tab", async () => {
-		const { AI_ASSISTANT_GUIDE } = await import("@/lib/onboarding/guides");
-		expect(AI_ASSISTANT_GUIDE.steps).toHaveLength(3);
-		expect(AI_ASSISTANT_GUIDE.steps[0].targetSelector).toContain("tab-ai");
+				renderHook(() => useOnboardingTriggers());
+				act(() => {
+					useModelStore.setState({ model: mockModel, filePath: null });
+				});
+				act(() => {
+					vi.advanceTimersByTime(800);
+				});
+
+				expect(startGuideSpy).not.toHaveBeenCalled();
+			},
+		);
 	});
 });

--- a/src/hooks/use-onboarding-triggers.ts
+++ b/src/hooks/use-onboarding-triggers.ts
@@ -3,6 +3,10 @@ import { useModelStore } from "@/stores/model-store";
 import { useOnboardingStore } from "@/stores/onboarding-store";
 
 const WHATS_NEW_STORAGE_KEY = "threatforge-last-seen-version";
+const WELCOME_GUIDE_ID = "welcome";
+const WELCOME_DELAY_MS = 500;
+const DFD_BASICS_GUIDE_ID = "dfd-basics";
+const DFD_BASICS_DELAY_MS = 800;
 
 /** Returns true if the What's New overlay is currently showing (blocks guide display) */
 function isWhatsNewVisible(): boolean {
@@ -13,6 +17,13 @@ function isWhatsNewVisible(): boolean {
 	return lastSeen === null;
 }
 
+function isGuideEligible(guideId: string): boolean {
+	const { activeGuide, completedGuideIds, dismissedGuideIds } = useOnboardingStore.getState();
+	return (
+		!activeGuide && !completedGuideIds.includes(guideId) && !dismissedGuideIds.includes(guideId)
+	);
+}
+
 /**
  * Auto-triggers onboarding guides based on user actions.
  * - "welcome" guide on first app launch (no model open, never completed/dismissed)
@@ -20,35 +31,25 @@ function isWhatsNewVisible(): boolean {
  */
 export function useOnboardingTriggers() {
 	const model = useModelStore((s) => s.model);
-	const startGuide = useOnboardingStore((s) => s.startGuide);
-	const completedGuideIds = useOnboardingStore((s) => s.completedGuideIds);
-	const dismissedGuideIds = useOnboardingStore((s) => s.dismissedGuideIds);
-	const activeGuide = useOnboardingStore((s) => s.activeGuide);
-
-	// Track whether we've already attempted the first-launch trigger this session
-	const firstLaunchChecked = useRef(false);
 	// Track whether a model was previously null (to detect first creation)
 	const hadNoModel = useRef(true);
 
-	// First-launch: trigger welcome guide once on mount if never seen
+	// Keep this mount effect replayable: StrictMode cleanup cancels the first timer, then replay
+	// schedules its replacement.
 	useEffect(() => {
-		if (firstLaunchChecked.current) return;
-		firstLaunchChecked.current = true;
-
 		// Don't show the welcome guide if the What's New overlay is visible (first launch)
 		// to avoid two overlapping modals
 		if (isWhatsNewVisible()) return;
+		if (!isGuideEligible(WELCOME_GUIDE_ID)) return;
 
-		const alreadySeen =
-			completedGuideIds.includes("welcome") || dismissedGuideIds.includes("welcome");
-		if (!alreadySeen && !activeGuide) {
-			// Delay slightly to let the UI render first
-			const timer = setTimeout(() => {
-				startGuide("welcome");
-			}, 500);
-			return () => clearTimeout(timer);
-		}
-	}, [completedGuideIds, dismissedGuideIds, activeGuide, startGuide]);
+		// Delay slightly to let the UI render first
+		const timer = setTimeout(() => {
+			if (isWhatsNewVisible()) return;
+			if (!isGuideEligible(WELCOME_GUIDE_ID)) return;
+			useOnboardingStore.getState().startGuide(WELCOME_GUIDE_ID);
+		}, WELCOME_DELAY_MS);
+		return () => clearTimeout(timer);
+	}, []);
 
 	// First-model-created: trigger DFD basics when model transitions from null to non-null
 	useEffect(() => {
@@ -56,19 +57,16 @@ export function useOnboardingTriggers() {
 			hadNoModel.current = true;
 			return;
 		}
+		if (!hadNoModel.current) return;
+		hadNoModel.current = false;
 
-		if (hadNoModel.current) {
-			hadNoModel.current = false;
+		if (!isGuideEligible(DFD_BASICS_GUIDE_ID)) return;
 
-			const alreadySeen =
-				completedGuideIds.includes("dfd-basics") || dismissedGuideIds.includes("dfd-basics");
-			if (!alreadySeen && !activeGuide) {
-				// Delay to let the canvas render after model creation
-				const timer = setTimeout(() => {
-					startGuide("dfd-basics");
-				}, 800);
-				return () => clearTimeout(timer);
-			}
-		}
-	}, [model, completedGuideIds, dismissedGuideIds, activeGuide, startGuide]);
+		// Delay to let the canvas render after model creation
+		const timer = setTimeout(() => {
+			if (!isGuideEligible(DFD_BASICS_GUIDE_ID)) return;
+			useOnboardingStore.getState().startGuide(DFD_BASICS_GUIDE_ID);
+		}, DFD_BASICS_DELAY_MS);
+		return () => clearTimeout(timer);
+	}, [model]);
 }

--- a/src/lib/onboarding/guides.test.ts
+++ b/src/lib/onboarding/guides.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { AI_ASSISTANT_GUIDE, ALL_GUIDES, STRIDE_ANALYSIS_GUIDE } from "./guides";
+
+describe("onboarding guide definitions", () => {
+	it("ALL_GUIDES contains all 4 guides in a stable order", () => {
+		expect(ALL_GUIDES).toHaveLength(4);
+		expect(ALL_GUIDES.map((g) => g.id)).toEqual([
+			"welcome",
+			"dfd-basics",
+			"stride-analysis",
+			"ai-assistant",
+		]);
+	});
+
+	it("STRIDE analysis guide has 3 steps targeting the threats tab", () => {
+		expect(STRIDE_ANALYSIS_GUIDE.steps).toHaveLength(3);
+		expect(STRIDE_ANALYSIS_GUIDE.steps[0].targetSelector).toContain("tab-threats");
+		expect(STRIDE_ANALYSIS_GUIDE.steps[1].targetSelector).toContain("btn-stride-analyze");
+	});
+
+	it("AI assistant guide has 3 steps targeting the AI tab", () => {
+		expect(AI_ASSISTANT_GUIDE.steps).toHaveLength(3);
+		expect(AI_ASSISTANT_GUIDE.steps[0].targetSelector).toContain("tab-ai");
+	});
+});

--- a/src/stores/onboarding-store.test.ts
+++ b/src/stores/onboarding-store.test.ts
@@ -100,6 +100,27 @@ describe("onboarding-store", () => {
 		expect(useOnboardingStore.getState().activeGuide).toBeNull();
 	});
 
+	it("re-shows a completed showOnce:false guide (stride-analysis)", () => {
+		useOnboardingStore.getState().startGuide("stride-analysis");
+		const steps = useOnboardingStore.getState().activeGuide?.steps.length ?? 0;
+		for (let i = 0; i < steps; i++) {
+			useOnboardingStore.getState().nextStep();
+		}
+		expect(useOnboardingStore.getState().completedGuideIds).toContain("stride-analysis");
+
+		useOnboardingStore.getState().startGuide("stride-analysis");
+		expect(useOnboardingStore.getState().activeGuide?.id).toBe("stride-analysis");
+	});
+
+	it("re-shows a dismissed showOnce:false guide (ai-assistant)", () => {
+		useOnboardingStore.getState().startGuide("ai-assistant");
+		useOnboardingStore.getState().dismissGuide();
+		expect(useOnboardingStore.getState().dismissedGuideIds).toContain("ai-assistant");
+
+		useOnboardingStore.getState().startGuide("ai-assistant");
+		expect(useOnboardingStore.getState().activeGuide?.id).toBe("ai-assistant");
+	});
+
 	it("resets a specific guide", () => {
 		useOnboardingStore.setState({
 			completedGuideIds: ["welcome", "dfd-basics"],


### PR DESCRIPTION
Closes #142

## Summary

- keep the welcome guide mount effect replayable so React StrictMode cleanup cancels the first timer and replay schedules exactly one replacement
- re-check live onboarding and What's New eligibility before delayed guide starts, preventing stale timers from overwriting active guides
- replace store-only pseudo-tests with real hook coverage for ordinary mounts, StrictMode replay, timer cleanup, completion/dismissal, overlay suppression, and mid-delay state changes
- update E2E and CI troubleshooting guidance to match the corrected lifecycle and current test coverage

## Verification

- `npm run ci:local`
- targeted onboarding suite: 35 tests passed
- regression discrimination: both StrictMode tests fail against the pre-fix hook and pass with this change

## Preflight

- PR reviewer: converged after correcting stale E2E/runbook references
- slop auditor: converged; no must-fix or should-fix findings
- security auditor: not applicable; no trust-boundary, IPC, secret, or file-I/O changes
- threat-model expert: not applicable; no `.thf`, STRIDE, or threat-quality changes

## Owner validation

Deferred under the authorized autonomous run. The merged PR remains the validation record. Confirm the welcome guide appears once in both a StrictMode development run and a production-like run when eligible, and remains absent when completed, dismissed, or blocked by What's New.