### PR TITLE
fix(desktop): add guarded native quit menus

### DIFF
--- a/src-tauri/src/commands/app_commands.rs
+++ b/src-tauri/src/commands/app_commands.rs
@@ -1,0 +1,8 @@
+use tauri::AppHandle;
+
+/// Exit after the frontend dirty-document guard has approved the quit.
+#[tauri::command]
+pub fn confirm_quit(app: AppHandle) -> Result<(), String> {
+    app.exit(0);
+    Ok(())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,10 +1,12 @@
 mod ai_commands;
+mod app_commands;
 mod file_commands;
 mod import_commands;
 mod stride_commands;
 mod update_commands;
 
 pub use ai_commands::*;
+pub use app_commands::*;
 pub use file_commands::*;
 pub use import_commands::*;
 pub use stride_commands::*;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,11 +9,18 @@ pub mod models;
 mod stride;
 
 use commands::{
-    analyze_stride, cancel_ai_stream, check_for_update, create_new_model, delete_api_key,
-    get_api_key_status, import_threat_model, install_update, open_layout, open_threat_model,
-    save_layout, save_threat_model, set_api_key, start_ai_stream, write_text_file,
+    analyze_stride, cancel_ai_stream, check_for_update, confirm_quit, create_new_model,
+    delete_api_key, get_api_key_status, import_threat_model, install_update, open_layout,
+    open_threat_model, save_layout, save_threat_model, set_api_key, start_ai_stream,
+    write_text_file,
 };
-use tauri::{Emitter, Manager};
+use tauri::{AppHandle, Emitter, Manager};
+
+fn emit_quit_requested(app_handle: &AppHandle) {
+    if app_handle.emit("quit-requested", ()).is_err() {
+        eprintln!("Failed to deliver guarded quit request");
+    }
+}
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -26,9 +33,14 @@ pub fn run() {
             let menu = menu::build_menu(app)?;
             app.set_menu(menu)?;
 
-            // Forward native menu events to the frontend
+            // Route every platform quit item through the frontend dirty-document guard.
             app.on_menu_event(move |app_handle, event| {
-                let _ = app_handle.emit("menu-action", event.id().0.as_str());
+                let id = event.id().0.as_str();
+                if id == "app-quit" || id == "file-exit" {
+                    emit_quit_requested(app_handle);
+                } else {
+                    let _ = app_handle.emit("menu-action", id);
+                }
             });
 
             // Initialize encrypted key storage
@@ -82,6 +94,7 @@ pub fn run() {
             import_threat_model,
             check_for_update,
             install_update,
+            confirm_quit,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -4,9 +4,50 @@ use tauri::{
 };
 
 /// Build the native application menu bar.
-/// Menu items emit events to the frontend via `menu-action` event.
+///
+/// Menu items emit events to the frontend via the `menu-action` event, except the
+/// platform quit affordances, which emit `quit-requested` and reuse the frontend
+/// dirty-document guard.
 pub fn build_menu(app: &App) -> Result<Menu<Wry>, Box<dyn std::error::Error>> {
     let handle = app.handle();
+
+    // macOS application submenu: rendered first, in the application-menu slot. Built from
+    // predefined items so About/Services/Hide/Quit carry their native behavior and the
+    // platform-correct Cmd+Q accelerator.
+    #[cfg(target_os = "macos")]
+    let app_menu = {
+        let about = PredefinedMenuItem::about(handle, None, None)?;
+        let services = PredefinedMenuItem::services(handle, None)?;
+        let hide = PredefinedMenuItem::hide(handle, None)?;
+        let hide_others = PredefinedMenuItem::hide_others(handle, None)?;
+        let show_all = PredefinedMenuItem::show_all(handle, None)?;
+        let app_name = handle.package_info().name.clone();
+        // Tauri 2.11.5 does not expose macOS applicationShouldTerminate, so predefined Quit's
+        // terminate: action cannot be guarded against unsaved changes.
+        let quit = MenuItem::with_id(
+            handle,
+            "app-quit",
+            format!("Quit {app_name}"),
+            true,
+            Some("CmdOrCtrl+Q"),
+        )?;
+        Submenu::with_items(
+            handle,
+            app_name,
+            true,
+            &[
+                &about,
+                &PredefinedMenuItem::separator(handle)?,
+                &services,
+                &PredefinedMenuItem::separator(handle)?,
+                &hide,
+                &hide_others,
+                &show_all,
+                &PredefinedMenuItem::separator(handle)?,
+                &quit,
+            ],
+        )?
+    };
 
     // File menu
     let file_new = MenuItem::with_id(handle, "file-new", "New Model", true, Some("CmdOrCtrl+N"))?;
@@ -36,6 +77,11 @@ pub fn build_menu(app: &App) -> Result<Menu<Wry>, Box<dyn std::error::Error>> {
         true,
         Some("CmdOrCtrl+W"),
     )?;
+    // Windows/Linux have no application menu, so the conventional quit lives in File → Exit.
+    // A custom item is required on both: predefined Quit is unsupported on Linux, and on Windows
+    // it posts WM_QUIT, bypassing Tauri's preventable ExitRequested event.
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    let file_exit = MenuItem::with_id(handle, "file-exit", "Exit", true, None::<&str>)?;
 
     let file_menu = Submenu::with_items(
         handle,
@@ -51,6 +97,10 @@ pub fn build_menu(app: &App) -> Result<Menu<Wry>, Box<dyn std::error::Error>> {
             &file_export_html,
             &PredefinedMenuItem::separator(handle)?,
             &file_close,
+            #[cfg(any(target_os = "windows", target_os = "linux"))]
+            &PredefinedMenuItem::separator(handle)?,
+            #[cfg(any(target_os = "windows", target_os = "linux"))]
+            &file_exit,
         ],
     )?;
 
@@ -136,6 +186,25 @@ pub fn build_menu(app: &App) -> Result<Menu<Wry>, Box<dyn std::error::Error>> {
         ],
     )?;
 
+    // macOS Window submenu: standard Minimize/Zoom/Close, using predefined items.
+    #[cfg(target_os = "macos")]
+    let window_menu = {
+        let minimize = PredefinedMenuItem::minimize(handle, None)?;
+        let zoom = PredefinedMenuItem::maximize(handle, None)?;
+        let close_window = PredefinedMenuItem::close_window(handle, None)?;
+        Submenu::with_items(
+            handle,
+            "Window",
+            true,
+            &[
+                &minimize,
+                &zoom,
+                &PredefinedMenuItem::separator(handle)?,
+                &close_window,
+            ],
+        )?
+    };
+
     // Help menu
     let help_keyboard_shortcuts = MenuItem::with_id(
         handle,
@@ -145,6 +214,9 @@ pub fn build_menu(app: &App) -> Result<Menu<Wry>, Box<dyn std::error::Error>> {
         None::<&str>,
     )?;
     let help_guides = MenuItem::with_id(handle, "help-guides", "Guided Tours", true, None::<&str>)?;
+    // macOS exposes About in the native application menu, so a Help → About there would be a
+    // duplicate. Keep the Help entry only where there is no application menu.
+    #[cfg(not(target_os = "macos"))]
     let help_about = MenuItem::with_id(
         handle,
         "help-about",
@@ -152,7 +224,6 @@ pub fn build_menu(app: &App) -> Result<Menu<Wry>, Box<dyn std::error::Error>> {
         true,
         None::<&str>,
     )?;
-
     let help_menu = Submenu::with_items(
         handle,
         "Help",
@@ -161,11 +232,26 @@ pub fn build_menu(app: &App) -> Result<Menu<Wry>, Box<dyn std::error::Error>> {
             &help_keyboard_shortcuts,
             &PredefinedMenuItem::separator(handle)?,
             &help_guides,
+            #[cfg(not(target_os = "macos"))]
             &PredefinedMenuItem::separator(handle)?,
+            #[cfg(not(target_os = "macos"))]
             &help_about,
         ],
     )?;
 
+    #[cfg(target_os = "macos")]
+    let menu = Menu::with_items(
+        handle,
+        &[
+            &app_menu,
+            &file_menu,
+            &edit_menu,
+            &view_menu,
+            &window_menu,
+            &help_menu,
+        ],
+    )?;
+    #[cfg(not(target_os = "macos"))]
     let menu = Menu::with_items(handle, &[&file_menu, &edit_menu, &view_menu, &help_menu])?;
 
     Ok(menu)

--- a/src/hooks/use-close-guard.test.tsx
+++ b/src/hooks/use-close-guard.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen, waitFor, within } from "@testing-librar
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 type CloseHandler = (event: { preventDefault: () => void }) => unknown;
+type QuitHandler = () => unknown;
 
 // Stub the Tauri window. `getCurrentWindow().onCloseRequested` captures the handler so a test can
 // fire a close request; `destroy` records that the window was actually closed.
@@ -26,11 +27,58 @@ const tauriWindow = vi.hoisted(() => {
 	};
 });
 
+// Stub the Tauri event bus. `listen("quit-requested", cb)` captures the callback so a test can
+// simulate the Rust-emitted native-quit request.
+const tauriEvent = vi.hoisted(() => {
+	let quitHandler: QuitHandler | null = null;
+	let nextListenError: Error | null = null;
+	const listen = vi.fn(async (event: string, cb: QuitHandler) => {
+		if (nextListenError) {
+			const error = nextListenError;
+			nextListenError = null;
+			throw error;
+		}
+		if (event === "quit-requested") quitHandler = cb;
+		return () => {
+			if (event === "quit-requested") quitHandler = null;
+		};
+	});
+	return {
+		listen,
+		getQuitHandler: () => quitHandler,
+		failNextListen: () => {
+			nextListenError = new Error("event API unavailable");
+		},
+		reset: () => {
+			quitHandler = null;
+			nextListenError = null;
+			listen.mockClear();
+		},
+	};
+});
+
+// Stub the Tauri IPC. `confirm_quit` is the only command the guard invokes; record every call.
+const tauriCore = vi.hoisted(() => {
+	const invoke = vi.fn().mockResolvedValue(undefined);
+	return {
+		invoke,
+		reset: () => invoke.mockClear(),
+	};
+});
+
 vi.mock("@tauri-apps/api/window", () => ({
 	getCurrentWindow: () => ({
 		onCloseRequested: tauriWindow.onCloseRequested,
 		destroy: tauriWindow.destroy,
 	}),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+	listen: tauriEvent.listen,
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+	invoke: tauriCore.invoke,
 }));
 
 import { useDocumentRegistry } from "@/stores/document-registry";
@@ -81,6 +129,8 @@ beforeEach(() => {
 	useDocumentRegistry.setState({ documents: {}, openDocumentIds: [], activeDocumentId: null });
 	setActiveStores(createDocumentStores());
 	tauriWindow.reset();
+	tauriEvent.reset();
+	tauriCore.reset();
 });
 
 describe("useCloseGuard browser guard", () => {
@@ -243,5 +293,89 @@ describe("useCloseGuard desktop guard", () => {
 
 		getStateSpy.mockRestore();
 		confirmSpy.mockRestore();
+	});
+
+	it("unregisters the window close guard when quit-listener setup fails", async () => {
+		tauriEvent.failNextListen();
+		const { unmount } = render(<Harness />);
+		await waitFor(() => expect(tauriWindow.getHandler()).toBeTruthy());
+		await waitFor(() => expect(tauriEvent.listen).toHaveBeenCalled());
+
+		unmount();
+
+		expect(tauriWindow.getHandler()).toBeNull();
+	});
+});
+
+describe("useCloseGuard desktop quit guard", () => {
+	beforeEach(() => {
+		(window as unknown as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+	});
+	afterEach(() => {
+		(window as unknown as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = undefined;
+	});
+
+	it("prevents an immediate quit on dirty state, lists every dirty document, and confirms exactly once", async () => {
+		const a = open("Alpha");
+		const b = open("Beta");
+		act(() => {
+			requireStores(a).model.getState().markDirty();
+			requireStores(b).model.getState().markDirty();
+		});
+
+		render(<Harness />);
+		await waitFor(() => expect(tauriEvent.getQuitHandler()).toBeTruthy());
+
+		await act(async () => {
+			tauriEvent.getQuitHandler()?.();
+		});
+
+		// The native quit was already prevented in Rust; the guard must not exit yet. Both dirty
+		// documents are listed and no confirmation IPC has fired.
+		const modal = await screen.findByTestId("close-guard-modal");
+		expect(within(modal).getByText("Alpha")).toBeInTheDocument();
+		expect(within(modal).getByText("Beta")).toBeInTheDocument();
+		expect(tauriCore.invoke).not.toHaveBeenCalled();
+
+		await act(async () => {
+			fireEvent.click(within(modal).getByRole("button", { name: "Discard and quit" }));
+		});
+
+		expect(tauriCore.invoke).toHaveBeenCalledTimes(1);
+		expect(tauriCore.invoke).toHaveBeenCalledWith("confirm_quit");
+	});
+
+	it("cancels a dirty quit without confirming exit", async () => {
+		const a = open("Alpha");
+		act(() => {
+			requireStores(a).model.getState().markDirty();
+		});
+		render(<Harness />);
+		await waitFor(() => expect(tauriEvent.getQuitHandler()).toBeTruthy());
+
+		await act(async () => {
+			tauriEvent.getQuitHandler()?.();
+		});
+		const modal = await screen.findByTestId("close-guard-modal");
+		await act(async () => {
+			fireEvent.click(within(modal).getByRole("button", { name: "Cancel" }));
+		});
+
+		expect(screen.queryByTestId("close-guard-modal")).not.toBeInTheDocument();
+		expect(tauriCore.invoke).not.toHaveBeenCalled();
+	});
+
+	it("quits immediately with no summary when nothing is dirty", async () => {
+		open("Clean");
+		render(<Harness />);
+		await waitFor(() => expect(tauriEvent.getQuitHandler()).toBeTruthy());
+
+		await act(async () => {
+			tauriEvent.getQuitHandler()?.();
+		});
+
+		expect(screen.queryByTestId("close-guard-modal")).not.toBeInTheDocument();
+		await waitFor(() => expect(tauriCore.invoke).toHaveBeenCalledWith("confirm_quit"));
+		expect(tauriCore.invoke).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/hooks/use-close-guard.tsx
+++ b/src/hooks/use-close-guard.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useState } from "react";
 import { documentDisplayTitle } from "@/lib/document-display-title";
 import { isTauri } from "@/lib/platform";
 import { useDocumentRegistry } from "@/stores/document-registry";
@@ -8,6 +8,13 @@ import type { DocumentId } from "@/types/document";
 interface DirtyDocument {
 	id: DocumentId;
 	title: string;
+}
+
+/** A pending close/quit decision awaiting user confirmation in the summary modal. */
+interface PendingClose {
+	documents: DirtyDocument[];
+	confirmLabel: string;
+	confirm: () => Promise<void>;
 }
 
 /**
@@ -26,24 +33,32 @@ function currentDirtyDocuments(): DirtyDocument[] {
 	return dirty;
 }
 
+/** Confirm an application quit that has cleared the dirty-document guard. */
+async function confirmQuit(): Promise<void> {
+	const { invoke } = await import("@tauri-apps/api/core");
+	await invoke<void>("confirm_quit");
+}
+
 /**
- * Window and application close guards (`#54` D6 / step 9). Mounted once in the app shell; returns
- * the desktop close-summary modal (or `null`), which the shell renders.
+ * Window and application close guards (`#54` D6 / step 9, `#143` quit). Mounted once in the app
+ * shell; returns the desktop close-summary modal (or `null`), which the shell renders.
  *
  * - **Browser:** a `beforeunload` listener is registered **only while at least one document is
  *   dirty** and removed as soon as none are. Browsers replace any custom string with their own, so
  *   the handler only calls `preventDefault`. Conditional registration keeps bfcache and the
  *   `#56` `pagehide` autosave flush intact — an always-registered handler would disable bfcache.
- * - **Desktop:** `onCloseRequested` calls `preventDefault()` **first** (the Tauri API destroys the
- *   window if the handler throws before preventing — the default is fail-open, and fail-open here
- *   means data loss), then either closes immediately when nothing is dirty or shows an in-app
- *   summary listing every dirty document. Any failure falls back to `window.confirm` so the window
- *   is never left unclosable and is never destroyed without asking.
+ * - **Desktop window close:** `onCloseRequested` calls `preventDefault()` **first** (the Tauri API
+ *   destroys the window if the handler throws before preventing — the default is fail-open, and
+ *   fail-open here means data loss), then either closes immediately when nothing is dirty or shows
+ *   an in-app summary listing every dirty document. Any failure falls back to `window.confirm` so
+ *   the window is never left unclosable and is never destroyed without asking.
+ * - **Desktop quit:** platform menu items emit `quit-requested` instead of exiting. The same
+ *   summary decides: clean state quits immediately via `confirm_quit`, dirty state prompts,
+ *   cancel keeps the app open, and confirmation quits.
  */
 export function useCloseGuard(): ReactNode {
 	const [dirtyCount, setDirtyCount] = useState(0);
-	const [pendingDocuments, setPendingDocuments] = useState<DirtyDocument[] | null>(null);
-	const destroyWindowRef = useRef<(() => Promise<void>) | null>(null);
+	const [pending, setPending] = useState<PendingClose | null>(null);
 
 	// Track the dirty count by subscribing to the registry (open set) and to each open document's
 	// own model store, re-subscribing as documents open and close.
@@ -103,7 +118,7 @@ export function useCloseGuard(): ReactNode {
 			try {
 				const { getCurrentWindow } = await import("@tauri-apps/api/window");
 				const win = getCurrentWindow();
-				destroyWindowRef.current = () => win.destroy();
+
 				const un = await win.onCloseRequested(async (event) => {
 					try {
 						// Prevent first: the API fails open (destroys the window) if the handler throws
@@ -114,7 +129,11 @@ export function useCloseGuard(): ReactNode {
 							await win.destroy();
 							return;
 						}
-						setPendingDocuments(dirty);
+						setPending({
+							documents: dirty,
+							confirmLabel: "Discard and close",
+							confirm: () => win.destroy(),
+						});
 					} catch {
 						// Never lose data silently, never leave the window unclosable.
 						if (window.confirm("You have unsaved changes. Discard them and close?")) {
@@ -136,36 +155,80 @@ export function useCloseGuard(): ReactNode {
 		return () => {
 			cancelled = true;
 			unlisten?.();
-			destroyWindowRef.current = null;
 		};
 	}, []);
 
-	const cancelClose = useCallback(() => setPendingDocuments(null), []);
-	const discardAndClose = useCallback(async () => {
-		setPendingDocuments(null);
-		try {
-			await destroyWindowRef.current?.();
-		} catch {
-			// Nothing further can be done safely if the window API rejects.
-		}
+	// Desktop: decide a native application quit that Rust has already prevented.
+	useEffect(() => {
+		if (!isTauri()) return;
+		let unlisten: (() => void) | undefined;
+		let cancelled = false;
+
+		void (async () => {
+			try {
+				const { listen } = await import("@tauri-apps/api/event");
+				const un = await listen<void>("quit-requested", () => {
+					void (async () => {
+						try {
+							const dirty = currentDirtyDocuments();
+							if (dirty.length === 0) {
+								await confirmQuit();
+								return;
+							}
+							setPending({
+								documents: dirty,
+								confirmLabel: "Discard and quit",
+								confirm: confirmQuit,
+							});
+						} catch {
+							// The exit was already prevented; doing nothing leaves the app open.
+						}
+					})();
+				});
+				if (cancelled) un();
+				else unlisten = un;
+			} catch {
+				// Event API unavailable: the prevented exit remains fail-closed.
+			}
+		})();
+
+		return () => {
+			cancelled = true;
+			unlisten?.();
+		};
 	}, []);
 
-	if (!pendingDocuments) return null;
+	const cancelClose = useCallback(() => setPending(null), []);
+	const confirmClose = useCallback(() => {
+		if (!pending) return;
+		// Capture the action before clearing the modal, then run it outside the state updater so it
+		// fires exactly once (a side effect inside an updater would run twice under StrictMode).
+		const { confirm } = pending;
+		setPending(null);
+		void confirm().catch(() => {
+			// The window/IPC call is the last safe step; nothing further can be done on failure.
+		});
+	}, [pending]);
+
+	if (!pending) return null;
 	return (
 		<CloseSummaryModal
-			documents={pendingDocuments}
+			documents={pending.documents}
+			confirmLabel={pending.confirmLabel}
 			onCancel={cancelClose}
-			onConfirm={() => void discardAndClose()}
+			onConfirm={confirmClose}
 		/>
 	);
 }
 
 function CloseSummaryModal({
 	documents,
+	confirmLabel,
 	onCancel,
 	onConfirm,
 }: {
 	documents: DirtyDocument[];
+	confirmLabel: string;
 	onCancel: () => void;
 	onConfirm: () => void;
 }) {
@@ -206,7 +269,7 @@ function CloseSummaryModal({
 						onClick={onConfirm}
 						className="rounded-md bg-destructive px-3 py-1.5 text-sm text-destructive-foreground hover:bg-destructive/90"
 					>
-						Discard and close
+						{confirmLabel}
 					</button>
 				</div>
 			</div>


### PR DESCRIPTION
Closes #143
Related: #196

## Summary

- add a first macOS application menu named from the configured app, with native About, Services, Hide, Hide Others, Show All, plus a guarded Cmd+Q Quit item
- add the native macOS Window menu with Minimize, Zoom, and Close Window, and add guarded `File → Exit` items on Windows/Linux
- route every in-app quit action through the existing all-document dirty summary; cancel stays open, while clean or confirmed quit uses a narrow no-argument Rust exit command
- preserve the independent fail-closed window-close guard and add real listener/IPC tests for dirty, cancel, clean, exact-once, and cleanup paths

Pinned-runtime review showed that predefined Quit cannot satisfy the data-loss contract: muda posts unpreventable `WM_QUIT` on Windows, does not support Quit on Linux, and tao 0.35.3 exposes no preventable macOS `applicationShouldTerminate:` hook. Custom menu items therefore preserve the visible native locations/accelerators while entering the verified guard. OS-level macOS quit sources outside the menu/Cmd+Q path are tracked separately in #196.

## Verification

- `npm run ci:local`
- `cargo clippy --locked --all-targets -- -D warnings` in Ubuntu 22.04 with the repository's Tauri system dependencies
- `npx vitest run src/hooks/use-close-guard.test.tsx` — 12 tests passed
- required remote CI passed, including macOS, Windows, Ubuntu, E2E, dependency review, and CodeQL
- canonical `npm run ci:docker` attempted twice; npm failed in its own pre-source `npm ci` layer with `Exit handler never called`, so no Docker source check is claimed

## Preflight

- PR reviewer: converged; no must-fix or should-fix findings
- slop auditor: converged after removing false predefined-Quit assumptions and dead RunEvent scaffolding
- security auditor: converged; no must-fix or should-fix findings, strict CSP/capabilities unchanged
- threat-model expert: not applicable; no `.thf`, STRIDE, or threat-quality changes

## Owner validation

Deferred under the authorized autonomous run. The merged PR remains the validation record.

- launch a built macOS bundle and confirm the app menu is first and titled `Threat Forge`
- confirm About, Services, Hide, Hide Others, Show All, Minimize, Zoom, and Close Window behave natively
- confirm Cmd+Q prompts with dirty foreground/background documents, Cancel stays open, and clean/confirmed quit exits
- inspect the duplicate Cmd+W presentation for File → Close Model and Window → Close; both routes are guarded, but menu preference is an owner judgment
- spot-check Windows/Linux `File → Exit`; both cfg branches compiled in required remote CI
- do not treat Dock/Apple-event Quit as covered; that runtime limitation is explicitly tracked in #196