### PR TITLE
fix(a11y): enforce empty-canvas contrast

### DIFF
--- a/docs/quality/e2e-visual-accessibility-rubric.md
+++ b/docs/quality/e2e-visual-accessibility-rubric.md
@@ -23,9 +23,9 @@ not claim any of them replace human visual review.
 
 `e2e/support/accessibility.ts`'s `KNOWN_ACCESSIBILITY_EXCEPTIONS` allowlists exact,
 pre-existing `{ ruleId, target }` node pairs — never a whole rule — each tied to its own tracking
-issue (`#218` contrast, `#220` tablist structure). A new node under an already-allowlisted rule
-still fails the gate; only removing the fix from its tracking issue, or genuinely fixing the
-underlying UI, should ever shrink this list.
+issue (`#220` tablist structure). A new node under an already-allowlisted rule still fails the gate;
+only removing the fix from its tracking issue, or genuinely fixing the underlying UI, should ever
+shrink this list.
 
 ## What "automated" and "partially automated" actually verify
 

--- a/e2e/accessibility-audit.spec.ts
+++ b/e2e/accessibility-audit.spec.ts
@@ -1,5 +1,6 @@
+import { THEME_PRESETS } from "@/lib/themes/presets";
 import { expect, test } from "./fixtures";
-import { assertNoSeriousAccessibilityViolations } from "./support/accessibility";
+import { assertNoSeriousAccessibilityViolations, scanAccessibility } from "./support/accessibility";
 import { installDeterministicClock } from "./support/base";
 import {
 	seedEmptyWorkspace,
@@ -8,17 +9,117 @@ import {
 } from "./support/workspace-fixtures";
 
 /**
- * Tier-2, explicit accessibility gate (issue #66, D4/step 4). Every test here calls
+ * Tier-2, explicit accessibility gate (issue #66, D4/step 4). State audits call
  * `assertNoSeriousAccessibilityViolations` against the default `KNOWN_ACCESSIBILITY_EXCEPTIONS`
- * allowlist, so a passing run proves no unexcepted serious/critical violation exists. Exact-match
- * unit coverage prevents rule-wide exceptions; tracked issues and owner review retire stale
- * exceptions when their underlying live violation is fixed.
+ * allowlist; focused regressions use the same scanner and require complete axe passes for their
+ * exact targets. Exact-match unit coverage prevents rule-wide exceptions; tracked issues and owner
+ * review retire stale exceptions when their underlying live violation is fixed.
  *
  * `seedMalformedWorkspace` is intentionally not covered: its failure surfaces through a native
  * `window.alert` dialog that this suite's dialog listener dismisses before axe can inspect any
  * resulting page state (see `workspace-fixtures.ts`'s own doc comment on that fixture).
  */
 test.describe("Accessibility audit", () => {
+	test("issue #218's four empty-canvas targets pass contrast in every built-in theme", async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 1280, height: 900 });
+		await installDeterministicClock(page);
+		await page.goto("/app");
+		await expect(page.getByTestId("empty-canvas")).toBeVisible();
+
+		const targetSelector = '[data-testid="empty-canvas-contrast-target"]';
+		const targets = page.locator(targetSelector);
+		await expect(targets).toHaveCount(4);
+
+		for (const preset of Object.values(THEME_PRESETS)) {
+			await test.step(preset.name, async () => {
+				await page.getByTestId("btn-settings-dialog").click();
+				const settings = page.getByTestId("settings-dialog");
+				await settings.getByRole("button", { name: "Appearance", exact: true }).click();
+				await settings
+					.getByRole("button", {
+						name: preset.mode === "dark" ? "Dark" : "Light",
+						exact: true,
+					})
+					.click();
+				await settings.getByRole("button", { name: preset.name, exact: true }).click();
+				await page.keyboard.press("Escape");
+				await expect(settings).toBeHidden();
+				await page.mouse.move(0, 0);
+
+				await expect
+					.poll(
+						() =>
+							page.evaluate(() => ({
+								background: document.documentElement.style
+									.getPropertyValue("--color-background")
+									.trim(),
+								foreground: document.documentElement.style
+									.getPropertyValue("--color-foreground")
+									.trim(),
+							})),
+						{ message: `${preset.name} should be the active theme before its contrast scan` },
+					)
+					.toEqual({
+						background: preset.tokens.background,
+						foreground: preset.tokens.foreground,
+					});
+
+				await expect
+					.poll(
+						() =>
+							targets.evaluateAll(
+								(elements) =>
+									new Set(
+										elements.map((element) => {
+											const style = getComputedStyle(element);
+											return `${style.color}|${style.opacity}`;
+										}),
+									).size,
+							),
+						{ message: `${preset.name} should apply one settled treatment to all four nodes` },
+					)
+					.toBe(1);
+
+				const result = await scanAccessibility(page, { include: [targetSelector] });
+				const contrastFailures = [...result.violations, ...result.incomplete]
+					.filter((violation) => violation.id === "color-contrast")
+					.flatMap((violation) => violation.nodes.map((node) => node.target.join(" > ")));
+				expect(
+					contrastFailures,
+					`${preset.name} should have no failed or incomplete color-contrast results`,
+				).toEqual([]);
+
+				const contrastPass = result.passes.find((entry) => entry.id === "color-contrast");
+				expect(
+					contrastPass?.nodes,
+					`${preset.name} should produce four measured color-contrast passes`,
+				).toHaveLength(4);
+
+				const restingOpacities = await targets.evaluateAll((elements) =>
+					elements.map((element) => Number.parseFloat(getComputedStyle(element).opacity)),
+				);
+				expect(
+					restingOpacities.every((opacity) => opacity > 0 && opacity < 1),
+					`${preset.name} secondary text should remain de-emphasized`,
+				).toBe(true);
+			});
+		}
+
+		const githubButton = page.locator('button[data-testid="empty-canvas-contrast-target"]');
+		const restingOpacity = Number.parseFloat(
+			await githubButton.evaluate((element) => getComputedStyle(element).opacity),
+		);
+		await githubButton.hover();
+		await expect
+			.poll(() =>
+				githubButton.evaluate((element) => Number.parseFloat(getComputedStyle(element).opacity)),
+			)
+			.toBe(1);
+		expect(restingOpacity).toBeLessThan(1);
+	});
+
 	test("pre-model component library is keyboard-scrollable with no unexcepted serious/critical violations", async ({
 		page,
 	}) => {

--- a/e2e/support/README.md
+++ b/e2e/support/README.md
@@ -45,8 +45,7 @@ restatement of that plan's reasoning.
     selector(s), `helpUrl`).
   - `KNOWN_ACCESSIBILITY_EXCEPTIONS`: exact `{ ruleId, target, issue }` node-level exceptions —
     never a whole rule ID — one entry per confirmed pre-existing violation, each tied to its own
-    tracking issue (`#218`, `#220`; see
-    `docs/quality/e2e-visual-accessibility-rubric.md`).
+    tracking issue (`#220`; see `docs/quality/e2e-visual-accessibility-rubric.md`).
   - `assertNoSeriousAccessibilityViolations(page, opts?)`: the tier-2, explicit, opt-in assertion
     every accessibility-audit spec calls; fails only on a serious/critical violation with no
     matching exact-target exception.

--- a/e2e/support/accessibility.ts
+++ b/e2e/support/accessibility.ts
@@ -28,14 +28,18 @@ type AccessibilityViolationNode = AccessibilityViolation["nodes"][number];
 
 /**
  * Run an axe-core scan against the current page. This is the sole AxeBuilder integration point;
- * extend its options when scoped scanning gains a real caller instead of constructing AxeBuilder
- * in another module.
+ * optional `include` selectors scope a scan to specific regression targets without changing the
+ * full-page default used by the accessibility gate.
  */
 export function scanAccessibility(
 	page: Page,
-	opts?: { tags?: string[] },
+	opts?: { tags?: string[]; include?: readonly string[] },
 ): Promise<AxeAnalyzeResult> {
-	return new AxeBuilder({ page }).withTags(opts?.tags ?? ["wcag2a", "wcag2aa"]).analyze();
+	const builder = new AxeBuilder({ page }).withTags(opts?.tags ?? ["wcag2a", "wcag2aa"]);
+	for (const selector of opts?.include ?? []) {
+		builder.include(selector);
+	}
+	return builder.analyze();
 }
 
 /** The exact normalized axe target selector this module matches exceptions against everywhere. */
@@ -84,9 +88,6 @@ export interface AccessibilityException {
  * over from the plan's earlier 4.10.2 probe. Each entry is one exact node target, never a whole
  * rule id: a new node under the same rule elsewhere still fails.
  *
- * - `color-contrast` (serious): the pre-model welcome screen's de-emphasized caption text, using
- *   Tailwind `text-muted-foreground/60` and `/40` opacity utilities — a deliberate low-emphasis
- *   design choice that fails strict WCAG AA contrast by construction. Tracked by #218.
  * - `aria-required-children` (critical): the document tab strip's `role="tablist"` container,
  *   whose actual `role="tab"` children are one level deeper than axe-core expects, alongside
  *   sibling close/pin buttons per this repo's deliberate tab-accessibility design
@@ -95,14 +96,6 @@ export interface AccessibilityException {
  *   recorded on its tracking issue rather than resolved here. Tracked by #220.
  */
 export const KNOWN_ACCESSIBILITY_EXCEPTIONS: readonly AccessibilityException[] = [
-	{ ruleId: "color-contrast", target: ".mb-3", issue: 218 },
-	{
-		ruleId: "color-contrast",
-		target: ".bottom-0 > .text-muted-foreground\\/60:nth-child(1)",
-		issue: 218,
-	},
-	{ ruleId: "color-contrast", target: ".hover\\:text-muted-foreground", issue: 218 },
-	{ ruleId: "color-contrast", target: ".text-muted-foreground\\/40", issue: 218 },
 	{ ruleId: "aria-required-children", target: ".overscroll-x-contain", issue: 220 },
 ];
 

--- a/src/components/canvas/canvas.tsx
+++ b/src/components/canvas/canvas.tsx
@@ -91,7 +91,10 @@ function EmptyCanvas() {
 
 				{/* Templates */}
 				<div className="mt-8 w-full max-w-2xl">
-					<p className="mb-3 text-center text-xs font-medium uppercase tracking-wider text-muted-foreground/60">
+					<p
+						data-testid="empty-canvas-contrast-target"
+						className="mb-3 text-center text-xs font-medium uppercase tracking-wider text-foreground opacity-95"
+					>
 						Start from a template
 					</p>
 					<div className="grid grid-cols-3 gap-2">
@@ -108,18 +111,29 @@ function EmptyCanvas() {
 
 			{/* Footer */}
 			<footer className="absolute bottom-0 left-0 right-0 flex items-center justify-center gap-4 border-t border-border/50 px-4 py-3">
-				<span className="text-xs text-muted-foreground/60">Built by Exit Zero Labs LLC</span>
+				<span
+					data-testid="empty-canvas-contrast-target"
+					className="text-xs text-foreground opacity-95"
+				>
+					Built by Exit Zero Labs LLC
+				</span>
 				<span className="text-muted-foreground/30">·</span>
 				<button
 					type="button"
 					onClick={() => void openExternalUrl("https://github.com/exit-zero-labs/threat-forge")}
-					className="flex items-center gap-1 text-xs text-muted-foreground/60 transition-colors hover:text-muted-foreground"
+					data-testid="empty-canvas-contrast-target"
+					className="flex items-center gap-1 text-xs text-foreground opacity-95 transition-opacity hover:opacity-100"
 				>
 					<GithubIcon className="h-3 w-3" />
 					GitHub
 				</button>
 				<span className="text-muted-foreground/30">·</span>
-				<span className="text-xs text-muted-foreground/40">v{__APP_VERSION__ ?? "dev"}</span>
+				<span
+					data-testid="empty-canvas-contrast-target"
+					className="text-xs text-foreground opacity-95"
+				>
+					v{__APP_VERSION__ ?? "dev"}
+				</span>
 			</footer>
 		</div>
 	);


### PR DESCRIPTION
Closes #218

## Summary

- replace the four accepted pre-model caption/footer treatments with theme foreground at 95% opacity, preserving measurable de-emphasis while meeting WCAG AA
- strengthen the GitHub footer control to full foreground opacity on hover
- retire only #218's four exact axe exceptions and update the current exception inventories
- verify the four targets across all 15 built-in themes through the real settings UI and scoped axe scans

## Acceptance criteria

- [x] All four accepted 12px targets meet or exceed 4.5:1 in every built-in theme
- [x] The targets remain de-emphasized relative to each theme's primary foreground
- [x] The accessibility gate passes after retiring #218's exact exceptions
- [x] No unrelated theme token, canvas copy, or visual baseline is changed

Minimum measured contrast is 4.88:1 in Solarized Light, versus 5.42:1 at full foreground opacity.

## Verification

- all-theme contrast regression repeated serially — 5/5 passed
- full accessibility audit/support coverage — 19/19 passed
- targeted Biome, frontend TypeScript, and E2E TypeScript — passed
- `git diff --check` — passed
- `npm run ci:local` — passed (1,909 frontend tests; 169 Rust tests passed and 1 ignored; web build and Worker dry-run passed)

## Independent preflight

Both applicable lanes were rerun after each revision until convergence:

| Lane | Findings resolved | Final state |
|---|---|---|
| PR reviewer | default-token failure in six themes; nondeterministic footer overlap at 1280×720; missing proof that each preset applied | Clean |
| Slop auditor | same all-theme gap and test race; stale broad claim that omitted a separate rotating-tip contrast defect | Clean |

Security and threat-model lanes do not apply: this change touches no trust boundary, IPC, file I/O, cryptography, AI, release path, `.thf` schema, STRIDE logic, or threat generation.

## Follow-up scope

- #224 tracks the pre-existing rotating-tip/footer overlap at 1280×720.
- #225 tracks the separate rotating-tip text contrast failure.

Neither defect is silently folded into #218's explicitly enumerated four-node contract.

## Owner validation

Inspect representative light and dark presets to confirm the 95% foreground treatment still reads as secondary, the GitHub hover affordance is appropriately stronger, and the four caption/footer targets remain visually coherent with the rest of the welcome screen.