### PR TITLE
fix(a11y): make palette list keyboard-scrollable

### DIFF
--- a/docs/quality/e2e-visual-accessibility-rubric.md
+++ b/docs/quality/e2e-visual-accessibility-rubric.md
@@ -23,9 +23,9 @@ not claim any of them replace human visual review.
 
 `e2e/support/accessibility.ts`'s `KNOWN_ACCESSIBILITY_EXCEPTIONS` allowlists exact,
 pre-existing `{ ruleId, target }` node pairs — never a whole rule — each tied to its own tracking
-issue (`#218` contrast, `#219` palette scroll-region focusability, `#220` tablist structure). A new
-node under an already-allowlisted rule still fails the gate; only removing the fix from its
-tracking issue, or genuinely fixing the underlying UI, should ever shrink this list.
+issue (`#218` contrast, `#220` tablist structure). A new node under an already-allowlisted rule
+still fails the gate; only removing the fix from its tracking issue, or genuinely fixing the
+underlying UI, should ever shrink this list.
 
 ## What "automated" and "partially automated" actually verify
 

--- a/e2e/accessibility-audit.spec.ts
+++ b/e2e/accessibility-audit.spec.ts
@@ -19,12 +19,38 @@ import {
  * resulting page state (see `workspace-fixtures.ts`'s own doc comment on that fixture).
  */
 test.describe("Accessibility audit", () => {
-	test("pre-model welcome screen has no unexcepted serious/critical violations", async ({
+	test("pre-model component library is keyboard-scrollable with no unexcepted serious/critical violations", async ({
 		page,
 	}) => {
 		await installDeterministicClock(page);
 		await page.goto("/app");
 		await expect(page.getByTestId("empty-canvas")).toBeVisible();
+
+		const palette = page.getByTestId("component-palette");
+		const componentList = palette.getByRole("region", {
+			name: "Library components",
+			exact: true,
+		});
+		const categoryTabCount = await palette.getByRole("button").count();
+
+		await page.getByTestId("library-search").click();
+		for (let tab = 0; tab <= categoryTabCount; tab++) {
+			await page.keyboard.press("Tab");
+		}
+		await expect(componentList).toBeFocused();
+
+		const initialScroll = await componentList.evaluate((element) => ({
+			top: element.scrollTop,
+			height: element.scrollHeight,
+			viewportHeight: element.clientHeight,
+		}));
+		expect(initialScroll.height).toBeGreaterThan(initialScroll.viewportHeight);
+
+		await page.keyboard.press("ArrowDown");
+		await expect
+			.poll(() => componentList.evaluate((element) => element.scrollTop))
+			.toBeGreaterThan(initialScroll.top);
+
 		await assertNoSeriousAccessibilityViolations(page);
 	});
 

--- a/e2e/support/README.md
+++ b/e2e/support/README.md
@@ -45,7 +45,7 @@ restatement of that plan's reasoning.
     selector(s), `helpUrl`).
   - `KNOWN_ACCESSIBILITY_EXCEPTIONS`: exact `{ ruleId, target, issue }` node-level exceptions —
     never a whole rule ID — one entry per confirmed pre-existing violation, each tied to its own
-    tracking issue (`#218`, `#219`, `#220`; see
+    tracking issue (`#218`, `#220`; see
     `docs/quality/e2e-visual-accessibility-rubric.md`).
   - `assertNoSeriousAccessibilityViolations(page, opts?)`: the tier-2, explicit, opt-in assertion
     every accessibility-audit spec calls; fails only on a serious/critical violation with no

--- a/e2e/support/accessibility.ts
+++ b/e2e/support/accessibility.ts
@@ -87,8 +87,6 @@ export interface AccessibilityException {
  * - `color-contrast` (serious): the pre-model welcome screen's de-emphasized caption text, using
  *   Tailwind `text-muted-foreground/60` and `/40` opacity utilities — a deliberate low-emphasis
  *   design choice that fails strict WCAG AA contrast by construction. Tracked by #218.
- * - `scrollable-region-focusable` (serious): the component palette's scrollable list, present in
- *   every document state. Tracked by #219.
  * - `aria-required-children` (critical): the document tab strip's `role="tablist"` container,
  *   whose actual `role="tab"` children are one level deeper than axe-core expects, alongside
  *   sibling close/pin buttons per this repo's deliberate tab-accessibility design
@@ -105,11 +103,6 @@ export const KNOWN_ACCESSIBILITY_EXCEPTIONS: readonly AccessibilityException[] =
 	},
 	{ ruleId: "color-contrast", target: ".hover\\:text-muted-foreground", issue: 218 },
 	{ ruleId: "color-contrast", target: ".text-muted-foreground\\/40", issue: 218 },
-	{
-		ruleId: "scrollable-region-focusable",
-		target: ".overflow-y-auto.p-2.flex-1",
-		issue: 219,
-	},
 	{ ruleId: "aria-required-children", target: ".overscroll-x-contain", issue: 220 },
 ];
 

--- a/src/components/palette/component-palette.tsx
+++ b/src/components/palette/component-palette.tsx
@@ -124,7 +124,20 @@ export function ComponentPalette() {
 			)}
 
 			{/* Component list */}
-			<div className="flex-1 overflow-y-auto p-2">
+			<section
+				aria-label="Library components"
+				className="flex-1 overflow-y-auto p-2"
+				// biome-ignore lint/a11y/noNoninteractiveTabindex: a scrollable region must be focusable for keyboard access
+				tabIndex={0}
+				onKeyDown={(event) => {
+					if (
+						event.target === event.currentTarget &&
+						(event.key === "ArrowUp" || event.key === "ArrowDown")
+					) {
+						event.stopPropagation();
+					}
+				}}
+			>
 				<div className="flex flex-col gap-0.5">
 					{filteredComponents.map((comp) => (
 						<LibraryPaletteItem key={comp.id} component={comp} />
@@ -135,7 +148,7 @@ export function ComponentPalette() {
 						</p>
 					)}
 				</div>
-			</div>
+			</section>
 		</div>
 	);
 }


### PR DESCRIPTION
Closes #219

## Summary

- make the named component-library scroll region reachable through normal Tab order
- preserve native ArrowUp/ArrowDown scrolling by preventing the global canvas shortcut from handling keys targeted at the region
- retire only #219's exact axe exception and update the current exception inventories
- add an end-to-end regression that proves keyboard focus, real overflow, native scrolling, and the serious/critical axe gate

## Acceptance criteria

- [x] The component list is reachable by Tab and scrolls with ArrowDown once focused
- [x] The accessibility audit passes after removing #219's exact `scrollable-region-focusable` exception
- [x] Existing palette element interactions remain green

## Verification

- `npx playwright test e2e/accessibility-audit.spec.ts e2e/canvas-elements.spec.ts` — 10/10 passed
- targeted Biome and TypeScript checks — passed
- `git diff --check` — passed
- `npm run ci:local` — passed (1,909 Vitest tests; 171 Cargo tests with 169 passed and 1 ignored; web build and Worker dry-run passed)

## Independent preflight

| Lane | Revision | Final state |
|---|---|---|
| PR reviewer | Removed stale #219 entries from both current exception inventories | Clean |
| Slop auditor | Removed the same current-state documentation drift; preserved historical plan evidence | Clean |

Security and threat-model specialist lanes do not apply: this change touches no trust boundary, IPC, file I/O, cryptography, AI, release path, `.thf` schema, STRIDE logic, or threat generation.

## Owner validation

Confirm the component-library region appears in a sensible Tab position, has an acceptable visible focus indicator in both themes, and scrolls naturally with ArrowUp/ArrowDown without moving the canvas or a selected node.