### PR TITLE
docs(e2e): add local agent scenario workflow

### DIFF
--- a/.github/instructions/e2e.instructions.md
+++ b/.github/instructions/e2e.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "e2e/**,playwright.config.*"
+applyTo: "e2e/**,playwright.config.*,scripts/run-agent-scenario*.mjs,docs/runbooks/running-agent-e2e-scenarios.md"
 ---
 
 # End-to-end tests
@@ -32,3 +32,8 @@ Follow `AGENTS.md`; this file adds Playwright rules.
   for any accessibility assertion instead of constructing a new `AxeBuilder` inline; add exceptions
   only as exact `{ ruleId, target }` node entries in `KNOWN_ACCESSIBILITY_EXCEPTIONS`, tied to a
   tracking issue — never allowlist a whole rule ID.
+- A local agent runs a named scenario with `npm run test:e2e:agent -- <scenario>` (or
+  `-- --list` for the catalog) instead of hand-building a Playwright invocation; see
+  `docs/runbooks/running-agent-e2e-scenarios.md` for scenario selection, evidence capture/location,
+  and defect reporting. Add a new scenario to `scripts/run-agent-scenario.mjs`'s `SCENARIOS` map and
+  the runbook's table together, never one without the other.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,10 @@ Examples:
 
 1. Run the smallest targeted checks while iterating.
 2. Run `npm run ci:local` before handoff.
-3. Add E2E, Docker, Tauri build, signing, or live-service checks when the change requires them.
+3. Add E2E, Docker, Tauri build, signing, or live-service checks when the change requires them. For
+   a browser-facing UI change, run the relevant scenario in
+   [docs/runbooks/running-agent-e2e-scenarios.md](docs/runbooks/running-agent-e2e-scenarios.md)
+   (`npm run test:e2e:agent -- <scenario>`) and inspect its evidence before handoff.
 4. Run the author anti-slop pass and independent PR preflight.
 5. Link the issue with `Closes #N` and the M/L plan when required.
 6. Include before/after screenshots or traces for visible UI changes.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,12 @@ Produces a native desktop binary for your platform (~10MB).
 ```bash
 npx vitest --run                                       # Frontend test suite
 cargo test --manifest-path src-tauri/Cargo.toml        # Rust test suite
+npx playwright test                                    # Browser E2E test suite
 ```
+
+For a local agent (or a contributor) to launch a single deterministic browser scenario in headed
+mode and inspect its evidence, see
+[docs/runbooks/running-agent-e2e-scenarios.md](docs/runbooks/running-agent-e2e-scenarios.md).
 
 ### Lint
 

