### PR TITLE
fix: suppress overlapping handle pointer-events by drag origin type

### DIFF
--- a/e2e/canvas-connections.spec.ts
+++ b/e2e/canvas-connections.spec.ts
@@ -1,0 +1,311 @@
+import { addPaletteItem, createModel, expect, test } from "./fixtures";
+
+/**
+ * Regression coverage for #213: every DFD connection point renders an overlapping
+ * source/target handle pair at identical coordinates. Whichever one paints on top wins the
+ * browser's `elementFromPoint` hit test at that pixel — for both directions, since both
+ * points use the same DOM order — so a real pointer drag that starts on one node's source
+ * handle and releases over another node's target handle at the same corner/cardinal
+ * position never resolves to the target underneath and no edge is created.
+ *
+ * Covers both cross-node connection directions, a same-node self-loop (which drops onto a
+ * different overlapping point but hits the identical collision), and re-targeting each side
+ * of an existing edge's reconnect anchors (target and source) onto an overlapping handle.
+ * Every connection point renders `target` before `source` in the DOM, so `source` always
+ * paints on top by default: the source-suppression branch (exercised by tests 1-4) is what
+ * makes a source→target drop resolve correctly and is directly proven by connection
+ * success. The target-suppression branch only matters for a drag that starts from a
+ * `target`-typed origin — reachable only via the source-side reconnect anchor (test 5) —
+ * and dropping onto the resulting source handle would already succeed from DOM order alone,
+ * so that test also asserts the suppression's CSS effect directly via `getComputedStyle`
+ * mid-drag rather than relying on connection outcome as its oracle.
+ *
+ * These tests perform a real mouse drag (move → down → move → up) between two separated
+ * nodes' handles, located by their `data-nodeid`/`data-handleid` attributes — no synthetic
+ * DOM dispatch, no direct Zustand store writes, no mocked callbacks.
+ */
+test.describe("Canvas pointer connections", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto("/app");
+		await createModel(page);
+	});
+
+	/**
+	 * Adds two nodes and drags the second clear of the first so they no longer overlap.
+	 *
+	 * Separates the nodes on a *purely horizontal* axis, away from the bottom-right corner.
+	 * A diagonal separation risks landing the destination node's handle under the MiniMap
+	 * panel, which sits above the canvas in paint order: `elementFromPoint` at the drop
+	 * point would then hit the MiniMap instead of a handle, and ReactFlow silently falls
+	 * back to its distance-based closest-handle match — which already prefers the opposite
+	 * handle type — masking the exact hit-testing collision (#213) this test exists to
+	 * catch.
+	 */
+	async function createSeparatedNodes(page: import("@playwright/test").Page) {
+		await addPaletteItem(page, "palette-item-web-server");
+		await addPaletteItem(page, "palette-item-sql-database");
+
+		const nodes = page.locator("[data-testid^='node-']");
+		const firstNode = nodes.first();
+		const secondNode = nodes.nth(1);
+
+		// Both palette double-clicks drop their node at the canvas center, so the two nodes
+		// land stacked on top of each other. Drag the second one clear of the first via
+		// ReactFlow's own node-drag gesture (mirrors canvas-handles.spec.ts) so the two
+		// nodes have distinct, non-overlapping handle positions for the connection gesture.
+		const secondBoxBefore = await secondNode.boundingBox();
+		if (!secondBoxBefore) throw new Error("second node has no bounding box");
+		await page.mouse.move(
+			secondBoxBefore.x + secondBoxBefore.width / 2,
+			secondBoxBefore.y + secondBoxBefore.height / 2,
+		);
+		await page.mouse.down();
+		await page.mouse.move(secondBoxBefore.x + 450, secondBoxBefore.y, { steps: 10 });
+		await page.mouse.up();
+
+		const secondBoxAfter = await secondNode.boundingBox();
+		if (!secondBoxAfter) throw new Error("second node has no bounding box after drag");
+		expect(secondBoxAfter.x).toBeGreaterThan(secondBoxBefore.x + 150);
+
+		// Sanity-check the two handles this test exercises are clear of the MiniMap panel,
+		// so the gesture below genuinely exercises direct hit-testing rather than the
+		// distance-based fallback.
+		const minimapBox = await page.locator(".react-flow__minimap").boundingBox();
+		const firstId = (await firstNode.getAttribute("data-testid"))?.replace(/^node-/, "");
+		const secondId = (await secondNode.getAttribute("data-testid"))?.replace(/^node-/, "");
+		if (!firstId || !secondId) throw new Error("node ids not found");
+		if (minimapBox) {
+			for (const [nodeId, handleId] of [
+				[firstId, "right-target"],
+				[secondId, "left-target"],
+			] as const) {
+				const box = await page
+					.locator(`[data-nodeid="${nodeId}"][data-handleid="${handleId}"]`)
+					.boundingBox();
+				if (!box) throw new Error(`${handleId} has no bounding box`);
+				const overlapsMinimap =
+					box.x < minimapBox.x + minimapBox.width &&
+					box.x + box.width > minimapBox.x &&
+					box.y < minimapBox.y + minimapBox.height &&
+					box.y + box.height > minimapBox.y;
+				expect(overlapsMinimap).toBe(false);
+			}
+		}
+
+		return { firstId, secondId };
+	}
+
+	/** Drags from one handle's center to another's via real, stepped pointer movement. */
+	async function dragHandleToHandle(
+		page: import("@playwright/test").Page,
+		fromHandle: import("@playwright/test").Locator,
+		toHandle: import("@playwright/test").Locator,
+	) {
+		const fromBox = await fromHandle.boundingBox();
+		const toBox = await toHandle.boundingBox();
+		if (!fromBox || !toBox) throw new Error("handle has no bounding box");
+
+		await page.mouse.move(fromBox.x + fromBox.width / 2, fromBox.y + fromBox.height / 2);
+		await page.mouse.down();
+		await page.mouse.move(toBox.x + toBox.width / 2, toBox.y + toBox.height / 2, { steps: 10 });
+		await page.mouse.up();
+	}
+
+	test("dragging from a source handle to an overlapping target handle creates exactly one edge", async ({
+		page,
+	}) => {
+		const { firstId, secondId } = await createSeparatedNodes(page);
+
+		// First node is on the left, second is on the right — first's right-source handle
+		// faces second's left-target handle, matching the issue's reproduction steps exactly.
+		const fromHandle = page.locator(
+			`[data-nodeid="${firstId}"][data-handleid="right-source"]`,
+		);
+		const toHandle = page.locator(`[data-nodeid="${secondId}"][data-handleid="left-target"]`);
+
+		await dragHandleToHandle(page, fromHandle, toHandle);
+
+		await expect(page.locator(".react-flow__edge")).toHaveCount(1);
+		await expect(page.getByLabel(`Edge from ${firstId} to ${secondId}`)).toBeVisible();
+	});
+
+	test("dragging the reverse direction from the other node's source handle also creates exactly one edge", async ({
+		page,
+	}) => {
+		const { firstId, secondId } = await createSeparatedNodes(page);
+
+		// Reverse direction, using the same two overlapping connection points: starting the
+		// drag from the second node's (left) source handle and releasing over the first
+		// node's (right) target handle. Both directions must remain available at every point.
+		const fromHandle = page.locator(
+			`[data-nodeid="${secondId}"][data-handleid="left-source"]`,
+		);
+		const toHandle = page.locator(`[data-nodeid="${firstId}"][data-handleid="right-target"]`);
+
+		await dragHandleToHandle(page, fromHandle, toHandle);
+
+		await expect(page.locator(".react-flow__edge")).toHaveCount(1);
+		await expect(page.getByLabel(`Edge from ${secondId} to ${firstId}`)).toBeVisible();
+	});
+
+	test("dragging from a node's own source handle to another overlapping target handle on itself creates a self-loop edge", async ({
+		page,
+	}) => {
+		await addPaletteItem(page, "palette-item-web-server");
+		const node = page.locator("[data-testid^='node-']").first();
+		const nodeId = (await node.getAttribute("data-testid"))?.replace(/^node-/, "");
+		if (!nodeId) throw new Error("node id not found");
+
+		// Self-loops connect two different cardinal points on the same node
+		// (canvas-utils.ts's default self-loop pair is right-source -> top-target), so the
+		// drop point still lands on the top point's own overlapping target/source pair —
+		// the same hit-testing collision (#213) as the cross-node case above.
+		const fromHandle = page.locator(`[data-nodeid="${nodeId}"][data-handleid="right-source"]`);
+		const toHandle = page.locator(`[data-nodeid="${nodeId}"][data-handleid="top-target"]`);
+
+		await dragHandleToHandle(page, fromHandle, toHandle);
+
+		await expect(page.locator(".react-flow__edge")).toHaveCount(1);
+		await expect(page.getByLabel(`Edge from ${nodeId} to ${nodeId}`)).toBeVisible();
+	});
+
+	test("dragging an existing edge's target reconnect anchor onto an overlapping target handle re-targets it without duplicating the edge", async ({
+		page,
+	}) => {
+		const { firstId, secondId } = await createSeparatedNodes(page);
+
+		const fromHandle = page.locator(
+			`[data-nodeid="${firstId}"][data-handleid="right-source"]`,
+		);
+		const initialTarget = page.locator(
+			`[data-nodeid="${secondId}"][data-handleid="left-target"]`,
+		);
+		await dragHandleToHandle(page, fromHandle, initialTarget);
+		await expect(page.locator(".react-flow__edge")).toHaveCount(1);
+
+		// ReactFlow renders a small circular reconnect anchor
+		// (`.react-flow__edgeupdater-target`) at the edge's current target endpoint; dragging
+		// it to a different handle re-targets the edge in place. The new drop point
+		// (top-left-target) is itself an overlapping target/source pair on the second node,
+		// staying clear of the always-present right panel (unlike the node's other corner/side
+		// handles further right), so this exercises the same suppression logic mid-reconnect,
+		// not just on initial connect. Dragging this anchor reports `connectingHandleType ===
+		// "source"` (the type of the anchor's fixed opposite end) — see the sibling test below
+		// for the complementary "target" branch, exercised by the source-side anchor.
+		const reconnectAnchor = page.locator(".react-flow__edgeupdater-target");
+		const newTarget = page.locator(
+			`[data-nodeid="${secondId}"][data-handleid="top-left-target"]`,
+		);
+		await dragHandleToHandle(page, reconnectAnchor, newTarget);
+
+		// Reconnecting must retarget the existing edge, never add a second one.
+		await expect(page.locator(".react-flow__edge")).toHaveCount(1);
+		await expect(page.getByLabel(`Edge from ${firstId} to ${secondId}`)).toBeVisible();
+
+		// Verify the persisted model actually recorded the new handle (not just that some
+		// edge still renders) by round-tripping through a real save.
+		const downloadPromise = page.waitForEvent("download");
+		await page.getByTestId("btn-save").click();
+		const download = await downloadPromise;
+		const readable = await download.createReadStream();
+		const chunks: Buffer[] = [];
+		for await (const chunk of readable) {
+			chunks.push(chunk as Buffer);
+		}
+		const content = Buffer.concat(chunks).toString("utf-8");
+
+		expect(content).toContain("target_handle: top-left-target");
+		expect(content).not.toContain("target_handle: left-target");
+	});
+
+	test("dragging an existing edge's source reconnect anchor onto an overlapping source handle re-targets it without duplicating the edge", async ({
+		page,
+	}) => {
+		const { firstId, secondId } = await createSeparatedNodes(page);
+
+		const fromHandle = page.locator(
+			`[data-nodeid="${firstId}"][data-handleid="right-source"]`,
+		);
+		const initialTarget = page.locator(
+			`[data-nodeid="${secondId}"][data-handleid="left-target"]`,
+		);
+		await dragHandleToHandle(page, fromHandle, initialTarget);
+		await expect(page.locator(".react-flow__edge")).toHaveCount(1);
+
+		// The complementary reconnect anchor (`.react-flow__edgeupdater-source`) sits at the
+		// edge's current source endpoint. Dragging it reports `connectingHandleType ===
+		// "target"` (the type of its fixed opposite end) — the one branch of the pointer-events
+		// suppression the sibling test above cannot exercise. Note that source-type handles
+		// already paint on top of target-type ones in the DOM (see shared-handles.tsx render
+		// order), so — unlike the sibling test — a real drop here would still land on a source
+		// handle even without this suppression; the mid-drag `getComputedStyle` check below is
+		// what actually proves this branch's CSS effect, since connection success alone would
+		// not discriminate it. The new drop point (top-left-source, on the first node) is a
+		// different overlapping target/source pair than the edge's current source, staying
+		// clear of the minimap and right panel.
+		const reconnectAnchor = page.locator(".react-flow__edgeupdater-source");
+		const newSource = page.locator(
+			`[data-nodeid="${firstId}"][data-handleid="top-left-source"]`,
+		);
+		const anchorBox = await reconnectAnchor.boundingBox();
+		const newSourceBox = await newSource.boundingBox();
+		if (!anchorBox || !newSourceBox) throw new Error("handle has no bounding box");
+
+		await page.mouse.move(anchorBox.x + anchorBox.width / 2, anchorBox.y + anchorBox.height / 2);
+		await page.mouse.down();
+		// A small move past the library's 1px drag threshold is enough to fire
+		// `onReconnectStart` and update `connectingHandleType` before the class list is read.
+		await page.mouse.move(
+			anchorBox.x + anchorBox.width / 2 + 5,
+			anchorBox.y + anchorBox.height / 2 + 5,
+			{ steps: 2 },
+		);
+
+		// Prove the CSS suppression itself fires for this branch: the target half of the
+		// drop point's pair must be non-interactive mid-drag, while the source half (the type
+		// this drag can actually complete on) stays interactive.
+		const midDragStyles = await page.evaluate(
+			({ nodeId }) => {
+				const targetEl = document.querySelector(
+					`[data-nodeid="${nodeId}"][data-handleid="top-left-target"]`,
+				);
+				const sourceEl = document.querySelector(
+					`[data-nodeid="${nodeId}"][data-handleid="top-left-source"]`,
+				);
+				return {
+					targetPointerEvents: targetEl ? getComputedStyle(targetEl).pointerEvents : null,
+					sourcePointerEvents: sourceEl ? getComputedStyle(sourceEl).pointerEvents : null,
+				};
+			},
+			{ nodeId: firstId },
+		);
+		expect(midDragStyles.targetPointerEvents).toBe("none");
+		expect(midDragStyles.sourcePointerEvents).toBe("auto");
+
+		await page.mouse.move(
+			newSourceBox.x + newSourceBox.width / 2,
+			newSourceBox.y + newSourceBox.height / 2,
+			{ steps: 10 },
+		);
+		await page.mouse.up();
+
+		// Reconnecting must retarget the existing edge, never add a second one.
+		await expect(page.locator(".react-flow__edge")).toHaveCount(1);
+		await expect(page.getByLabel(`Edge from ${firstId} to ${secondId}`)).toBeVisible();
+
+		// Verify the persisted model actually recorded the new handle (not just that some
+		// edge still renders) by round-tripping through a real save.
+		const downloadPromise = page.waitForEvent("download");
+		await page.getByTestId("btn-save").click();
+		const download = await downloadPromise;
+		const readable = await download.createReadStream();
+		const chunks: Buffer[] = [];
+		for await (const chunk of readable) {
+			chunks.push(chunk as Buffer);
+		}
+		const content = Buffer.concat(chunks).toString("utf-8");
+
+		expect(content).toContain("source_handle: top-left-source");
+		expect(content).not.toContain("source_handle: right-source");
+	});
+});

