### PR TITLE
feat(ai): refresh curated model catalog

### DIFF
--- a/e2e/ai-tool-loop.spec.ts
+++ b/e2e/ai-tool-loop.spec.ts
@@ -21,7 +21,7 @@ function sse(frames: SseFrame[]): string {
 	return frames.map((f) => `event: ${f.event}\ndata: ${JSON.stringify(f.data)}\n\n`).join("");
 }
 
-const MODEL = "claude-sonnet-4-20250514";
+const MODEL = "claude-sonnet-5";
 
 /** One assistant turn that calls add_element for a "Cache" process. */
 function addElementResponse(): string {

--- a/src/components/panels/ai-chat-tab.test.tsx
+++ b/src/components/panels/ai-chat-tab.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { StreamConversationHandlers } from "@/lib/ai/protocol/client";
 import { flattenText } from "@/lib/ai/protocol/messages";
+import { DEFAULT_ANTHROPIC_MODEL } from "@/lib/ai-models";
 import { useAiTurnStore } from "@/stores/ai-turn-store";
 import { useChatStore } from "@/stores/chat-store";
 import { useDocumentRegistry } from "@/stores/document-registry";
@@ -67,7 +68,7 @@ beforeEach(() => {
 	setActiveStores(createDocumentStores());
 	useAiTurnStore.getState().resetTurn();
 	useSettingsStore.setState((state) => ({
-		settings: { ...state.settings, aiModelAnthropic: "claude-sonnet-4-20250514" },
+		settings: { ...state.settings, aiModelAnthropic: DEFAULT_ANTHROPIC_MODEL },
 	}));
 	useChatStore.setState({
 		sessions: [],

--- a/src/components/panels/ai-settings-content.test.tsx
+++ b/src/components/panels/ai-settings-content.test.tsx
@@ -1,0 +1,100 @@
+/** AI settings model picker and persisted legacy-selection behavior. */
+
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_ANTHROPIC_MODEL, DEFAULT_OPENAI_MODEL } from "@/lib/ai-models";
+import { useChatStore } from "@/stores/chat-store";
+import { useSettingsStore } from "@/stores/settings-store";
+import { DEFAULT_USER_SETTINGS } from "@/types/settings";
+import { AiSettingsContent } from "./ai-settings-content";
+
+vi.mock("@/lib/adapters/get-keychain-adapter", () => ({
+	getKeychainAdapter: () =>
+		Promise.resolve({
+			hasKey: async () => false,
+			setKey: async () => undefined,
+			deleteKey: async () => undefined,
+		}),
+}));
+
+function modelSelect(): HTMLSelectElement {
+	return screen.getByRole<HTMLSelectElement>("combobox", { name: "Model" });
+}
+
+function providerSelect(): HTMLSelectElement {
+	return screen.getByRole<HTMLSelectElement>("combobox", { name: "Provider" });
+}
+
+beforeEach(() => {
+	localStorage.clear();
+	useChatStore.setState({ provider: "anthropic" });
+	useSettingsStore.setState({ settings: { ...DEFAULT_USER_SETTINGS } });
+});
+
+describe("a current catalog model", () => {
+	it("renders selected, with its description, and no legacy warning", async () => {
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+
+		expect(modelSelect().value).toBe(DEFAULT_ANTHROPIC_MODEL);
+		expect(screen.getByText("Balanced speed and capability")).toBeInTheDocument();
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+	});
+});
+
+describe("a persisted legacy model id", () => {
+	beforeEach(() => {
+		useSettingsStore.setState((state) => ({
+			settings: { ...state.settings, aiModelAnthropic: "claude-sonnet-4-20250514" },
+		}));
+	});
+
+	it("shows the legacy id as the selected, visibly labeled option without rewriting settings", async () => {
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+
+		expect(modelSelect().value).toBe("claude-sonnet-4-20250514");
+		expect(screen.getByText(/claude-sonnet-4-20250514.*legacy/i)).toBeInTheDocument();
+		expect(screen.getByRole("alert")).toHaveTextContent(
+			/"claude-sonnet-4-20250514" is no longer offered/,
+		);
+		expect(useSettingsStore.getState().settings.aiModelAnthropic).toBe("claude-sonnet-4-20250514");
+	});
+
+	it("switches to the recommended default only when the user clicks the deliberate control", async () => {
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+
+		fireEvent.click(screen.getByRole("button", { name: /switch to .*recommended default/i }));
+
+		expect(useSettingsStore.getState().settings.aiModelAnthropic).toBe(DEFAULT_ANTHROPIC_MODEL);
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+	});
+
+	it("switches deliberately by picking any current model from the dropdown", async () => {
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+
+		fireEvent.change(modelSelect(), { target: { value: "claude-haiku-4-5-20251001" } });
+
+		expect(useSettingsStore.getState().settings.aiModelAnthropic).toBe("claude-haiku-4-5-20251001");
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+	});
+});
+
+describe("provider switching", () => {
+	it("shows the OpenAI catalog and default after switching providers", async () => {
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+
+		fireEvent.change(providerSelect(), { target: { value: "openai" } });
+
+		expect(useChatStore.getState().provider).toBe("openai");
+		expect(modelSelect().value).toBe(DEFAULT_OPENAI_MODEL);
+	});
+});

--- a/src/components/panels/ai-settings-content.tsx
+++ b/src/components/panels/ai-settings-content.tsx
@@ -1,7 +1,7 @@
-import { Eye, EyeOff, Loader2, Trash2 } from "lucide-react";
+import { AlertTriangle, Eye, EyeOff, Loader2, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { getKeychainAdapter } from "@/lib/adapters/get-keychain-adapter";
-import { getModelsForProvider } from "@/lib/ai-models";
+import { getDefaultModelId, getModelById, getModelsForProvider } from "@/lib/ai-models";
 import { isTauri } from "@/lib/platform";
 import { cn } from "@/lib/utils";
 import { type AiProvider, useChatStore } from "@/stores/chat-store";
@@ -36,6 +36,11 @@ export function AiSettingsContent() {
 	const models = getModelsForProvider(provider);
 	const selectedModelId =
 		provider === "anthropic" ? settings.aiModelAnthropic : settings.aiModelOpenai;
+	const selectedModel = models.find((m) => m.id === selectedModelId);
+	// Keep a persisted retired/unknown id visible until the user deliberately replaces it.
+	const isLegacyModel = selectedModelId !== "" && selectedModel === undefined;
+	const defaultModelId = getDefaultModelId(provider);
+	const defaultModelLabel = getModelById(defaultModelId)?.label ?? defaultModelId;
 
 	useEffect(() => {
 		async function checkStatus() {
@@ -107,6 +112,7 @@ export function AiSettingsContent() {
 			<div>
 				<span className="mb-1 block text-[10px] font-medium text-muted-foreground">Provider</span>
 				<select
+					aria-label="Provider"
 					value={provider}
 					onChange={(e) => setProvider(e.target.value as AiProvider)}
 					className="w-full rounded border border-border bg-background px-2 py-1.5 text-xs focus:border-primary focus:outline-none"
@@ -123,20 +129,43 @@ export function AiSettingsContent() {
 			<div>
 				<span className="mb-1 block text-[10px] font-medium text-muted-foreground">Model</span>
 				<select
+					aria-label="Model"
 					value={selectedModelId}
 					onChange={(e) => handleModelChange(e.target.value)}
 					className="w-full rounded border border-border bg-background px-2 py-1.5 text-xs focus:border-primary focus:outline-none"
 				>
+					{isLegacyModel && (
+						<option value={selectedModelId}>{selectedModelId} (legacy, unavailable)</option>
+					)}
 					{models.map((m) => (
 						<option key={m.id} value={m.id}>
 							{m.label}
 						</option>
 					))}
 				</select>
-				{models.find((m) => m.id === selectedModelId)?.description && (
-					<p className="mt-0.5 text-[10px] text-muted-foreground/70">
-						{models.find((m) => m.id === selectedModelId)?.description}
-					</p>
+				{selectedModel?.description && (
+					<p className="mt-0.5 text-[10px] text-muted-foreground/70">{selectedModel.description}</p>
+				)}
+				{isLegacyModel && (
+					<div
+						role="alert"
+						className="mt-1.5 flex items-start gap-1.5 rounded border border-amber-500/30 bg-amber-500/10 px-2 py-1.5 text-[10px] text-amber-600 dark:text-amber-400"
+					>
+						<AlertTriangle className="mt-0.5 h-3 w-3 flex-shrink-0" />
+						<div className="space-y-1">
+							<p>
+								"{selectedModelId}" is no longer offered for this provider. Tool use stays disabled
+								for it; pick a current model above to restore tool use.
+							</p>
+							<button
+								type="button"
+								onClick={() => handleModelChange(defaultModelId)}
+								className="font-medium underline underline-offset-2 hover:no-underline"
+							>
+								Switch to {defaultModelLabel} (recommended default)
+							</button>
+						</div>
+					</div>
 				)}
 			</div>
 

--- a/src/lib/ai-models.test.ts
+++ b/src/lib/ai-models.test.ts
@@ -1,0 +1,104 @@
+/** Curated picker and request-preflight model metadata (issue #195). */
+
+import { describe, expect, it } from "vitest";
+import {
+	AI_MODELS,
+	DEFAULT_ANTHROPIC_MODEL,
+	DEFAULT_OPENAI_MODEL,
+	getDefaultModelId,
+	getModelById,
+	getModelsForProvider,
+	resolveCapabilities,
+} from "./ai-models";
+
+describe("the curated catalog", () => {
+	it("has exactly the six current models, in order, with nothing retired", () => {
+		expect(AI_MODELS.map((m) => ({ id: m.id, provider: m.provider, label: m.label }))).toEqual([
+			{ id: "claude-opus-4-8", provider: "anthropic", label: "Claude Opus 4.8" },
+			{ id: "claude-sonnet-5", provider: "anthropic", label: "Claude Sonnet 5" },
+			{ id: "claude-haiku-4-5-20251001", provider: "anthropic", label: "Claude Haiku 4.5" },
+			{ id: "gpt-5.6-sol", provider: "openai", label: "GPT-5.6 Sol" },
+			{ id: "gpt-5.6-terra", provider: "openai", label: "GPT-5.6 Terra" },
+			{ id: "gpt-5.6-luna", provider: "openai", label: "GPT-5.6 Luna" },
+		]);
+	});
+
+	it("orders Anthropic models most capable to fastest", () => {
+		expect(getModelsForProvider("anthropic").map((m) => m.id)).toEqual([
+			"claude-opus-4-8",
+			"claude-sonnet-5",
+			"claude-haiku-4-5-20251001",
+		]);
+	});
+
+	it("orders OpenAI models flagship to cost-sensitive", () => {
+		expect(getModelsForProvider("openai").map((m) => m.id)).toEqual([
+			"gpt-5.6-sol",
+			"gpt-5.6-terra",
+			"gpt-5.6-luna",
+		]);
+	});
+
+	it("pins each model's documented context window", () => {
+		const windows = Object.fromEntries(AI_MODELS.map((m) => [m.id, m.capabilities.maxInputTokens]));
+		expect(windows).toEqual({
+			"claude-opus-4-8": 1_000_000,
+			"claude-sonnet-5": 1_000_000,
+			"claude-haiku-4-5-20251001": 200_000,
+			"gpt-5.6-sol": 1_050_000,
+			"gpt-5.6-terra": 1_050_000,
+			"gpt-5.6-luna": 1_050_000,
+		});
+	});
+
+	it("pins every model as tool-capable, parallel-tool-capable, and streaming", () => {
+		for (const model of AI_MODELS) {
+			expect(model.capabilities).toMatchObject({
+				toolCalling: true,
+				parallelToolCalls: true,
+				streaming: true,
+			});
+		}
+	});
+
+	it("defaults new and reset settings to Sonnet 5 and GPT-5.6 Sol", () => {
+		expect(DEFAULT_ANTHROPIC_MODEL).toBe("claude-sonnet-5");
+		expect(DEFAULT_OPENAI_MODEL).toBe("gpt-5.6-sol");
+		expect(getDefaultModelId("anthropic")).toBe(DEFAULT_ANTHROPIC_MODEL);
+		expect(getDefaultModelId("openai")).toBe(DEFAULT_OPENAI_MODEL);
+	});
+
+	it("excludes every retired model this catalog replaced", () => {
+		const ids = new Set(AI_MODELS.map((m) => m.id));
+		for (const retired of [
+			"claude-opus-4-20250514",
+			"claude-sonnet-4-20250514",
+			"claude-haiku-3-5-20241022",
+			"gpt-4o",
+			"gpt-4o-mini",
+		]) {
+			expect(ids.has(retired)).toBe(false);
+		}
+	});
+
+	it("looks a current model up by id and resolves its capabilities as known", () => {
+		const model = getModelById("claude-sonnet-5");
+		expect(model?.provider).toBe("anthropic");
+
+		const resolution = resolveCapabilities("anthropic", "claude-sonnet-5");
+		expect(resolution).toEqual({ known: true, capabilities: model?.capabilities });
+	});
+
+	it("resolves a retired id as unknown rather than reusing a current model's capabilities", () => {
+		expect(getModelById("claude-sonnet-4-20250514")).toBeUndefined();
+		expect(resolveCapabilities("anthropic", "claude-sonnet-4-20250514")).toEqual({
+			known: false,
+		});
+	});
+
+	it("resolves a model id under the wrong provider as unknown", () => {
+		// A GPT id submitted while the Anthropic provider is selected must not
+		// borrow OpenAI's capabilities.
+		expect(resolveCapabilities("anthropic", "gpt-5.6-sol")).toEqual({ known: false });
+	});
+});

--- a/src/lib/ai-models.ts
+++ b/src/lib/ai-models.ts
@@ -24,7 +24,7 @@ export interface ModelCapabilities {
 }
 
 export interface AiModelOption {
-	/** Model ID sent to the provider API (e.g., "claude-sonnet-4-20250514") */
+	/** Model ID sent to the provider API (e.g., "claude-sonnet-5") */
 	id: string;
 	/** Human-readable label for the dropdown */
 	label: string;
@@ -37,55 +37,91 @@ export interface AiModelOption {
 }
 
 /**
- * Every curated model streams and calls tools today; the differences are the
- * context window and, for the smaller models, no published guarantee of parallel
- * tool calls. Windows follow each provider's documented input limits.
+ * Every curated model streams, calls tools, and supports parallel tool calls
+ * today, so only the context window differs between them.
+ *
+ * Anthropic's Messages API documents the context window as the whole
+ * conversation budget — input plus the model's own response — matching how
+ * `maxInputTokens` is spent in `budgetMessages` (input is budgeted against it,
+ * then `reserveOutputTokens` is held back from the same figure). Opus 4.8 and
+ * Sonnet 5 publish a 1M-token window; Haiku 4.5 publishes 200k. Tool use
+ * (including `tool_choice` and parallel tool calls) and streaming are
+ * undifferentiated Messages API features with no per-model carve-out for any
+ * of the three.
+ *
+ * Evidence, retrieved 2026-07-24 while implementing issue #195:
+ * - Models overview (IDs, context windows, descriptions):
+ *   https://platform.claude.com/docs/en/about-claude/models/overview
+ * - Context-window behavior (1M is the default and needs no beta header):
+ *   https://platform.claude.com/docs/en/build-with-claude/context-windows
+ * - Tool use / parallel tool calls (`tool_choice` modes and
+ *   `disable_parallel_tool_use` apply the same way across Opus 4.8, Sonnet 5,
+ *   and Haiku 4.5, with no exclusion for any of them):
+ *   https://platform.claude.com/docs/en/agents-and-tools/tool-use/overview
+ *   https://platform.claude.com/docs/en/agents-and-tools/tool-use/parallel-tool-use
  */
-const ANTHROPIC_CONTEXT_WINDOW = 200_000;
-const OPENAI_CONTEXT_WINDOW = 128_000;
+const ANTHROPIC_OPUS_SONNET_CONTEXT_WINDOW = 1_000_000;
+const ANTHROPIC_HAIKU_CONTEXT_WINDOW = 200_000;
+
+/**
+ * GPT-5.6 Sol, Terra, and Luna each publish the same 1,050,000-token context
+ * window and 128,000-token max output, and each model page lists "Streaming:
+ * Supported" and "Function calling: Supported" with no per-model exception.
+ * OpenAI's function-calling guide documents parallel tool calls as the default
+ * for any function-calling model (`parallel_tool_calls` defaults to true and
+ * disables the behavior when set to false); the one documented exception is an
+ * older `gpt-4.1-nano` snapshot, not any GPT-5.6 model.
+ *
+ * Evidence, retrieved 2026-07-24 while implementing issue #195:
+ * https://developers.openai.com/api/docs/models/gpt-5.6-sol
+ * https://developers.openai.com/api/docs/models/gpt-5.6-terra
+ * https://developers.openai.com/api/docs/models/gpt-5.6-luna
+ * https://developers.openai.com/api/docs/guides/function-calling
+ */
+const OPENAI_CONTEXT_WINDOW = 1_050_000;
 
 export const AI_MODELS: AiModelOption[] = [
 	{
-		id: "claude-opus-4-20250514",
-		label: "Claude Opus 4",
+		id: "claude-opus-4-8",
+		label: "Claude Opus 4.8",
 		provider: "anthropic",
-		description: "Most capable, best for complex analysis",
+		description: "Most capable, best for complex agentic work",
 		capabilities: {
 			toolCalling: true,
 			parallelToolCalls: true,
 			streaming: true,
-			maxInputTokens: ANTHROPIC_CONTEXT_WINDOW,
+			maxInputTokens: ANTHROPIC_OPUS_SONNET_CONTEXT_WINDOW,
 		},
 	},
 	{
-		id: "claude-sonnet-4-20250514",
-		label: "Claude Sonnet 4",
+		id: "claude-sonnet-5",
+		label: "Claude Sonnet 5",
 		provider: "anthropic",
 		description: "Balanced speed and capability",
 		capabilities: {
 			toolCalling: true,
 			parallelToolCalls: true,
 			streaming: true,
-			maxInputTokens: ANTHROPIC_CONTEXT_WINDOW,
+			maxInputTokens: ANTHROPIC_OPUS_SONNET_CONTEXT_WINDOW,
 		},
 	},
 	{
-		id: "claude-haiku-3-5-20241022",
-		label: "Claude 3.5 Haiku",
+		id: "claude-haiku-4-5-20251001",
+		label: "Claude Haiku 4.5",
 		provider: "anthropic",
-		description: "Fastest, good for quick tasks",
+		description: "Fastest, near-frontier intelligence for quick tasks",
 		capabilities: {
 			toolCalling: true,
 			parallelToolCalls: true,
 			streaming: true,
-			maxInputTokens: ANTHROPIC_CONTEXT_WINDOW,
+			maxInputTokens: ANTHROPIC_HAIKU_CONTEXT_WINDOW,
 		},
 	},
 	{
-		id: "gpt-4o",
-		label: "GPT-4o",
+		id: "gpt-5.6-sol",
+		label: "GPT-5.6 Sol",
 		provider: "openai",
-		description: "Most capable OpenAI model",
+		description: "Frontier model for complex professional work",
 		capabilities: {
 			toolCalling: true,
 			parallelToolCalls: true,
@@ -94,10 +130,22 @@ export const AI_MODELS: AiModelOption[] = [
 		},
 	},
 	{
-		id: "gpt-4o-mini",
-		label: "GPT-4o Mini",
+		id: "gpt-5.6-terra",
+		label: "GPT-5.6 Terra",
 		provider: "openai",
-		description: "Fast and affordable",
+		description: "Balances intelligence and cost",
+		capabilities: {
+			toolCalling: true,
+			parallelToolCalls: true,
+			streaming: true,
+			maxInputTokens: OPENAI_CONTEXT_WINDOW,
+		},
+	},
+	{
+		id: "gpt-5.6-luna",
+		label: "GPT-5.6 Luna",
+		provider: "openai",
+		description: "Optimized for cost-sensitive, high-volume workloads",
 		capabilities: {
 			toolCalling: true,
 			parallelToolCalls: true,
@@ -107,8 +155,12 @@ export const AI_MODELS: AiModelOption[] = [
 	},
 ];
 
-export const DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-20250514";
-export const DEFAULT_OPENAI_MODEL = "gpt-4o";
+/**
+ * Defaults for new and reset settings (owner-selected, issue #195). Defined
+ * once here and reused by `DEFAULT_USER_SETTINGS` so the two never drift.
+ */
+export const DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-5";
+export const DEFAULT_OPENAI_MODEL = "gpt-5.6-sol";
 
 /** Get models available for a specific provider. */
 export function getModelsForProvider(provider: AiProvider): AiModelOption[] {

--- a/src/lib/ai/protocol/client.test.ts
+++ b/src/lib/ai/protocol/client.test.ts
@@ -18,6 +18,7 @@ import type {
 	TransportCallbacks,
 } from "@/lib/adapters/chat-adapter";
 import { TauriChatTransport } from "@/lib/adapters/tauri-chat-adapter";
+import { DEFAULT_ANTHROPIC_MODEL } from "@/lib/ai-models";
 import { type ConversationRequest, streamConversation } from "./client";
 import { ProtocolException } from "./errors";
 import type { StreamEvent } from "./events";
@@ -53,7 +54,7 @@ const relay = vi.hoisted(() => {
 vi.mock("@tauri-apps/api/core", () => ({ invoke: relay.invoke }));
 vi.mock("@tauri-apps/api/event", () => ({ listen: relay.listen }));
 
-const KNOWN_MODEL = "claude-sonnet-4-20250514";
+const KNOWN_MODEL = DEFAULT_ANTHROPIC_MODEL;
 
 const userTurn: ProtocolMessage[] = [{ role: "user", content: [{ type: "text", text: "hi" }] }];
 

--- a/src/lib/ai/protocol/contract.test.ts
+++ b/src/lib/ai/protocol/contract.test.ts
@@ -65,6 +65,7 @@ import {
 	OPENAI_TOOL_STREAM,
 	OPENAI_TRUNCATED_STREAM,
 } from "@/lib/ai/providers/test-fixtures/openai-fixtures";
+import { AI_MODELS, DEFAULT_ANTHROPIC_MODEL, DEFAULT_OPENAI_MODEL } from "@/lib/ai-models";
 import { type ConversationRequest, streamConversation } from "./client";
 import {
 	createRetryingTransport,
@@ -106,8 +107,8 @@ vi.mock("@tauri-apps/api/core", () => ({ invoke: relay.invoke }));
 vi.mock("@tauri-apps/api/event", () => ({ listen: relay.listen }));
 
 const KNOWN_MODEL: Record<AiProvider, string> = {
-	anthropic: "claude-sonnet-4-20250514",
-	openai: "gpt-4o",
+	anthropic: DEFAULT_ANTHROPIC_MODEL,
+	openai: DEFAULT_OPENAI_MODEL,
 };
 
 const ANTHROPIC_KEY = "sk-ant-contract-test-key";
@@ -256,6 +257,57 @@ describe("provider and transport neutrality", () => {
 		expect(await runTauri("anthropic", ANTHROPIC_UNKNOWN_EVENT_STREAM)).toEqual(
 			EXPECTED_UNKNOWN_EVENT_EVENTS,
 		);
+	});
+});
+
+/**
+ * Every catalog id reaches the wire unchanged, on both platforms.
+ *
+ * `buildAnthropicRequestBody`/`buildOpenAiRequestBody` copy `modelId` onto the
+ * wire `model` field (issue #61 step 6), and neither transport inspects that
+ * field before sending it — the browser transport `JSON.stringify`s
+ * `request.body` straight into `fetch`, and the desktop transport hands it to
+ * `start_ai_stream` for the Rust relay to forward untouched. Driving the real
+ * client and both real transports (fixtures only, no network) is what proves
+ * that composed chain for the six ids ThreatForge actually offers, rather than
+ * re-asserting the builders' one-line copy in isolation.
+ */
+describe("catalog model ids reach the wire unchanged on both transports", () => {
+	it.each(AI_MODELS)("sends $provider model $id verbatim", async (model) => {
+		const textStream = model.provider === "anthropic" ? ANTHROPIC_TEXT_STREAM : OPENAI_TEXT_STREAM;
+		const conversationRequest: ConversationRequest = {
+			provider: model.provider,
+			modelId: model.id,
+			system: "system prompt",
+			messages: userTurn,
+			tools: [],
+			maxOutputTokens: 1024,
+		};
+
+		vi.mocked(fetch).mockResolvedValue(fakeStream(textStream));
+		await streamConversation(conversationRequest, new BrowserChatTransport(), {
+			onEvent: () => undefined,
+		});
+		const browserCall = vi.mocked(fetch).mock.calls[0];
+		if (!browserCall) throw new Error("expected the browser transport to call fetch");
+		const browserBody = browserCall[1]?.body;
+		if (typeof browserBody !== "string") throw new Error("expected a JSON browser request body");
+		const parsedBrowserBody: unknown = JSON.parse(browserBody);
+		expect(parsedBrowserBody).toMatchObject({ model: model.id });
+
+		const open = streamConversation(conversationRequest, new TauriChatTransport(), {
+			onEvent: () => undefined,
+		});
+		const streamId = await nthStreamId(1);
+		replayTauriFrames(relay, streamId, textStream);
+		await open;
+		const startCall = relay.invoke.mock.calls.find((call) => call[0] === "start_ai_stream");
+		if (!startCall) throw new Error("expected the desktop transport to invoke start_ai_stream");
+		const desktopArgs = startCall[1];
+		if (typeof desktopArgs !== "object" || desktopArgs === null || !("body" in desktopArgs)) {
+			throw new Error("expected a desktop request body");
+		}
+		expect(desktopArgs.body).toMatchObject({ model: model.id });
 	});
 });
 

--- a/src/lib/ai/protocol/request.test.ts
+++ b/src/lib/ai/protocol/request.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { CapabilityResolution } from "@/lib/ai-models";
+import { type CapabilityResolution, DEFAULT_ANTHROPIC_MODEL } from "@/lib/ai-models";
 import { ProtocolException } from "./errors";
 import { type CapabilityResolver, preflightRequest } from "./request";
 import type { ToolDescriptor } from "./tools";
@@ -7,7 +7,7 @@ import type { ToolDescriptor } from "./tools";
 const oneTool: ToolDescriptor[] = [{ name: "add_element", description: "Add an element." }];
 
 /** A curated, tool-capable Anthropic model id. */
-const KNOWN_MODEL = "claude-sonnet-4-20250514";
+const KNOWN_MODEL = DEFAULT_ANTHROPIC_MODEL;
 
 describe("preflightRequest", () => {
 	afterEach(() => {

--- a/src/stores/ai-turn-store.test.ts
+++ b/src/stores/ai-turn-store.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { StreamConversationHandlers } from "@/lib/ai/protocol/client";
 import type { StreamEvent } from "@/lib/ai/protocol/events";
+import { DEFAULT_ANTHROPIC_MODEL } from "@/lib/ai-models";
 import { useHistoryStore } from "@/stores/history-store";
 import { useModelStore } from "@/stores/model-store";
 import { useSettingsStore } from "@/stores/settings-store";
@@ -76,7 +77,7 @@ beforeEach(() => {
 	useHistoryStore.getState().clear();
 	useChatStore.setState({ provider: "anthropic" });
 	useSettingsStore.setState((state) => ({
-		settings: { ...state.settings, aiModelAnthropic: "claude-sonnet-4-20250514" },
+		settings: { ...state.settings, aiModelAnthropic: DEFAULT_ANTHROPIC_MODEL },
 	}));
 });
 

--- a/src/types/settings.test.ts
+++ b/src/types/settings.test.ts
@@ -1,0 +1,14 @@
+/** Keep persisted settings defaults aligned with the curated model catalog. */
+
+import { describe, expect, it } from "vitest";
+import { DEFAULT_ANTHROPIC_MODEL, DEFAULT_OPENAI_MODEL } from "@/lib/ai-models";
+import { DEFAULT_USER_SETTINGS } from "./settings";
+
+describe("DEFAULT_USER_SETTINGS AI model defaults", () => {
+	it("matches both catalog defaults", () => {
+		expect(DEFAULT_USER_SETTINGS).toMatchObject({
+			aiModelAnthropic: DEFAULT_ANTHROPIC_MODEL,
+			aiModelOpenai: DEFAULT_OPENAI_MODEL,
+		});
+	});
+});

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -5,6 +5,8 @@
  * File settings are stored alongside the threat model.
  */
 
+import { DEFAULT_ANTHROPIC_MODEL, DEFAULT_OPENAI_MODEL } from "@/lib/ai-models";
+
 /** Font size preference for the application UI */
 export type FontSize = "small" | "default" | "large";
 
@@ -67,8 +69,8 @@ export const DEFAULT_USER_SETTINGS: UserSettings = {
 	authorName: "",
 	authorEmail: "",
 	fontSize: "default",
-	aiModelAnthropic: "claude-sonnet-4-20250514",
-	aiModelOpenai: "gpt-4o",
+	aiModelAnthropic: DEFAULT_ANTHROPIC_MODEL,
+	aiModelOpenai: DEFAULT_OPENAI_MODEL,
 };
 
 /** Mapping from font size preference to CSS font-size value on <html> */


### PR DESCRIPTION
Closes #195
Related: #201

## Summary

- replace the retired Claude/GPT picker entries with Claude Opus 4.8, Sonnet 5, Haiku 4.5 and GPT-5.6 Sol, Terra, Luna
- default new/reset settings to Sonnet 5 and Sol from one shared source
- pin officially documented context windows and tool/parallel/streaming capability metadata
- preserve persisted retired/unknown IDs without silently rewriting them; label them unavailable, keep tools fail-closed, and offer a deliberate switch to a current default
- prove all six selected IDs reach browser and Tauri provider request bodies unchanged

## Provider evidence

- Anthropic IDs/windows: <https://platform.claude.com/docs/en/about-claude/models/overview>
- Anthropic 1M default/no beta header: <https://platform.claude.com/docs/en/build-with-claude/context-windows>
- Anthropic parallel tools: <https://platform.claude.com/docs/en/agents-and-tools/tool-use/parallel-tool-use>
- OpenAI model pages: <https://developers.openai.com/api/docs/models/gpt-5.6-sol>, <https://developers.openai.com/api/docs/models/gpt-5.6-terra>, <https://developers.openai.com/api/docs/models/gpt-5.6-luna>
- OpenAI parallel function calls: <https://developers.openai.com/api/docs/guides/function-calling>

## Verification

- `npm run ci:local`
- targeted model/settings/protocol suites — 118 tests passed
- `npx playwright test e2e/ai-tool-loop.spec.ts --workers=1` — 4 tests passed
- live official pages rechecked for exact IDs, 1M/200k and 1.05M windows, Chat Completions, streaming, function calling, and parallel-tool behavior
- required remote CI passed, including E2E, macOS/Windows/Ubuntu builds, dependency review, and CodeQL

## Preflight

- PR reviewer: converged; no must-fix or should-fix findings
- slop auditor: converged; no must-fix or should-fix findings
- security auditor: converged; no must-fix or should-fix findings, key/endpoints/CSP/IPC unchanged
- threat-model expert: not applicable; no `.thf`, STRIDE, or threat-quality change

## Owner validation

Deferred under the authorized autonomous run. The merged PR remains the validation record.

- inspect the provider ordering, descriptions, Sonnet/Sol defaults, and explicit legacy-model warning/switch flow
- confirm retaining a retired non-empty ID until deliberate user action is preferable to silently migrating it
- no live provider request was made; deterministic request-body contracts and current official docs are the verification evidence
- note that near-max 1M-context requests expose a separate desktop byte-cap assumption; that cross-boundary work is explicitly tracked in #201 rather than hidden in this catalog change