### PR TITLE
fix(a11y): correct rotating tip contrast

### DIFF
--- a/e2e/accessibility-audit.spec.ts
+++ b/e2e/accessibility-audit.spec.ts
@@ -1,3 +1,4 @@
+import type { Page } from "@playwright/test";
 import { THEME_PRESETS } from "@/lib/themes/presets";
 import { expect, test } from "./fixtures";
 import { assertNoSeriousAccessibilityViolations, scanAccessibility } from "./support/accessibility";
@@ -7,6 +8,19 @@ import {
 	seedEphemeralWorkspace,
 	seedRealisticWorkspace,
 } from "./support/workspace-fixtures";
+
+async function setReduceMotion(page: Page, enabled: boolean): Promise<void> {
+	await page.getByTestId("btn-settings-dialog").click();
+	const settings = page.getByTestId("settings-dialog");
+	await settings.getByRole("button", { name: "Appearance", exact: true }).click();
+	const toggle = settings.getByTestId("toggle-reduce-motion");
+	if ((await toggle.getAttribute("aria-checked")) !== String(enabled)) {
+		await toggle.click();
+	}
+	await expect(toggle).toHaveAttribute("aria-checked", String(enabled));
+	await page.keyboard.press("Escape");
+	await expect(settings).toBeHidden();
+}
 
 /**
  * Tier-2, explicit accessibility gate (issue #66, D4/step 4). State audits call
@@ -20,7 +34,7 @@ import {
  * resulting page state (see `workspace-fixtures.ts`'s own doc comment on that fixture).
  */
 test.describe("Accessibility audit", () => {
-	test("issue #218's four empty-canvas targets pass contrast in every built-in theme", async ({
+	test("issue #218's four empty-canvas targets and the rotating tip pass contrast in every built-in theme", async ({
 		page,
 	}) => {
 		await page.setViewportSize({ width: 1280, height: 900 });
@@ -31,11 +45,28 @@ test.describe("Accessibility audit", () => {
 		const targetSelector = '[data-testid="empty-canvas-contrast-target"]';
 		const targets = page.locator(targetSelector);
 		await expect(targets).toHaveCount(4);
+		const tipSelector = '[data-testid="rotating-tip-contrast-target"]';
+		const tip = page.locator(tipSelector);
+		await expect(tip).toBeVisible();
+
+		await setReduceMotion(page, true);
+		const settings = page.getByTestId("settings-dialog");
+
+		const reducedMotionTip = await tip.innerText();
+		await page.clock.runFor(7400);
+		await expect(tip).toHaveText(reducedMotionTip);
+		await expect
+			.poll(() =>
+				tip.evaluate((element) => ({
+					opacity: getComputedStyle(element).opacity,
+					transition: element.style.transition,
+				})),
+			)
+			.toEqual({ opacity: "1", transition: "none" });
 
 		for (const preset of Object.values(THEME_PRESETS)) {
 			await test.step(preset.name, async () => {
 				await page.getByTestId("btn-settings-dialog").click();
-				const settings = page.getByTestId("settings-dialog");
 				await settings.getByRole("button", { name: "Appearance", exact: true }).click();
 				await settings
 					.getByRole("button", {
@@ -82,7 +113,25 @@ test.describe("Accessibility audit", () => {
 					)
 					.toBe(1);
 
-				const result = await scanAccessibility(page, { include: [targetSelector] });
+				await expect(tip).toBeVisible();
+				const tipHierarchy = await tip.evaluate((element) => {
+					const heading = document.querySelector('[data-testid="empty-canvas"] h2');
+					const style = getComputedStyle(element);
+					const headingStyle = heading ? getComputedStyle(heading) : null;
+					return {
+						fontSize: Number.parseFloat(style.fontSize),
+						headingFontSize: headingStyle ? Number.parseFloat(headingStyle.fontSize) : null,
+					};
+				});
+				expect(tipHierarchy.headingFontSize).not.toBeNull();
+				expect(
+					tipHierarchy.fontSize,
+					`${preset.name} tip should remain subordinate to the primary heading`,
+				).toBeLessThan(tipHierarchy.headingFontSize ?? 0);
+
+				const result = await scanAccessibility(page, {
+					include: [`${targetSelector}, ${tipSelector}`],
+				});
 				const contrastFailures = [...result.violations, ...result.incomplete]
 					.filter((violation) => violation.id === "color-contrast")
 					.flatMap((violation) => violation.nodes.map((node) => node.target.join(" > ")));
@@ -94,8 +143,8 @@ test.describe("Accessibility audit", () => {
 				const contrastPass = result.passes.find((entry) => entry.id === "color-contrast");
 				expect(
 					contrastPass?.nodes,
-					`${preset.name} should produce four measured color-contrast passes`,
-				).toHaveLength(4);
+					`${preset.name} should produce five measured color-contrast passes`,
+				).toHaveLength(5);
 
 				const restingOpacities = await targets.evaluateAll((elements) =>
 					elements.map((element) => Number.parseFloat(getComputedStyle(element).opacity)),
@@ -118,6 +167,50 @@ test.describe("Accessibility audit", () => {
 			)
 			.toBe(1);
 		expect(restingOpacity).toBeLessThan(1);
+	});
+
+	test("rotating tip keeps its seven-second interval and 400ms fade", async ({ page }) => {
+		await installDeterministicClock(page);
+		await page.goto("/app");
+
+		const tip = page.getByTestId("rotating-tip-contrast-target");
+		await expect(tip).toBeVisible();
+		await setReduceMotion(page, true);
+		const initialTip = await tip.innerText();
+		await page.clock.pauseAt(await page.evaluate(() => Date.now() + 1000));
+		await setReduceMotion(page, false);
+		await expect
+			.poll(() =>
+				tip.evaluate((element) => {
+					const style = getComputedStyle(element);
+					return {
+						opacity: style.opacity,
+						transitionDuration: style.transitionDuration,
+						transitionProperty: style.transitionProperty,
+					};
+				}),
+			)
+			.toEqual({
+				opacity: "1",
+				transitionDuration: "0.4s",
+				transitionProperty: "opacity",
+			});
+
+		await page.clock.runFor(6999);
+		await expect(tip).toHaveText(initialTip);
+		expect(await tip.evaluate((element) => element.style.opacity)).toBe("1");
+
+		await page.clock.runFor(1);
+		await expect.poll(() => tip.evaluate((element) => element.style.opacity)).toBe("0");
+		await expect(tip).toHaveText(initialTip);
+		await page.clock.runFor(399);
+		await expect(tip).toHaveText(initialTip);
+
+		await page.clock.runFor(1);
+		await expect(tip).not.toHaveText(initialTip);
+		await expect.poll(() => tip.evaluate((element) => element.style.opacity)).toBe("1");
+		await page.clock.runFor(400);
+		await expect.poll(() => tip.evaluate((element) => getComputedStyle(element).opacity)).toBe("1");
 	});
 
 	test("pre-model component library is keyboard-scrollable with no unexcepted serious/critical violations", async ({

--- a/src/components/canvas/canvas.tsx
+++ b/src/components/canvas/canvas.tsx
@@ -215,7 +215,8 @@ function RotatingTip() {
 
 	return (
 		<p
-			className="text-center text-xs italic text-muted-foreground/60"
+			data-testid="rotating-tip-contrast-target"
+			className="text-center text-xs italic text-foreground"
 			style={{
 				opacity: visible ? 1 : 0,
 				transition: reduceMotion ? "none" : "opacity 400ms ease-in-out",

--- a/src/components/panels/settings-dialog.tsx
+++ b/src/components/panels/settings-dialog.tsx
@@ -230,6 +230,7 @@ function AppearanceSection() {
 				<ToggleSwitch
 					checked={settings.reduceMotion}
 					onChange={(v) => updateSetting("reduceMotion", v)}
+					testId="toggle-reduce-motion"
 				/>
 			</SettingRow>
 
@@ -448,15 +449,18 @@ function SettingRow({
 function ToggleSwitch({
 	checked,
 	onChange,
+	testId,
 }: {
 	checked: boolean;
 	onChange: (value: boolean) => void;
+	testId?: string;
 }) {
 	return (
 		<button
 			type="button"
 			role="switch"
 			aria-checked={checked}
+			data-testid={testId}
 			onClick={() => onChange(!checked)}
 			className={cn(
 				"relative h-5 w-9 shrink-0 rounded-full transition-colors",


### PR DESCRIPTION
Closes #225

## Summary

- render the rotating tip with the opaque theme foreground so axe can measure it while the existing inline opacity remains dedicated to the fade animation
- extend the scoped all-theme regression from #218 to require five measured passes, including the tip, in every built-in preset
- deterministically verify the seven-second interval, 400ms fade, non-repeating tip swap, and reduced-motion behavior
- add a direct, idempotent test seam for the reduce-motion setting

## Acceptance criteria

- [x] The rotating tip meets WCAG AA in all 15 built-in themes (minimum 5.42:1 in Solarized Light)
- [x] Its 12px italic hierarchy remains subordinate to the primary heading
- [x] All tip variants retain the existing timing, fade, swap, and reduced-motion behavior
- [x] The separate 1280×720 overlap tracked by #224 remains out of scope

## Verification

- accessibility audit — 7/7 passed
- all-theme regression repeated serially — 3/3 passed
- animation regression repeated serially — 5/5 passed
- settings dialog regression — 8/8 passed
- targeted Biome and frontend/E2E TypeScript — passed
- `git diff --check` — passed
- `npm run ci:local` — passed (1,909 frontend tests; 169 Rust tests plus 3 MCP tests; web build and Worker dry-run passed)

## Independent preflight

Both applicable lanes were rerun after the should-fix revision until convergence:

| Lane | Findings resolved | Final state |
|---|---|---|
| PR reviewer | Confirmed all-theme contrast and deterministic timer/fade/reduced-motion behavior | Clean |
| Slop auditor | Replaced brittle parent traversal and assumed toggle state; removed exact class restatements and raw axe HTML filtering | Clean |

Security and threat-model lanes do not apply: this change touches no trust boundary, IPC, file I/O, cryptography, AI, release path, `.thf` schema, STRIDE logic, or threat generation.

## Owner validation

Inspect representative light and dark presets to confirm the 12px italic tip still reads as secondary despite using the full foreground color, and observe one normal rotation plus reduced-motion mode to validate the animation feels unchanged.