### PR TITLE
test(e2e): cover onboarding guide auto-start

### DIFF
--- a/docs/runbooks/diagnosing-ci-failures.md
+++ b/docs/runbooks/diagnosing-ci-failures.md
@@ -241,7 +241,9 @@ a saturated runner defeats.
   node that is never added still has to fail.
 
 Hook-level tests cover guide auto-start timers, eligibility, and the `welcome` guide's StrictMode
-replay. Real-browser auto-start coverage remains tracked in #141.
+replay. `e2e/onboarding-auto-start.spec.ts` (#141) covers real-browser auto-start: it imports the
+plain `@playwright/test` `test` rather than this fixture, seeds only what each case's contract
+calls for, and dismisses each guide through its rendered UI.
 
 ### A test that stays flaky gets quarantined, visibly
 

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -3,14 +3,12 @@ import { type Page, expect, test as base } from "@playwright/test";
 /** Platform-aware modifier key: Meta on macOS, Control elsewhere */
 export const modKey = process.platform === "darwin" ? "Meta" : "Control";
 
-/** Dismiss the "What's New" overlay if it is visible (blocks interactions on first launch) */
+/** Wait for and dismiss the first-launch "What's New" overlay through its rendered UI. */
 export async function dismissWhatsNew(page: Page) {
 	const overlay = page.getByTestId("whats-new-overlay");
-	const isVisible = await overlay.isVisible().catch(() => false);
-	if (isVisible) {
-		await overlay.locator("button", { hasText: "Got it" }).click();
-		await overlay.waitFor({ state: "hidden" });
-	}
+	await expect(overlay).toBeVisible();
+	await overlay.getByRole("button", { name: "Got it" }).click();
+	await expect(overlay).toBeHidden();
 }
 
 /**
@@ -83,9 +81,11 @@ const AUTO_START_GUIDE_IDS = ["welcome", "dfd-basics"];
  *    cleanup cancels the first timer and effect replay schedules its replacement. Seeding the
  *    guide id prevents that replacement from blocking E2E interaction.
  *
- * This removes E2E coverage of guide auto-start. Hook-level tests cover the timers, StrictMode
- * replay, live eligibility checks, and What's New suppression; real-browser auto-start coverage
- * remains tracked in #141.
+ * This intentionally removes guide auto-start from every spec built on this fixture. Hook-level
+ * tests cover the timers, StrictMode replay, live eligibility checks, and What's New suppression;
+ * dedicated real-browser auto-start coverage lives in `e2e/onboarding-auto-start.spec.ts` (#141),
+ * which imports the plain `@playwright/test` `test` instead of this fixture so it is not
+ * suppressed away.
  */
 export async function suppressFirstRunOverlays(page: Page) {
 	await page.addInitScript((guideIds: string[]) => {

--- a/e2e/onboarding-auto-start.spec.ts
+++ b/e2e/onboarding-auto-start.spec.ts
@@ -1,0 +1,65 @@
+import { expect, type Page, test } from "@playwright/test";
+import { createModel, dismissWhatsNew } from "./fixtures";
+
+// The shared fixture suppresses both guides for deterministic workflow specs. These tests use
+// plain Playwright contexts and seed only what each first-run contract requires.
+const CURRENT_VERSION = "1.0.0";
+
+async function readOnboardingState(page: Page): Promise<unknown> {
+	return page.evaluate<unknown>(() => {
+		const raw = localStorage.getItem("threatforge-onboarding");
+		return raw === null ? null : JSON.parse(raw);
+	});
+}
+
+test.describe("Onboarding guide auto-start (real browser, #141)", () => {
+	test("welcome guide auto-starts when eligible under StrictMode and can be dismissed", async ({
+		page,
+	}) => {
+		// Suppressing What's New makes welcome eligible; onboarding itself stays unseeded.
+		await page.addInitScript((version: string) => {
+			localStorage.setItem("threatforge-last-seen-version", version);
+		}, CURRENT_VERSION);
+
+		await page.goto("/app");
+
+		expect(await page.evaluate(() => localStorage.getItem("threatforge-onboarding"))).toBeNull();
+
+		// This fails against the pre-#142 ref guard, whose timer never survived StrictMode replay.
+		const tooltip = page.getByTestId("guide-tooltip");
+		await expect(tooltip).toBeVisible();
+		await expect(tooltip).toHaveAttribute("aria-label", "The Canvas");
+
+		await tooltip.getByRole("button", { name: "Skip" }).click();
+
+		await expect(tooltip).toBeHidden();
+		expect(await readOnboardingState(page)).toEqual(
+			expect.objectContaining({
+				dismissedGuideIds: expect.arrayContaining(["welcome"]),
+			}),
+		);
+	});
+
+	test("dfd-basics guide auto-starts after the first model is created and can be dismissed through its UI", async ({
+		page,
+	}) => {
+		await page.goto("/app");
+		await dismissWhatsNew(page);
+		await createModel(page);
+
+		const tooltip = page.getByTestId("guide-tooltip");
+		await expect(tooltip).toBeVisible();
+		await expect(tooltip).toHaveAttribute("aria-label", "Add a Component");
+		await expect(page.getByTestId("guide-overlay")).toBeVisible();
+
+		await tooltip.getByRole("button", { name: "Skip" }).click();
+
+		await expect(tooltip).toBeHidden();
+		await expect(page.getByTestId("guide-overlay")).toBeHidden();
+		expect(await readOnboardingState(page)).toEqual(
+			expect.objectContaining({
+				dismissedGuideIds: expect.arrayContaining(["dfd-basics"]),
+			}),
+		);
+	});
+});


### PR DESCRIPTION
Closes #141
Related: #198

## Summary

- add a dedicated unseeded Playwright spec for real-browser welcome and DFD onboarding auto-start
- prove the welcome timer survives the app's StrictMode replay when only What's New is marked seen
- prove first-model `dfd-basics` starts after dismissing the real What's New overlay
- dismiss both guides through rendered UI and verify their persisted onboarding state
- preserve shared-fixture suppression and update the E2E troubleshooting record to point at the dedicated coverage

## Verification

- `npm run ci:local`
- `npm run test:e2e` — 63 tests passed
- dedicated spec with `--repeat-each=10 --workers=1` — 20 tests passed
- regression discrimination: against the pre-#142 hook, welcome fails while DFD still passes; the fixed hook was restored byte-identical
- required remote CI passed, including E2E, macOS/Windows/Ubuntu builds, dependency review, and CodeQL

## Preflight

- PR reviewer: converged; no must-fix or should-fix findings
- slop auditor: converged; no must-fix or should-fix findings
- security auditor: not applicable; test/docs only, no trust-boundary change
- threat-model expert: not applicable; no `.thf`, STRIDE, or threat-quality change

## Owner validation

Deferred under the authorized autonomous run. The merged PR remains the validation record.

- confirm the isolated plain-Playwright contexts reflect the intended first-run contracts without weakening shared fixture determinism
- confirm real-browser UI dismissal and persisted dismissed ids are the right acceptance signal
- note that the welcome first step currently has no rendered `canvas-area` target before model creation; this pre-existing UX decision is explicitly split into #198 rather than hidden by this test