--- a/src/components/canvas/dfd-canvas.tsx
+++ b/src/components/canvas/dfd-canvas.tsx
@@ -3,6 +3,7 @@ import {
 	BackgroundVariant,
 	type Connection,
 	Controls,
+	type HandleType,
 	MiniMap,
 	type OnConnectStart,
 	type OnNodeDrag,
@@ -171,11 +172,13 @@ export function DfdCanvas() {
 	const onConnectStart: OnConnectStart = useCallback((_event, params) => {
 		connectingNodeId.current = params.nodeId ?? null;
 		useCanvasInstanceStore.getState().setIsConnecting(true);
+		useCanvasInstanceStore.getState().setConnectingHandleType(params.handleType ?? null);
 	}, []);
 
 	const onConnectEnd = useCallback(() => {
 		connectingNodeId.current = null;
 		useCanvasInstanceStore.getState().setIsConnecting(false);
+		useCanvasInstanceStore.getState().setConnectingHandleType(null);
 	}, []);
 
 	const onReconnect = useCallback(
@@ -186,15 +189,17 @@ export function DfdCanvas() {
 	);
 
 	const onReconnectStart = useCallback(
-		(_event: React.MouseEvent, _edge: DfdEdge, _handleType: string) => {
+		(_event: React.MouseEvent, _edge: DfdEdge, handleType: HandleType) => {
 			useCanvasInstanceStore.getState().setIsConnecting(true);
+			useCanvasInstanceStore.getState().setConnectingHandleType(handleType);
 		},
 		[],
 	);
 
 	const onReconnectEnd = useCallback(
-		(_event: MouseEvent | TouchEvent, _edge: DfdEdge, _handleType: string) => {
+		(_event: MouseEvent | TouchEvent, _edge: DfdEdge, _handleType: HandleType) => {
 			useCanvasInstanceStore.getState().setIsConnecting(false);
+			useCanvasInstanceStore.getState().setConnectingHandleType(null);
 		},
 		[],
 	);

--- a/src/components/canvas/nodes/shared-handles.test.tsx
+++ b/src/components/canvas/nodes/shared-handles.test.tsx
@@ -37,7 +37,7 @@ function classTokens(id: string): string[] {
 }
 
 afterEach(() => {
-	useCanvasInstanceStore.setState({ isConnecting: false });
+	useCanvasInstanceStore.setState({ isConnecting: false, connectingHandleType: null });
 });
 
 describe("NodeHandles", () => {
@@ -101,6 +101,62 @@ describe("NodeHandles", () => {
 		]) {
 			expect(idleClasses).toContain(shared);
 			expect(connectingClasses).toContain(shared);
+		}
+	});
+
+	// #213: every connection point renders an overlapping target/source pair. While a drag is
+	// in progress, the handle sharing the drag-origin's type must stop receiving pointer
+	// events so the browser's `elementFromPoint` hit test resolves to the opposite-type
+	// handle underneath instead of whichever one happens to paint on top.
+	it("suppresses pointer events only on source handles while connecting from a source handle", () => {
+		render(<NodeHandles />);
+
+		act(() => {
+			useCanvasInstanceStore.setState({ isConnecting: true, connectingHandleType: "source" });
+		});
+
+		for (const id of HANDLE_IDS) {
+			const classes = classTokens(id);
+			if (id.endsWith("-source")) {
+				expect(classes).toContain("!pointer-events-none");
+				expect(classes).not.toContain("!pointer-events-auto");
+			} else {
+				expect(classes).toContain("!pointer-events-auto");
+				expect(classes).not.toContain("!pointer-events-none");
+			}
+		}
+	});
+
+	it("suppresses pointer events only on target handles while connecting from a target handle", () => {
+		render(<NodeHandles />);
+
+		act(() => {
+			useCanvasInstanceStore.setState({ isConnecting: true, connectingHandleType: "target" });
+		});
+
+		for (const id of HANDLE_IDS) {
+			const classes = classTokens(id);
+			if (id.endsWith("-target")) {
+				expect(classes).toContain("!pointer-events-none");
+				expect(classes).not.toContain("!pointer-events-auto");
+			} else {
+				expect(classes).toContain("!pointer-events-auto");
+				expect(classes).not.toContain("!pointer-events-none");
+			}
+		}
+	});
+
+	it("keeps every handle pointer-interactive when connecting without a known handle type", () => {
+		render(<NodeHandles />);
+
+		act(() => {
+			useCanvasInstanceStore.setState({ isConnecting: true, connectingHandleType: null });
+		});
+
+		for (const id of HANDLE_IDS) {
+			const classes = classTokens(id);
+			expect(classes).toContain("!pointer-events-auto");
+			expect(classes).not.toContain("!pointer-events-none");
 		}
 	});
 });

--- a/src/components/canvas/nodes/shared-handles.tsx
+++ b/src/components/canvas/nodes/shared-handles.tsx
@@ -2,15 +2,13 @@ import { Handle, Position } from "@xyflow/react";
 import { useCanvasInstanceStore } from "@/stores/canvas-instance-store";
 
 /**
- * Base handle style: small dot, smooth fade transition. Opacity is deliberately
- * excluded here — it is applied per-render below so the idle and connecting
- * states never emit conflicting same-specificity utilities on the same element.
- *
- * Pointer events remain enabled while the dot is transparent, so the handle
- * stays available as a connection target in its idle state.
+ * Base handle style: small dot, smooth fade transition. Pointer-events is deliberately
+ * excluded here alongside opacity — both are applied per-render below so idle/connecting
+ * and target/source states never emit conflicting same-specificity utilities on the same
+ * element (see the pointer-events note further down for why this matters for #213).
  */
 const HANDLE_STYLE =
-	"!w-1.5 !h-1.5 !border-none !bg-muted-foreground !pointer-events-auto transition-opacity duration-150";
+	"!w-1.5 !h-1.5 !border-none !bg-muted-foreground transition-opacity duration-150";
 
 /**
  * Idle visibility: hidden until the ancestor `.group` node wrapper is hovered.
@@ -27,6 +25,20 @@ const HANDLE_IDLE_CLASS = "opacity-0 group-hover:opacity-100";
  */
 const HANDLE_CONNECTING_CLASS = "opacity-100";
 
+/** Pointer events enabled — the normal state, so idle handles stay clickable. */
+const HANDLE_POINTER_AUTO = "!pointer-events-auto";
+
+/**
+ * Pointer events disabled for the duration of a same-type overlap suppression (#213): every
+ * connection point renders a target and a source handle at identical coordinates, and
+ * whichever one is later in the DOM always paints on top, winning the browser's
+ * `elementFromPoint` hit test regardless of which type the in-progress drag actually needs.
+ * Setting `pointer-events: none` on the handle sharing the dragged handle's type makes the
+ * browser skip it and resolve the opposite-type handle underneath instead, since strict
+ * connection mode can only ever complete a connection on the opposite type anyway.
+ */
+const HANDLE_POINTER_NONE = "!pointer-events-none";
+
 /**
  * Shared bidirectional handles for all DFD element nodes.
  * 8 connection points: 4 cardinal (top, bottom, left, right) + 4 corners.
@@ -38,75 +50,88 @@ const HANDLE_CONNECTING_CLASS = "opacity-100";
  */
 export function NodeHandles() {
 	const isConnecting = useCanvasInstanceStore((s) => s.isConnecting);
-	const cls = `${HANDLE_STYLE} ${isConnecting ? HANDLE_CONNECTING_CLASS : HANDLE_IDLE_CLASS}`;
+	const connectingHandleType = useCanvasInstanceStore((s) => s.connectingHandleType);
+	const visibilityCls = isConnecting ? HANDLE_CONNECTING_CLASS : HANDLE_IDLE_CLASS;
+
+	// While connecting, suppress pointer events only on the handle type matching the one the
+	// drag started from — the opposite type stays interactive so it wins the hit test at
+	// every overlapping point. Outside of a drag (or when the type is unknown) both stay
+	// interactive, preserving today's idle/hover behavior.
+	const targetPointerCls =
+		isConnecting && connectingHandleType === "target" ? HANDLE_POINTER_NONE : HANDLE_POINTER_AUTO;
+	const sourcePointerCls =
+		isConnecting && connectingHandleType === "source" ? HANDLE_POINTER_NONE : HANDLE_POINTER_AUTO;
+
+	const targetCls = `${HANDLE_STYLE} ${targetPointerCls} ${visibilityCls}`;
+	const sourceCls = `${HANDLE_STYLE} ${sourcePointerCls} ${visibilityCls}`;
 
 	return (
 		<>
 			{/* Cardinal handles */}
-			<Handle id="top-target" type="target" position={Position.Top} className={cls} />
-			<Handle id="top-source" type="source" position={Position.Top} className={cls} />
-			<Handle id="bottom-target" type="target" position={Position.Bottom} className={cls} />
-			<Handle id="bottom-source" type="source" position={Position.Bottom} className={cls} />
-			<Handle id="left-target" type="target" position={Position.Left} className={cls} />
-			<Handle id="left-source" type="source" position={Position.Left} className={cls} />
-			<Handle id="right-target" type="target" position={Position.Right} className={cls} />
-			<Handle id="right-source" type="source" position={Position.Right} className={cls} />
+			<Handle id="top-target" type="target" position={Position.Top} className={targetCls} />
+			<Handle id="top-source" type="source" position={Position.Top} className={sourceCls} />
+			<Handle id="bottom-target" type="target" position={Position.Bottom} className={targetCls} />
+			<Handle id="bottom-source" type="source" position={Position.Bottom} className={sourceCls} />
+			<Handle id="left-target" type="target" position={Position.Left} className={targetCls} />
+			<Handle id="left-source" type="source" position={Position.Left} className={sourceCls} />
+			<Handle id="right-target" type="target" position={Position.Right} className={targetCls} />
+			<Handle id="right-source" type="source" position={Position.Right} className={sourceCls} />
 
 			{/* Corner handles — positioned via style offset from their nearest side */}
 			<Handle
 				id="top-left-target"
 				type="target"
 				position={Position.Top}
-				className={cls}
+				className={targetCls}
 				style={{ left: "15%" }}
 			/>
 			<Handle
 				id="top-left-source"
 				type="source"
 				position={Position.Top}
-				className={cls}
+				className={sourceCls}
 				style={{ left: "15%" }}
 			/>
 			<Handle
 				id="top-right-target"
 				type="target"
 				position={Position.Top}
-				className={cls}
+				className={targetCls}
 				style={{ left: "85%" }}
 			/>
 			<Handle
 				id="top-right-source"
 				type="source"
 				position={Position.Top}
-				className={cls}
+				className={sourceCls}
 				style={{ left: "85%" }}
 			/>
 			<Handle
 				id="bottom-left-target"
 				type="target"
 				position={Position.Bottom}
-				className={cls}
+				className={targetCls}
 				style={{ left: "15%" }}
 			/>
 			<Handle
 				id="bottom-left-source"
 				type="source"
 				position={Position.Bottom}
-				className={cls}
+				className={sourceCls}
 				style={{ left: "15%" }}
 			/>
 			<Handle
 				id="bottom-right-target"
 				type="target"
 				position={Position.Bottom}
-				className={cls}
+				className={targetCls}
 				style={{ left: "85%" }}
 			/>
 			<Handle
 				id="bottom-right-source"
 				type="source"
 				position={Position.Bottom}
-				className={cls}
+				className={sourceCls}
 				style={{ left: "85%" }}
 			/>
 		</>

--- a/src/stores/canvas-instance-store.test.ts
+++ b/src/stores/canvas-instance-store.test.ts
@@ -13,6 +13,7 @@ describe("canvas-instance-store", () => {
 			draggedIcon: null,
 			draggedName: null,
 			isConnecting: false,
+			connectingHandleType: null,
 			altDragActive: false,
 		});
 	});
@@ -102,6 +103,19 @@ describe("canvas-instance-store", () => {
 
 			useCanvasInstanceStore.getState().setIsConnecting(false);
 			expect(useCanvasInstanceStore.getState().isConnecting).toBe(false);
+		});
+
+		it("tracks which handle type a connection drag started from, defaulting to null", () => {
+			expect(useCanvasInstanceStore.getState().connectingHandleType).toBeNull();
+
+			useCanvasInstanceStore.getState().setConnectingHandleType("source");
+			expect(useCanvasInstanceStore.getState().connectingHandleType).toBe("source");
+
+			useCanvasInstanceStore.getState().setConnectingHandleType("target");
+			expect(useCanvasInstanceStore.getState().connectingHandleType).toBe("target");
+
+			useCanvasInstanceStore.getState().setConnectingHandleType(null);
+			expect(useCanvasInstanceStore.getState().connectingHandleType).toBeNull();
 		});
 
 		it("tracks Alt+drag so the canvas store can hand history to the Alt+drag handler", () => {

--- a/src/stores/canvas-instance-store.ts
+++ b/src/stores/canvas-instance-store.ts
@@ -1,4 +1,4 @@
-import type { Viewport } from "@xyflow/react";
+import type { HandleType, Viewport } from "@xyflow/react";
 import { create } from "zustand";
 
 /**
@@ -49,6 +49,17 @@ interface CanvasInstanceState {
 	isConnecting: boolean;
 	setIsConnecting: (connecting: boolean) => void;
 
+	/**
+	 * The handle type (`source` or `target`) the in-progress connection/reconnect drag
+	 * started from, or `null` when idle. Every connection point renders an overlapping
+	 * source/target handle pair (#213); while a drag is active, `NodeHandles` uses this to
+	 * suppress pointer events on same-type siblings so the browser's hit test at the drop
+	 * point always resolves to the opposite-type handle underneath instead of whichever one
+	 * happens to paint on top.
+	 */
+	connectingHandleType: HandleType | null;
+	setConnectingHandleType: (handleType: HandleType | null) => void;
+
 	/** When true, the canvas store skips its drag-end history push — Alt+drag owns its own entry. */
 	altDragActive: boolean;
 	setAltDragActive: (active: boolean) => void;
@@ -90,6 +101,9 @@ export const useCanvasInstanceStore = create<CanvasInstanceState>((set) => ({
 
 	isConnecting: false,
 	setIsConnecting: (connecting) => set({ isConnecting: connecting }),
+
+	connectingHandleType: null,
+	setConnectingHandleType: (handleType) => set({ connectingHandleType: handleType }),
 
 	altDragActive: false,
 	setAltDragActive: (active) => set({ altDragActive: active }),


### PR DESCRIPTION
## Root cause

Every DFD connection point renders an overlapping `target`/`source` `<Handle>` pair at identical coordinates. `@xyflow/react`'s own CSS makes handles `pointer-events: none` by default, re-enabling them per-handle only when ReactFlow itself determines they're a valid connect/connecting target. `shared-handles.tsx` previously forced `!pointer-events-auto` unconditionally on **every** handle, defeating that validity-aware mechanism — so raw DOM paint order (not connection validity) decided which overlapping handle won the browser's `elementFromPoint` hit test. Since `target`-type handles render before `source`-type handles in JSX with no z-index override, `source` always paints on top by default stacking order, so a real drag from a source handle onto an overlapping target handle never resolved onto the target underneath, and no edge was created.

## Fix

- `src/stores/canvas-instance-store.ts`: added `connectingHandleType: HandleType | null` + setter, tracking which handle type a drag started from.
- `src/components/canvas/dfd-canvas.tsx`: wires `onConnectStart`/`onConnectEnd`/`onReconnectStart`/`onReconnectEnd` to set/clear it (reconnect reports the *opposite* anchor's type, which is the semantically correct value for this suppression).
- `src/components/canvas/nodes/shared-handles.tsx`: replaced the blanket pointer-events override with per-render `targetCls`/`sourceCls`, each suppressing pointer-events only on the handle type matching `connectingHandleType` while a drag is active. The other type stays interactive so it always wins the hit test at every overlapping point.

**Preserved unchanged (by design):** handle IDs and the `-source`/`-target` suffix convention (persisted in `.thf` files via `source_handle`/`target_handle`), ReactFlow's strict connection mode, self-loop/reconnect wiring, undo, and #134 hover/connecting visibility. No renames, no connection-mode change, no schema change.

## Tests

`e2e/canvas-connections.spec.ts` (new) — 5 real mouse-drag Playwright tests, no synthetic DOM dispatch, no direct Zustand writes, no mocked callbacks:

1. Source→target drag creates exactly one edge.
2. Reverse direction (other node's source→target) creates exactly one edge.
3. Self-loop (drag from a node's own source handle to a different overlapping point on itself).
4. Reconnecting an edge's **target** anchor onto an overlapping target handle re-targets without duplicating (verified via save + read-YAML round trip of `target_handle`).
5. Reconnecting an edge's **source** anchor onto an overlapping source handle re-targets without duplicating (verified via save + read-YAML round trip of `source_handle`), **plus** a mid-drag `getComputedStyle` assertion proving the target-suppression branch's CSS effect directly — since a real drop there would succeed from default DOM order alone, connection outcome alone can't discriminate that branch.

All 5 confirmed **failing on pre-fix `main`** (via `git stash` of the fix files) and **passing on fixed code** (15/15 across a `--repeat-each=3` run, no flake).

Also added targeted unit tests: `shared-handles.test.tsx` (pointer-events suppression per `connectingHandleType` value) and `canvas-instance-store.test.ts` (new field getter/setter).

## Verification

- `npx tsc --noEmit` — clean
- `npx biome check` — clean on all changed files
- `npx vitest run` — 1805/1805 passed (full suite)
- `npx playwright test` — 68/68 passed (full suite, no regressions in `canvas-handles.spec.ts` #134 coverage or `canvas-elements.spec.ts`)
- `npm run ci:local` — full green (lockfile check, Tauri version alignment, Biome, tsc, worker tsc, cargo fmt, clippy -D warnings, full Vitest, full cargo test (169 passed), web build, Cloudflare Worker dry run)

## Preflight (review-to-convergence)

- **Self-review (`anti-slop-review`):** one minor doc-drift nit found and fixed (spec file-header comment under-described test coverage).
- **Round 1 (`slop-auditor` + `pr-reviewer`, parallel):** slop-auditor clean. pr-reviewer found one should-fix — reconnect coverage only drove `connectingHandleType === "source"` via a real gesture, leaving the `"target"` branch verified only by direct store injection in a unit test. **Resolved** by adding test 5 (source-reconnect-anchor), verified genuine pass/fail via stash/restore.
- **Round 2 (`pr-reviewer` follow-up):** found the new test 5's comments overclaimed that connection outcome proved both pointer-events-suppression branches — the target branch is DOM-order-redundant for connection success given current render order, so outcome alone doesn't discriminate it. **Resolved** by adding a direct mid-drag `getComputedStyle` assertion for that branch (independently verified to fail when the branch is neutered, pass with the real fix) and correcting the doc comment to state precisely what each test proves.
- **Round 3 (`pr-reviewer` final convergence):** independently re-traced the xyflow mechanism, re-ran the neuter-and-revert experiment itself, reran the full spec 3×, and confirmed no other gaps in the diff. **Verdict: clean.** No must-fix or should-fix remaining. One non-blocking `consider` (minor gesture-helper duplication in the new mid-drag test, judged an acceptable, well-justified deviation).

## Owner validation

Verification and preflight are complete; **owner validation and merge remain** per AGENTS.md (green CI is not `Done`). This PR is opened as draft pending required remote CI checks; the user has explicitly pre-authorized an admin squash merge for this run once checks pass.

Closes #213