--- a/docs/runbooks/running-agent-e2e-scenarios.md
+++ b/docs/runbooks/running-agent-e2e-scenarios.md
@@ -1,0 +1,200 @@
+# Running agent E2E scenarios
+
+A local coding agent (or a contributor) can launch ThreatForge in its **browser** app mode against
+a deterministic, named scenario, watch it run, and inspect the same evidence CI produces — with no
+new fixture, helper, or artifact format beyond what issues `#65` and `#66` already built. This
+runbook is that workflow's contract. It does not cover desktop/Tauri E2E: native dialogs, file
+associations, installer signing, notarization, and the updater remain issue `#68`'s separate,
+not-yet-built scope, and nothing here claims to exercise them.
+
+## Scope: browser mode only
+
+Every scenario below runs through `playwright.config.ts`'s existing `webServer` (`npm run dev:web`
+on port 3000) against the `chromium` project — the identical browser app mode
+`.github/workflows/ci.yml`'s `E2E Tests` job uses. This never launches the desktop shell
+(`npm run tauri dev` / `npm run tauri build`); there is no fixture, helper, or artifact contract
+for desktop E2E today.
+
+## The one command
+
+```bash
+npm run test:e2e:agent -- --list                 # print the scenario catalog
+npm run test:e2e:agent -- <scenario>              # headed local run (default)
+npm run test:e2e:agent -- <scenario> --headless   # CI-shaped headless run
+```
+
+This runs `scripts/run-agent-scenario.mjs`, which:
+
+1. Resolves `<scenario>` against the fixed catalog below and refuses to start (prints the catalog
+   and exits non-zero) on an unknown or missing name — a scenario is never guessed from a loose
+   match.
+2. Invokes the repository-pinned `node_modules/@playwright/test/cli.js` directly with
+   `test <the scenario's spec file(s)> [--grep <exact-title pattern>] [--headed]` — no `npx`
+   network fallback. It uses the same fixtures/helpers, `playwright.config.ts`, and `chromium`
+   project as CI; `--headed` is the only local-only addition and is omitted with `--headless`.
+3. Always runs `node scripts/build-artifact-manifest.mjs` afterward — the identical command
+   `.github/workflows/ci.yml`'s "Build E2E artifact manifest" step runs with `if: always()` — so a
+   local run leaves the same `test-results/results.json`, `test-results/artifact-manifest.json`,
+   and `playwright-report/` layout CI does, whether the scenario passed or failed.
+
+`npx playwright test e2e/<file>.spec.ts`, `npx playwright test --headed`, and
+`bash scripts/ci-local.sh --e2e` continue to work exactly as before; this command is a documented,
+narrowed convenience over the same underlying invocation; it is not a new test runner.
+
+Each scenario run clears the prior `test-results/` and `playwright-report/` directories before
+launching so stale evidence can never masquerade as the current result. Copy any evidence you need
+to retain before starting another scenario.
+
+## Scenario catalog
+
+Each scenario name below is exactly the identifier `scripts/run-agent-scenario.mjs`'s exported
+`SCENARIOS` map uses; running `npm run test:e2e:agent -- --list` prints the same names and their
+spec files directly from that source, so this table can never silently drift out of sync with what
+the command actually runs without both being caught by
+`scripts/run-agent-scenario.test.mjs`.
+
+| Scenario | Outcome prompt (what to try) | Spec file(s) |
+|---|---|---|
+| `document-creation` | Create a new, empty document from the empty-state button, and again from the toolbar button; confirm the canvas, palette, and right panel are all usable afterward. | `e2e/new-model.spec.ts` |
+| `multi-tab-restore` | Open several documents, edit one, reload the page, and confirm every tab returns in its persisted order with the correct tab active and content intact — not reset. | `e2e/browser-restore.spec.ts` |
+| `import-export` | Open a large committed `.thf` file and a deliberately malformed one through the real Open-file dialog, then create a document, add and connect elements, rename one, confirm `.thf` and HTML downloads are emitted, and reload to confirm browser workspace autosave restores the model. This does not reopen the downloaded `.thf`. | `e2e/workspace-fixtures.spec.ts` (`seedLargeWorkspace`, `seedMalformedWorkspace`, and the combined interaction-helpers test only) |
+| `threat-analysis` | Run STRIDE analysis against a modeled document and copy one generated threat as YAML. | `e2e/stride-analysis.spec.ts` |
+| `native-ai-tools` | Ask the AI panel to add an element, then approve, deny, stop, and undo a proposed tool call — against a canned, scripted SSE fixture. No API key and no network call ever leaves the machine (`seedAnthropicApiKey` plus a routed fake response; see "No real providers, secrets, or production data" below). | `e2e/ai-tool-loop.spec.ts` |
+| `release-smoke` | The browser-available subset of `docs/runbooks/releasing-a-version.md`'s smoke checklist: create a document, save a `.thf` download, run STRIDE analysis, and confirm the AI panel's no-key state and settings entry point. HTML export belongs to `import-export`; desktop-only installer/signing/native-dialog/file-association/updater steps remain issue `#68`'s scope and are **not** exercised or claimed here. | `e2e/new-model.spec.ts`, `e2e/save-reopen.spec.ts`, `e2e/stride-analysis.spec.ts`, `e2e/ai-chat.spec.ts` |
+| `visual-evidence` | Capture the pre-model empty state and all six templates as successful, path-backed screenshot attachments for manual review. This produces evidence only; it does not assert or certify visual quality. | `e2e/screenshot-templates.spec.ts` |
+
+## Starting, selecting, and navigating
+
+1. `npm install` once, then `npx playwright install --with-deps chromium` once (matches CI's
+   "Install Playwright browsers" step).
+2. Run `npm run test:e2e:agent -- --list` to see every scenario name, its outcome prompt, and its
+   spec file(s) without opening this file.
+3. Run `npm run test:e2e:agent -- <scenario>` to watch a real Chromium window perform that
+   scenario. Shared create/open/switch/drag/connect/edit/save/export/restore setup uses
+   `e2e/support/interactions.ts` and `workspace-fixtures.ts` where those contracts exist; individual
+   specs also exercise their own user-facing controls directly with semantic Playwright locators.
+   Read the scenario's spec file and retained `test.step` hierarchy to see exactly what ran — do not
+   assume every low-level action is wrapped by a shared helper.
+4. To explore beyond a scripted scenario's fixed steps — e.g. to try an interaction no existing
+   spec performs yet — use `npm run test:e2e:ui` (`playwright test --ui`), which opens Playwright's
+   interactive UI mode against the same fixtures/config for step-by-step, pausable execution and
+   locator picking; or run `npm run dev:web` and open `http://localhost:3000/app` directly for
+   fully manual browser exploration. Both stay inside browser mode and remain subject to the "No
+   real providers, secrets, or production data" rules below even outside an automated spec.
+
+## Capturing and locating evidence
+
+Every attempt's evidence lands under `test-results/<sanitized-test-name>-chromium/` and the
+top-level `test-results/` files below; nothing here is scenario-specific machinery — it is exactly
+what `playwright.config.ts` and `e2e/support/base.ts` (issues `#65`/`#66`) already produce for any
+`npx playwright test` run:
+
+| Evidence | Where | Present when |
+|---|---|---|
+| Screenshot | `screenshot` attachment | On a failing attempt (`screenshot: "only-on-failure"`), or on a successful `visual-evidence` scenario that explicitly attaches template images |
+| Trace | `trace` attachment (`trace.zip`) | Any unexpected failed attempt (`trace: "retain-on-failure"`); omitted for an expected (`test.fail()`) policy-proof attempt |
+| Video | `video` attachment | Same condition as trace (`video: "retain-on-failure"`) |
+| DOM snapshot | `error-context` attachment | Alongside a failure screenshot |
+| Console transcript | `console-log` attachment (bounded to ≤300 entries/≤20,000 characters) | Any page-backed attempt that did not pass, whose actual status differs from its expected status, or that is about to fail the browser-event policy |
+| Accessibility projection | `accessibility` attachment (bounded, privacy-reduced) | Same condition as the console transcript |
+| Runtime viewport | `artifact-context` attachment | Every page-backed attempt, unconditionally |
+| Diagnostic capture failure | `diagnostic-capture-error` attachment | Only if capturing one of the above itself failed |
+| HTML report | `playwright-report/index.html` | Every run; open with `npx playwright show-report` |
+| Machine-readable report | `test-results/results.json` | Every run (the JSON reporter) |
+| Artifact manifest | `test-results/artifact-manifest.json` | Every run of `npm run test:e2e:agent`, since it always calls `node scripts/build-artifact-manifest.mjs` afterward — one entry per attempt, every step/attachment classified, paths normalized relative to the repo root |
+
+Do not guess attachment names or classifications — `e2e/support/README.md`'s "Conventions for
+future issues" section is the exact, single source of the `test.step`/attachment classification
+tables `scripts/build-artifact-manifest.mjs` implements; this runbook does not restate them.
+
+To inspect a specific attempt: open `npx playwright show-report` and click through to the failing
+test, or read `test-results/artifact-manifest.json` directly for the exact attachment path before
+opening the HTML report at all. To step through a trace: `npx playwright show-trace
+test-results/<attempt-folder>/trace.zip`. To read the browser's own console output for an attempt,
+open its `console-log` attachment — do not re-run with a hand-rolled `page.on("console", ...)`
+listener; `e2e/support/base.ts` already attaches one.
+
+### Capturing an unasserted visual defect
+
+If a scenario passes but you observe a visual defect that its assertions do not cover:
+
+1. For the empty/template states, run
+   `npm run test:e2e:agent -- visual-evidence`; it creates seven successful path-backed screenshot
+   attachments and rebuilds the normal manifest.
+2. For any other state, create a short-lived `e2e/_local-evidence.spec.ts` using the shared fixture,
+   reproduce only the observed state, then capture through the existing artifact layout:
+
+   ```ts
+   import { test } from "./fixtures";
+
+   test("local visual evidence", async ({ page }, testInfo) => {
+     // Reproduce the user-visible state with committed fixtures/helpers and fake data only.
+     const screenshotPath = testInfo.outputPath("manual-repro.png");
+     await page.screenshot({ path: screenshotPath });
+     await testInfo.attach("manual-repro", { path: screenshotPath, contentType: "image/png" });
+   });
+   ```
+
+   Run the pinned local CLI with one worker, then build the manifest:
+
+   ```bash
+   node node_modules/@playwright/test/cli.js test e2e/_local-evidence.spec.ts --headed --workers=1
+   node scripts/build-artifact-manifest.mjs
+   node -e "require('node:fs').rmSync('e2e/_local-evidence.spec.ts')"
+   ```
+
+   Confirm the temporary spec is deleted before handoff. Never use real user data or credentials.
+
+## Reporting a defect
+
+For either an automated failure or a manual visual reproduction, follow the repository bug-template
+shape and report exactly what was observed, not an inferred cause:
+
+- Scenario name, exact command (headed/headless), commit (`git rev-parse HEAD`), operating system,
+  and Chromium/Playwright version.
+- Minimal user-visible reproduction steps plus **expected** and **observed** behavior.
+- For an automated failure: full test title/location (`file.spec.ts:line`) from the terminal or
+  `results.json`, and exact console/error text.
+- For a manual reproduction: the temporary evidence spec's title and the manual actions performed.
+- Preserved attachment paths (screenshot, trace, console-log, accessibility, DOM snapshot) copied
+  from `artifact-manifest.json`, not guessed. Copy the evidence before another scenario clears it.
+
+Do not describe a defect in terms of an implementation selector (a CSS class, a `data-testid`, an
+internal function name) the agent has not actually observed failing; describe the user-visible
+outcome instead (e.g. "the tenth tab is not marked selected after reload" rather than "the
+`aria-selected` attribute logic is wrong"). File the defect as a linked GitHub issue per `AGENTS.md`
+— this runbook does not authorize creating or updating issues itself.
+
+## No real providers, secrets, or production data
+
+- Never seed a real provider API key, credential, or production secret into any scenario run.
+  `native-ai-tools` and any AI-touching manual exploration use only the fixed, obviously-fake
+  `seedAnthropicApiKey` placeholder (`sk-ant-e2e-not-a-real-key`) paired with a routed, canned SSE
+  response (`e2e/ai-tool-loop.spec.ts`) — no request ever reaches a real provider, and this
+  workflow never does either.
+- Never open a real user's `.thf` file or other production data through any scenario or manual
+  exploration session; use only the committed fixtures under `e2e/fixtures/` and
+  `tests/fixtures/thf/`.
+- Never skip, weaken, or silently reinterpret a failing check to make a scenario "pass" — a
+  failing scenario is a real defect signal, not noise to route around.
+- A scenario passing is evidence that its own written assertions held, nothing more. It does not,
+  by itself, establish visual quality (hierarchy, alignment, overlap, or clipping) — see
+  `docs/quality/e2e-visual-accessibility-rubric.md` for exactly which rubric items are automated
+  today and which remain owner-validated from retained screenshots/video. Do not report a scenario
+  as visually correct solely because it passed.
+
+## Local/CI parity
+
+| | Local (`npm run test:e2e:agent`) | CI (`.github/workflows/ci.yml`, `e2e` job) |
+|---|---|---|
+| Fixtures/helpers | `e2e/support/workspace-fixtures.ts`, `e2e/support/interactions.ts` | Identical |
+| Browser/project | `chromium` against `npm run dev:web` (`playwright.config.ts`) | Identical |
+| Command shape | pinned local Playwright CLI: `test <files> --grep <pattern> --workers=1 [--headed]` | `npx playwright test` using the same pinned package (whole suite, headless, one worker) |
+| Retries / focused-test guard | 0 retries; `forbidOnly` off | 2 retries; `forbidOnly` on |
+| Web server lifecycle | Reuses an already-running local server when available | Starts a fresh server (`reuseExistingServer: false`) |
+| Artifact manifest | `node scripts/build-artifact-manifest.mjs`, always run | Same command, `if: always()` |
+| Report/report paths | `test-results/results.json`, `test-results/artifact-manifest.json`, `playwright-report/` | Identical |
+
+Intentional differences are scope, headedness, retries/`forbidOnly`, and whether an existing dev
+server may be reused. Workers, fixtures, project, browser app, artifact layout, and manifest command
+remain identical.

--- a/e2e/support/README.md
+++ b/e2e/support/README.md
@@ -100,3 +100,14 @@ restatement of that plan's reasoning.
   A new `test.step`/attachment name follows one of these rules automatically; a genuinely new kind
   needs a matching classifier update in `build-artifact-manifest.mjs` (and its test file) — never a
   guess baked into a spec.
+
+## Local agent workflow (`#67`)
+
+`scripts/run-agent-scenario.mjs` (`npm run test:e2e:agent -- <scenario>`) launches one named,
+deterministic scenario in the same browser app mode, against the same fixtures/helpers in this
+directory, that CI uses — never a new fixture, helper, or artifact format. The full workflow —
+starting, selecting a scenario, navigating/capturing/locating evidence, and reporting a defect from
+observed evidence — is documented in `docs/runbooks/running-agent-e2e-scenarios.md`, not restated
+here. `scripts/run-agent-scenario.test.mjs` fails if that runbook's scenario catalog,
+`package.json`'s `test:e2e:agent` script, or the underlying spec files/test titles drift out of
+sync with each other.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"test:e2e": "playwright test",
 		"test:e2e:ui": "playwright test --ui",
 		"test:e2e:headed": "playwright test --headed",
+		"test:e2e:agent": "node scripts/run-agent-scenario.mjs",
 		"ci:local": "bash scripts/ci-local.sh",
 		"ci:docker": "docker compose run --rm --build ci",
 		"ci:docker:build": "docker compose run --rm --build ci bash scripts/ci-local.sh --build",

--- a/scripts/build-artifact-manifest.mjs
+++ b/scripts/build-artifact-manifest.mjs
@@ -35,8 +35,8 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-const DEFAULT_REPORT_PATH = "test-results/results.json";
-const DEFAULT_MANIFEST_PATH = "test-results/artifact-manifest.json";
+export const DEFAULT_REPORT_PATH = "test-results/results.json";
+export const DEFAULT_MANIFEST_PATH = "test-results/artifact-manifest.json";
 const SCHEMA_VERSION = 1;
 
 /** The sole current Playwright project (`playwright.config.ts`'s `devices["Desktop Chrome"]`). */

--- a/scripts/run-agent-scenario.mjs
+++ b/scripts/run-agent-scenario.mjs
@@ -1,0 +1,280 @@
+// Launches one named, deterministic browser E2E scenario for local agent inspection (issue #67).
+//
+// Usage:
+//   node scripts/run-agent-scenario.mjs --list             # print the scenario catalog
+//   node scripts/run-agent-scenario.mjs <scenario>          # headed local run (default)
+//   node scripts/run-agent-scenario.mjs <scenario> --headless
+//
+// Also invocable via the documented npm script (see docs/runbooks/running-agent-e2e-scenarios.md):
+//   npm run test:e2e:agent -- --list
+//   npm run test:e2e:agent -- <scenario>
+//
+// Every scenario below is a real spec file — optionally narrowed to an exact allowlist of test
+// titles — built on the same #65 fixtures/helpers (`e2e/support/workspace-fixtures.ts`,
+// `e2e/support/interactions.ts`) that CI runs, and the same `playwright.config.ts` project/
+// webServer CI itself uses (chromium against `npm run dev:web` on port 3000). This script never
+// launches the desktop Tauri shell (`npm run tauri dev`) — browser mode is the only mode the #65/
+// #66/#67 fixtures and artifact layout exist for; desktop E2E is issue #68's separate scope.
+//
+// No new fixture, helper, or artifact mechanism is introduced: this invokes the repository-pinned
+// Playwright CLI directly (never `npx` network fallback) with
+// `test <files> [--grep <pattern>] [--headed]`, followed by the exact
+// `node scripts/build-artifact-manifest.mjs` step CI runs. A local run therefore leaves the same
+// `test-results/results.json`, `test-results/artifact-manifest.json`, and `playwright-report/`
+// layout as CI.
+
+import { spawnSync } from "node:child_process";
+import { rmSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), "..", "..");
+const PLAYWRIGHT_CLI = path.join(REPO_ROOT, "node_modules", "@playwright", "test", "cli.js");
+
+/**
+ * One outcome-oriented scenario per critical flow named in issue #67's acceptance criteria,
+ * mapped to the existing spec file(s)/test title(s) that already exercise it. `titles` is an
+ * exact-match allowlist turned into an anchored `--grep` alternation, so adding/removing a test
+ * never silently changes a scenario's contract.
+ *
+ * @typedef {{ description: string; files: string[]; titles: string[] }} Scenario
+ * @type {Record<string, Scenario>}
+ */
+export const SCENARIOS = {
+	"document-creation": {
+		description: "Create a new, empty document from both the empty-state and toolbar affordances.",
+		files: ["e2e/new-model.spec.ts"],
+		titles: [
+			"creates new model via empty state button",
+			"creates new model via toolbar button",
+			"shows palette and right panel after creation",
+		],
+	},
+	"multi-tab-restore": {
+		description:
+			"Open several documents, reload, and confirm every tab is restored in persisted order with the correct tab active.",
+		files: ["e2e/browser-restore.spec.ts"],
+		titles: [
+			"a document's edit survives a page reload and returns as content, not a reset",
+			"reload restores every open tab in persisted order and hydrates an inactive one on demand",
+			"reload honors the active-document choice over creation order",
+		],
+	},
+	"import-export": {
+		description:
+			"Open a large committed .thf file and a malformed one through the real Open dialog, then create, edit, save, export, and restore a document end to end.",
+		files: ["e2e/workspace-fixtures.spec.ts"],
+		titles: [
+			"seedLargeWorkspace renders 150 elements and 100 flows within 5000ms",
+			"seedMalformedWorkspace surfaces the complete parse-failure alert and leaves the canvas unchanged",
+			"shared interaction helpers execute real create, switch, edit, drag, connect, save, export, and restore workflows",
+		],
+	},
+	"threat-analysis": {
+		description: "Run STRIDE analysis against a modeled document and copy a generated threat.",
+		files: ["e2e/stride-analysis.spec.ts"],
+		titles: [
+			"STRIDE button is disabled with no elements",
+			"generates threats and copies one as YAML",
+		],
+	},
+	"native-ai-tools": {
+		description:
+			"Exercise the bounded AI tool loop (approve, deny, stop, undo) with an obviously-fake local key and canned SSE fixture — no real credential or provider request leaves the machine.",
+		files: ["e2e/ai-tool-loop.spec.ts"],
+		titles: [
+			"approving a tool call adds the element to the canvas",
+			"stopping while a call is pending leaves the canvas unchanged",
+			"denying a call keeps the canvas unchanged and continues the turn",
+			"undoing the turn removes the applied element in one step",
+		],
+	},
+	"release-smoke": {
+		description:
+			"The browser-available subset of docs/runbooks/releasing-a-version.md's smoke checklist: create, save a .thf download, run STRIDE analysis, and confirm AI-panel availability/settings. Desktop-only steps remain issue #68's scope.",
+		files: [
+			"e2e/new-model.spec.ts",
+			"e2e/save-reopen.spec.ts",
+			"e2e/stride-analysis.spec.ts",
+			"e2e/ai-chat.spec.ts",
+		],
+		titles: [
+			"creates new model via empty state button",
+			"creates new model via toolbar button",
+			"shows palette and right panel after creation",
+			"save triggers a YAML download with model data",
+			"model state includes all added elements",
+			"saved YAML preserves element names after editing",
+			"STRIDE button is disabled with no elements",
+			"generates threats and copies one as YAML",
+			"AI tab shows no API key message",
+			"settings gear in AI tab opens settings dialog at AI section",
+		],
+	},
+	"visual-evidence": {
+		description:
+			"Capture the empty state and all six templates as path-backed Playwright screenshot attachments for manual visual review; this is evidence capture, not a visual-quality pass/fail gate.",
+		files: ["e2e/screenshot-templates.spec.ts"],
+		titles: [
+			"screenshot empty state",
+			"screenshot template: ecommerce-platform",
+			"screenshot template: cloud-microservices",
+			"screenshot template: mobile-banking",
+			"screenshot template: saas-platform",
+			"screenshot template: iot-smart-building",
+			"screenshot template: healthcare-system",
+		],
+	},
+};
+
+/** Escape every regex metacharacter in `text` so it matches only as a literal string. */
+export function escapeRegExp(text) {
+	return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Build a Playwright `--grep` pattern that matches exactly the given full test titles, anchored
+ * at the end. Playwright matches `--grep` against the joined `<project> <file> <describe...>
+ * <test>` path (`Suite._grepTitleWithTags`, `node_modules/playwright/lib/common/index.js`), not
+ * the bare test title, so a leading `^` anchor would have to also reproduce that project/file/
+ * describe prefix and silently break the moment any of it changed. Anchoring only the end is
+ * sufficient to require each alternative to be this exact title with no extra trailing text, and
+ * the file argument already scopes the match to one spec file.
+ *
+ * @param {string[]} titles
+ * @returns {string}
+ */
+export function buildGrepPattern(titles) {
+	if (titles.length === 0) throw new Error("A titled scenario must allow at least one test title");
+	const escaped = titles.map(escapeRegExp);
+	return escaped.length === 1 ? `${escaped[0]}$` : `(${escaped.join("|")})$`;
+}
+
+/**
+ * @param {string[]} argv
+ * @returns {{ list: boolean; scenario: string | undefined; headless: boolean; errors: string[] }}
+ */
+export function parseArgs(argv) {
+	const supportedFlags = new Set(["--list", "--headless"]);
+	const unknownFlags = argv.filter((arg) => arg.startsWith("--") && !supportedFlags.has(arg));
+	const positionals = argv.filter((arg) => !arg.startsWith("--"));
+	const list = argv.includes("--list");
+	const headless = argv.includes("--headless");
+	const errors = unknownFlags.map((flag) => `Unknown option: "${flag}"`);
+	if (positionals.length > 1)
+		errors.push(`Expected one scenario, received: ${positionals.join(", ")}`);
+	if (list && (headless || positionals.length > 0)) {
+		errors.push("--list cannot be combined with a scenario or --headless");
+	}
+	return { list, scenario: positionals[0], headless, errors };
+}
+
+function printUsage() {
+	console.error("Usage: node scripts/run-agent-scenario.mjs <scenario> [--headless]");
+	console.error("       node scripts/run-agent-scenario.mjs --list");
+	console.error("\nAvailable scenarios:");
+	for (const [name, scenario] of Object.entries(SCENARIOS)) {
+		console.error(`  ${name} — ${scenario.description}`);
+	}
+}
+
+function printCatalog() {
+	for (const [name, scenario] of Object.entries(SCENARIOS)) {
+		console.log(`${name}\n  ${scenario.description}\n  files: ${scenario.files.join(", ")}`);
+	}
+}
+
+/**
+ * @param {Scenario} scenario
+ * @param {{ headless: boolean }} opts
+ * @returns {string[]}
+ */
+export function buildPlaywrightArgs(scenario, opts) {
+	const args = ["test", ...scenario.files];
+	args.push("--grep", buildGrepPattern(scenario.titles), "--workers=1");
+	if (!opts.headless) args.push("--headed");
+	return args;
+}
+
+/**
+ * Execute one already-validated scenario. Dependencies are injectable so orchestration order,
+ * cleanup, manifest-on-failure, and exit-code precedence are testable without launching a browser.
+ *
+ * @param {string} scenarioName
+ * @param {{ headless: boolean }} opts
+ * @param {{
+ *   spawn?: typeof spawnSync;
+ *   remove?: typeof rmSync;
+ *   log?: (message: string) => void;
+ * }} [deps]
+ * @returns {number}
+ */
+export function runScenario(scenarioName, opts, deps = {}) {
+	const spawn = deps.spawn ?? spawnSync;
+	const remove = deps.remove ?? rmSync;
+	const log = deps.log ?? ((message) => console.error(message));
+	if (!Object.hasOwn(SCENARIOS, scenarioName)) {
+		throw new Error(`Unknown scenario: ${scenarioName}`);
+	}
+	const scenario = SCENARIOS[scenarioName];
+	const playwrightArgs = buildPlaywrightArgs(scenario, { headless: opts.headless });
+
+	log(`▸ Running scenario "${scenarioName}": ${scenario.description}`);
+	log(`▸ node node_modules/@playwright/test/cli.js ${playwrightArgs.join(" ")}`);
+	remove(path.join(REPO_ROOT, "test-results"), { recursive: true, force: true });
+	remove(path.join(REPO_ROOT, "playwright-report"), { recursive: true, force: true });
+	const playwrightResult = spawn(process.execPath, [PLAYWRIGHT_CLI, ...playwrightArgs], {
+		cwd: REPO_ROOT,
+		stdio: "inherit",
+	});
+	if (playwrightResult.error) {
+		log(`Playwright could not start: ${playwrightResult.error.message}`);
+	}
+	if (playwrightResult.signal) {
+		log(`Playwright terminated by signal: ${playwrightResult.signal}`);
+	}
+
+	// Mirrors CI's `if: always()` manifest step whether the scenario passed, failed, or did not start.
+	log("▸ node scripts/build-artifact-manifest.mjs");
+	const manifestResult = spawn(process.execPath, ["scripts/build-artifact-manifest.mjs"], {
+		cwd: REPO_ROOT,
+		stdio: "inherit",
+	});
+	if (manifestResult.error) {
+		log(`Artifact manifest could not start: ${manifestResult.error.message}`);
+	}
+	if (manifestResult.signal) {
+		log(`Artifact manifest terminated by signal: ${manifestResult.signal}`);
+	}
+
+	const playwrightStatus = playwrightResult.status ?? 1;
+	const manifestStatus = manifestResult.status ?? 1;
+	return playwrightStatus !== 0 ? playwrightStatus : manifestStatus;
+}
+
+function main() {
+	const parsed = parseArgs(process.argv.slice(2));
+
+	if (parsed.errors.length > 0) {
+		for (const error of parsed.errors) console.error(error);
+		printUsage();
+		process.exit(1);
+	}
+
+	if (parsed.list) {
+		printCatalog();
+		return;
+	}
+
+	if (!parsed.scenario || !Object.hasOwn(SCENARIOS, parsed.scenario)) {
+		if (parsed.scenario) console.error(`Unknown scenario: "${parsed.scenario}"\n`);
+		printUsage();
+		process.exit(1);
+	}
+
+	process.exit(runScenario(parsed.scenario, { headless: parsed.headless }));
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+	main();
+}

--- a/scripts/run-agent-scenario.test.mjs
+++ b/scripts/run-agent-scenario.test.mjs
@@ -1,0 +1,362 @@
+// @vitest-environment node
+//
+// Deterministic drift detection for the local agent scenario launcher (issue #67):
+// `scripts/run-agent-scenario.mjs`'s scenario catalog, the runbook that documents it, and
+// `package.json`'s `test:e2e:agent` script must never silently diverge from each other or from
+// the real spec files/test titles they claim to run. Every check here reads real file content or
+// spawns the real CLI rather than re-asserting the implementation's own hardcoded data back at
+// itself — a renamed scenario, a renamed/removed spec file, a retitled test, a real-title/grep
+// mismatch, or a moved artifact-manifest path fails one of these tests.
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { load } from "js-yaml";
+import { describe, expect, it } from "vitest";
+import { DEFAULT_MANIFEST_PATH, DEFAULT_REPORT_PATH } from "./build-artifact-manifest.mjs";
+import {
+	buildGrepPattern,
+	buildPlaywrightArgs,
+	escapeRegExp,
+	parseArgs,
+	runScenario,
+	SCENARIOS,
+} from "./run-agent-scenario.mjs";
+
+const repoRoot = join(import.meta.dirname, "..");
+const runbookPath = join(repoRoot, "docs", "runbooks", "running-agent-e2e-scenarios.md");
+const packageJsonPath = join(repoRoot, "package.json");
+const launcherScriptPath = join(repoRoot, "scripts", "run-agent-scenario.mjs");
+const playwrightCli = join(repoRoot, "node_modules", "@playwright", "test", "cli.js");
+
+function readRepoFile(relativePath) {
+	return readFileSync(join(repoRoot, relativePath), "utf8");
+}
+
+function readIfPresent(relativePath) {
+	const fullPath = join(repoRoot, relativePath);
+	return existsSync(fullPath) ? readFileSync(fullPath) : null;
+}
+
+describe("SCENARIOS catalog stays honest against real spec files", () => {
+	for (const [name, scenario] of Object.entries(SCENARIOS)) {
+		it(`${name}: every referenced spec file exists`, () => {
+			for (const file of scenario.files) {
+				expect(existsSync(join(repoRoot, file)), `${file} does not exist`).toBe(true);
+			}
+		});
+	}
+});
+
+describe("escapeRegExp / buildGrepPattern", () => {
+	it("escapes every regex metacharacter", () => {
+		expect(escapeRegExp("a.b*c?d^e$f{g}h(i)j|k[l]m\\n")).toBe(
+			"a\\.b\\*c\\?d\\^e\\$f\\{g\\}h\\(i\\)j\\|k\\[l\\]m\\\\n",
+		);
+	});
+
+	it("a single title is anchored only at the end", () => {
+		expect(buildGrepPattern(["hello world"])).toBe("hello world$");
+	});
+
+	it("multiple titles become an end-anchored alternation", () => {
+		expect(buildGrepPattern(["a", "b, c"])).toBe("(a|b, c)$");
+	});
+
+	// Playwright matches `--grep` against the full `<project> <file> <describe...> <test>` path
+	// (`Suite._grepTitleWithTags`), not the bare test title — a leading `^` anchor would require
+	// reproducing that entire prefix and silently stop matching the moment any of it changed.
+	// `buildGrepPattern` deliberately never emits a leading `^` for exactly this reason.
+	it("never anchors the start of the pattern", () => {
+		expect(buildGrepPattern(["solo"])).not.toMatch(/^\^/);
+		expect(buildGrepPattern(["a", "b"])).not.toMatch(/^\^/);
+	});
+});
+
+describe("parseArgs", () => {
+	it("recognizes --list regardless of position", () => {
+		expect(parseArgs(["--list"])).toEqual({
+			list: true,
+			scenario: undefined,
+			headless: false,
+			errors: [],
+		});
+	});
+
+	it("reads a bare scenario name with headed as the default", () => {
+		expect(parseArgs(["document-creation"])).toEqual({
+			list: false,
+			scenario: "document-creation",
+			headless: false,
+			errors: [],
+		});
+	});
+
+	it("reads --headless alongside a scenario name", () => {
+		expect(parseArgs(["threat-analysis", "--headless"])).toEqual({
+			list: false,
+			scenario: "threat-analysis",
+			headless: true,
+			errors: [],
+		});
+	});
+
+	it("reports an absent scenario name as undefined, not a flag", () => {
+		expect(parseArgs(["--headless"])).toEqual({
+			list: false,
+			scenario: undefined,
+			headless: true,
+			errors: [],
+		});
+	});
+
+	it("rejects unknown flags, extra scenarios, and --list combinations", () => {
+		expect(parseArgs(["document-creation", "--typo"]).errors).toEqual(['Unknown option: "--typo"']);
+		expect(parseArgs(["document-creation", "threat-analysis"]).errors).toEqual([
+			"Expected one scenario, received: document-creation, threat-analysis",
+		]);
+		expect(parseArgs(["document-creation", "--list"]).errors).toContain(
+			"--list cannot be combined with a scenario or --headless",
+		);
+	});
+});
+
+describe("buildPlaywrightArgs", () => {
+	it("defaults to headed with exact grep and one worker", () => {
+		expect(buildPlaywrightArgs(SCENARIOS["document-creation"], { headless: false })).toEqual([
+			"test",
+			"e2e/new-model.spec.ts",
+			"--grep",
+			buildGrepPattern(SCENARIOS["document-creation"].titles),
+			"--workers=1",
+			"--headed",
+		]);
+	});
+
+	describe("runScenario orchestration", () => {
+		const execute = (playwrightStatus, manifestStatus) => {
+			const events = [];
+			const statuses = [playwrightStatus, manifestStatus];
+			const status = runScenario(
+				"document-creation",
+				{ headless: true },
+				{
+					remove: (target) => events.push({ kind: "remove", target }),
+					spawn: (command, args) => {
+						events.push({ kind: "spawn", command, args });
+						return { status: statuses.shift(), signal: null };
+					},
+					log: (message) => events.push({ kind: "log", message }),
+				},
+			);
+			return { events, status };
+		};
+
+		it("cleans both evidence roots, runs Playwright, then runs the manifest even when Playwright fails", () => {
+			const { events, status } = execute(7, 0);
+			const removes = events.filter((event) => event.kind === "remove");
+			const spawns = events.filter((event) => event.kind === "spawn");
+
+			expect(removes).toHaveLength(2);
+			expect(removes[0].target).toMatch(/test-results$/);
+			expect(removes[1].target).toMatch(/playwright-report$/);
+			expect(spawns).toHaveLength(2);
+			expect(spawns[0].args[0]).toMatch(/node_modules[/\\]@playwright[/\\]test[/\\]cli\.js$/);
+			expect(spawns[0].args).toContain("--workers=1");
+			expect(spawns[1].args).toEqual(["scripts/build-artifact-manifest.mjs"]);
+			expect(Math.max(...removes.map((event) => events.indexOf(event)))).toBeLessThan(
+				events.indexOf(spawns[0]),
+			);
+			expect(events.indexOf(spawns[0])).toBeLessThan(events.indexOf(spawns[1]));
+			expect(status).toBe(7);
+		});
+
+		it("returns the manifest failure when Playwright passes", () => {
+			expect(execute(0, 9).status).toBe(9);
+		});
+
+		it("returns success only when both subprocesses pass", () => {
+			expect(execute(0, 0).status).toBe(0);
+		});
+	});
+
+	it("omits --headed when --headless is requested", () => {
+		expect(buildPlaywrightArgs(SCENARIOS["document-creation"], { headless: true })).toEqual([
+			"test",
+			"e2e/new-model.spec.ts",
+			"--grep",
+			buildGrepPattern(SCENARIOS["document-creation"].titles),
+			"--workers=1",
+		]);
+	});
+
+	it("adds an end-anchored --grep alternation for a titled scenario", () => {
+		const args = buildPlaywrightArgs(SCENARIOS["import-export"], { headless: true });
+		expect(args[0]).toBe("test");
+		expect(args[1]).toBe("e2e/workspace-fixtures.spec.ts");
+		expect(args[2]).toBe("--grep");
+		expect(args[3]).toBe(buildGrepPattern(SCENARIOS["import-export"].titles));
+		expect(args[4]).toBe("--workers=1");
+	});
+
+	it("rejects an empty title allowlist", () => {
+		expect(() => buildGrepPattern([])).toThrow("at least one");
+	});
+});
+
+describe("each scenario resolves through the real Playwright CLI", () => {
+	for (const [name, scenario] of Object.entries(SCENARIOS)) {
+		it(`${name}: lists at least one real test with its exact file/title filter`, () => {
+			const retainedBefore = {
+				json: readIfPresent("test-results/results.json"),
+				html: readIfPresent("playwright-report/index.html"),
+			};
+			const args = [
+				...buildPlaywrightArgs(scenario, { headless: true }),
+				"--list",
+				"--reporter=line",
+			];
+			const result = spawnSync(process.execPath, [playwrightCli, ...args], {
+				cwd: repoRoot,
+				encoding: "utf8",
+			});
+			expect(result.status).toBe(0);
+			const listedTitles = result.stdout
+				.split("\n")
+				.filter((line) => line.includes(" › "))
+				.map((line) => line.split(" › ").at(-1)?.trim())
+				.filter((title) => title !== undefined);
+			expect(listedTitles).toHaveLength(scenario.titles.length);
+			expect(new Set(listedTitles)).toEqual(new Set(scenario.titles));
+			expect(result.stdout).toMatch(
+				new RegExp(`Total: ${scenario.titles.length} tests? in ${scenario.files.length} files?`),
+			);
+			expect(readIfPresent("test-results/results.json")).toEqual(retainedBefore.json);
+			expect(readIfPresent("playwright-report/index.html")).toEqual(retainedBefore.html);
+		});
+	}
+});
+
+describe("run-agent-scenario.mjs CLI", () => {
+	it("--list prints every scenario name and description without touching Playwright", () => {
+		const result = spawnSync(process.execPath, [launcherScriptPath, "--list"], {
+			cwd: repoRoot,
+			encoding: "utf8",
+		});
+		expect(result.status).toBe(0);
+		for (const [name, scenario] of Object.entries(SCENARIOS)) {
+			expect(result.stdout).toContain(name);
+			expect(result.stdout).toContain(scenario.description);
+		}
+	});
+
+	it("an unknown scenario name fails fast with the catalog, never invoking Playwright", () => {
+		const result = spawnSync(process.execPath, [launcherScriptPath, "not-a-real-scenario"], {
+			cwd: repoRoot,
+			encoding: "utf8",
+		});
+		expect(result.status).not.toBe(0);
+		expect(result.stderr).toContain('Unknown scenario: "not-a-real-scenario"');
+		for (const name of Object.keys(SCENARIOS)) {
+			expect(result.stderr).toContain(name);
+		}
+	});
+
+	for (const inheritedName of ["constructor", "__proto__"]) {
+		it(`rejects inherited object key "${inheritedName}" as an unknown scenario`, () => {
+			const result = spawnSync(process.execPath, [launcherScriptPath, inheritedName], {
+				cwd: repoRoot,
+				encoding: "utf8",
+			});
+			expect(result.status).not.toBe(0);
+			expect(result.stderr).toContain(`Unknown scenario: "${inheritedName}"`);
+			expect(result.stderr).toContain("Available scenarios:");
+			expect(result.stderr).not.toContain("TypeError");
+		});
+	}
+
+	it("no arguments fails fast with usage", () => {
+		const result = spawnSync(process.execPath, [launcherScriptPath], {
+			cwd: repoRoot,
+			encoding: "utf8",
+		});
+		expect(result.status).not.toBe(0);
+		expect(result.stderr).toContain("Usage:");
+	});
+});
+
+describe("cross-file consistency", () => {
+	it("package.json's test:e2e:agent script runs this exact launcher", () => {
+		const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+		expect(packageJson.scripts["test:e2e:agent"]).toBe("node scripts/run-agent-scenario.mjs");
+	});
+
+	it("the runbook documents exactly the same scenario names the launcher implements", () => {
+		const runbook = readFileSync(runbookPath, "utf8");
+		const catalogSection = runbook.split("## Scenario catalog")[1]?.split("## Starting")[0] ?? "";
+		const documentedNames = [...catalogSection.matchAll(/\| `([a-z-]+)` \|/g)].map((m) => m[1]);
+		expect(documentedNames.length).toBeGreaterThan(0);
+		expect(new Set(documentedNames)).toEqual(new Set(Object.keys(SCENARIOS)));
+	});
+
+	it("the runbook maps every scenario to exactly the same spec files", () => {
+		const runbook = readFileSync(runbookPath, "utf8");
+		const catalogSection = runbook.split("## Scenario catalog")[1]?.split("## Starting")[0] ?? "";
+		for (const [name, scenario] of Object.entries(SCENARIOS)) {
+			const row = catalogSection.split("\n").find((line) => line.startsWith(`| \`${name}\` |`));
+			expect(row, `runbook has no table row for ${name}`).toBeDefined();
+			const documentedFiles = [...(row ?? "").matchAll(/`(e2e\/[^`]+\.spec\.ts)`/g)].map(
+				(match) => match[1],
+			);
+			expect(new Set(documentedFiles), name).toEqual(new Set(scenario.files));
+		}
+	});
+
+	it("the runbook's artifact paths use the manifest builder's exported defaults", () => {
+		const runbook = readFileSync(runbookPath, "utf8");
+		expect(runbook).toContain(DEFAULT_REPORT_PATH);
+		expect(runbook).toContain(DEFAULT_MANIFEST_PATH);
+		expect(runbook).toContain("node scripts/build-artifact-manifest.mjs");
+	});
+
+	it("the CI E2E job runs Playwright, builds the manifest next, and uploads both report roots", () => {
+		const ci = load(readRepoFile(".github/workflows/ci.yml"));
+		const steps = ci.jobs.e2e.steps;
+		const playwrightIndex = steps.findIndex((step) => step.run === "npx playwright test");
+		const manifestIndex = steps.findIndex(
+			(step) => step.run === "node scripts/build-artifact-manifest.mjs",
+		);
+		const uploadIndex = steps.findIndex((step) => step.name === "Upload Playwright report");
+		const manifest = steps[manifestIndex];
+		const upload = steps[uploadIndex];
+		expect(playwrightIndex).toBeGreaterThan(-1);
+		expect(manifestIndex).toBeGreaterThan(playwrightIndex);
+		expect(uploadIndex).toBeGreaterThan(manifestIndex);
+		expect(manifest.if).toBe("always()");
+		expect(upload.if).toContain("failure()");
+		expect(upload.if).toContain("has-flaky");
+		expect(
+			upload.with.path
+				.split("\n")
+				.map((line) => line.trim())
+				.filter(Boolean),
+		).toEqual(["playwright-report/", "test-results/"]);
+	});
+
+	it("the runbook is discoverable from README and CONTRIBUTING", () => {
+		const runbookRelativePath = "docs/runbooks/running-agent-e2e-scenarios.md";
+		expect(existsSync(runbookPath)).toBe(true);
+		expect(readRepoFile("README.md")).toContain(runbookRelativePath);
+		expect(readRepoFile("CONTRIBUTING.md")).toContain(runbookRelativePath);
+	});
+
+	it("the E2E instructions apply to both the launcher and its binding runbook", () => {
+		const instructions = readRepoFile(".github/instructions/e2e.instructions.md");
+		const frontmatter = instructions.match(/^---\n([\s\S]*?)\n---/);
+		expect(frontmatter).not.toBeNull();
+		const metadata = load(frontmatter?.[1] ?? "");
+		const patterns = metadata.applyTo.split(",").map((pattern) => pattern.trim());
+		expect(patterns).toContain("scripts/run-agent-scenario*.mjs");
+		expect(patterns).toContain("docs/runbooks/running-agent-e2e-scenarios.md");
+	});
+});


### PR DESCRIPTION
Closes #67

## Summary

- add one stable `npm run test:e2e:agent -- <scenario>` command using the repository-pinned Playwright CLI, one worker, headed by default, and `--headless` when requested
- define seven exact outcome-oriented scenarios for document creation, multi-tab restore, import/export, threat analysis, native AI tools, browser release smoke, and successful visual evidence
- clear stale evidence before each run and always rebuild #66's artifact manifest, including after Playwright failure
- add strict argument/prototype safety, spawn/signal diagnostics, and exit-code precedence
- add a binding runbook covering scenario selection, real interactions, artifact inspection, on-demand path-backed screenshots, automated/manual defect reports, fake-data requirements, visual-quality limits, and browser/#68 desktop boundaries
- add structural drift enforcement across exact Playwright title sets, runbook file mappings, package script, E2E instruction frontmatter, CI step order/conditions/upload roots, README, and CONTRIBUTING

## Acceptance criteria

- [x] One documented command launches the correct browser mode and deterministic named scenario
- [x] Runbook covers navigation, click/drag/connect/edit/save/export/restore, screenshot/trace/console/accessibility/DOM/manifest evidence, and defect reporting
- [x] Scenario prompts describe user outcomes rather than implementation selectors
- [x] Critical flows include document creation, multi-tab restore, import/export, threat analysis, canned native AI tools, and an explicitly browser-only release smoke boundary
- [x] Evidence requirements forbid claiming visual quality from pass/fail alone
- [x] Local and CI reuse identical fixtures, project, browser app, one worker, artifact layout, and manifest command; documented differences are scope, headedness, retries/forbidOnly, and server reuse

## Verification

- `git diff --check` — passed
- `npx biome check .` — 337 files passed
- launcher/drift suite — 42/42 passed
- `npm run ci:local` — passed
- full Playwright — 107/107 passed
- all named scenarios headless — 3 + 3 + 3 + 2 + 4 + 10 + 7 tests passed
- headed `document-creation` scenario — 3/3 passed
- import/export manifest — exactly 3 scenario entries
- visual-evidence manifest — 7 path-backed screenshot entries
- real Playwright discovery uses `--reporter=line`, preserves prior JSON/HTML evidence, and matches exact scenario title sets

## Independent preflight

All applicable lanes were rerun after every must/should revision until convergence:

| Lane | Findings resolved | Final state |
|------|-------------------|-------------|
| PR reviewer | release/export scope, prototype-safe lookup, exact title contracts, one-worker execution, truthful CI differences, non-destructive discovery | Clean |
| Slop auditor | autosave round-trip wording, structured runbook/CI drift checks, successful visual evidence path, complete manual/automated defect report, applyTo scope, real orchestration tests | Clean |
| Security auditor | pinned local CLI/no network fallback, strict args, shell-free spawn, fixed cleanup roots, fake-key/provider isolation, browser/#68 boundary, temporary evidence cleanup | Clean |

Self-review additionally fixed stale-evidence reuse, empty title maps, unsupported flags, manifest spawn diagnostics, helper/fake-key overclaims, and cross-platform temporary screenshot cleanup.

## Owner validation

Owner judgment remains for runbook tone/completeness for agent readers, whether the browser-only release-smoke framing is sufficiently clear, usefulness of the on-demand screenshot recipe, and practical headed scenario ergonomics. Owner validation is deferred under the explicitly authorized autonomous run; it is recorded, not waived.