### PR TITLE
fix(a11y): keep welcome footer visible

### DIFF
--- a/e2e/accessibility-audit.spec.ts
+++ b/e2e/accessibility-audit.spec.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test";
 import { THEME_PRESETS } from "@/lib/themes/presets";
+import { TIPS } from "@/lib/tips";
 import { expect, test } from "./fixtures";
 import { assertNoSeriousAccessibilityViolations, scanAccessibility } from "./support/accessibility";
 import { installDeterministicClock } from "./support/base";
@@ -211,6 +212,130 @@ test.describe("Accessibility audit", () => {
 		await expect.poll(() => tip.evaluate((element) => element.style.opacity)).toBe("1");
 		await page.clock.runFor(400);
 		await expect.poll(() => tip.evaluate((element) => getComputedStyle(element).opacity)).toBe("1");
+	});
+
+	test("every canonical rotating tip stays above the usable footer at 1280x720", async ({
+		page,
+	}) => {
+		test.slow();
+		await page.setViewportSize({ width: 1280, height: 720 });
+		await installDeterministicClock(page);
+		await page.goto("/app");
+		await expect(page.getByTestId("empty-canvas")).toBeVisible();
+		await setReduceMotion(page, true);
+		await page.addInitScript((tipCount) => {
+			const nativeRandom = Math.random;
+			Math.random = () => {
+				const rawIndex = new URL(window.location.href).searchParams.get("e2eTipIndex");
+				const requestedIndex = rawIndex === null ? -1 : Number(rawIndex);
+				if (!Number.isInteger(requestedIndex) || requestedIndex < 0 || requestedIndex >= tipCount) {
+					return nativeRandom();
+				}
+				return (requestedIndex + 0.5) / tipCount;
+			};
+		}, TIPS.length);
+
+		const tipSelector = '[data-testid="rotating-tip-contrast-target"]';
+		const footerTargetSelector =
+			'[data-testid="empty-canvas"] > footer [data-testid="empty-canvas-contrast-target"]';
+
+		for (const [index, expectedTip] of TIPS.entries()) {
+			await test.step(`tip ${index + 1} of ${TIPS.length}`, async () => {
+				await page.goto(`/app?e2eTipIndex=${index}`);
+				const emptyCanvas = page.getByTestId("empty-canvas");
+				const tip = page.locator(tipSelector);
+				const footer = emptyCanvas.locator("footer");
+				await expect(emptyCanvas).toBeVisible();
+				await expect(tip).toHaveText(expectedTip);
+				await expect.poll(() => tip.evaluate((element) => element.style.transition)).toBe("none");
+
+				const emptyCanvasBox = await emptyCanvas.boundingBox();
+				const tipBox = await tip.boundingBox();
+				const footerBox = await footer.boundingBox();
+				expect(
+					emptyCanvasBox,
+					`${expectedTip}: empty canvas should have rendered geometry`,
+				).not.toBeNull();
+				expect(tipBox, `${expectedTip}: tip should have rendered geometry`).not.toBeNull();
+				expect(footerBox, `${expectedTip}: footer should have rendered geometry`).not.toBeNull();
+				if (!emptyCanvasBox || !tipBox || !footerBox) return;
+				expect(
+					footerBox.y + footerBox.height,
+					`${expectedTip}: footer should remain inside the empty canvas`,
+				).toBeLessThanOrEqual(emptyCanvasBox.y + emptyCanvasBox.height);
+				expect(
+					tipBox.y + tipBox.height,
+					`${expectedTip}: tip bottom should not cross footer top`,
+				).toBeLessThanOrEqual(footerBox.y);
+
+				const result = await scanAccessibility(page, {
+					include: [`${tipSelector}, ${footerTargetSelector}`],
+				});
+				expect(
+					result.incomplete.map((entry) => entry.id),
+					`${expectedTip}: tip/footer axe results should be complete`,
+				).toEqual([]);
+				expect(
+					result.violations
+						.filter((entry) => entry.id === "color-contrast")
+						.flatMap((entry) => entry.nodes.map((node) => node.target.join(" > "))),
+					`${expectedTip}: tip/footer targets should pass color contrast`,
+				).toEqual([]);
+				expect(
+					result.passes.find((entry) => entry.id === "color-contrast")?.nodes,
+					`${expectedTip}: axe should measure all four tip/footer contrast targets`,
+				).toHaveLength(4);
+			});
+		}
+
+		const longestTip = TIPS.reduce((longest, tip) => (tip.length > longest.length ? tip : longest));
+		const longestTipIndex = TIPS.indexOf(longestTip);
+		for (const height of [800, 851]) {
+			await test.step(`longest tip stays contained at 1280x${height}`, async () => {
+				await page.setViewportSize({ width: 1280, height });
+				await page.goto(`/app?e2eTipIndex=${longestTipIndex}`);
+
+				const emptyCanvas = page.getByTestId("empty-canvas");
+				const tip = page.locator(tipSelector);
+				const footer = emptyCanvas.locator("footer");
+				await expect(tip).toHaveText(longestTip);
+
+				const emptyCanvasBox = await emptyCanvas.boundingBox();
+				const tipBox = await tip.boundingBox();
+				const footerBox = await footer.boundingBox();
+				expect(emptyCanvasBox).not.toBeNull();
+				expect(tipBox).not.toBeNull();
+				expect(footerBox).not.toBeNull();
+				if (!emptyCanvasBox || !tipBox || !footerBox) return;
+				expect(footerBox.y + footerBox.height).toBeLessThanOrEqual(
+					emptyCanvasBox.y + emptyCanvasBox.height,
+				);
+				expect(tipBox.y + tipBox.height).toBeLessThanOrEqual(footerBox.y);
+			});
+		}
+
+		const emptyCanvas = page.getByTestId("empty-canvas");
+		const footer = emptyCanvas.locator("footer");
+		const githubButton = footer.getByRole("button", { name: /GitHub/ });
+		await expect(githubButton).toBeEnabled();
+		// Exercise the real window.open path without making the regression depend on GitHub uptime.
+		await page
+			.context()
+			.route(/^https:\/\/github\.com\/exit-zero-labs\/threat-forge\/?$/, (route) =>
+				route.fulfill({ status: 200, contentType: "text/html", body: "" }),
+			);
+		const popupPromise = page.waitForEvent("popup");
+		await githubButton.click();
+		const popup = await popupPromise;
+		await expect(popup).toHaveURL(/^https:\/\/github\.com\/exit-zero-labs\/threat-forge\/?$/);
+		await popup.close();
+
+		const templateButton = emptyCanvas.getByRole("button", { name: /E-Commerce Platform/ });
+		await expect(templateButton).toBeEnabled();
+		await templateButton.click();
+		await expect(emptyCanvas).toBeHidden();
+		await expect(page.getByTestId("canvas-area")).toBeVisible();
+		await expect(page.locator(".react-flow__node").first()).toBeVisible();
 	});
 
 	test("pre-model component library is keyboard-scrollable with no unexcepted serious/critical violations", async ({

--- a/src/components/canvas/canvas.tsx
+++ b/src/components/canvas/canvas.tsx
@@ -57,19 +57,20 @@ function EmptyCanvas() {
 	}, []);
 
 	return (
-		<div
-			data-testid="empty-canvas"
-			className="relative flex h-full flex-col items-center bg-background"
-		>
+		<div data-testid="empty-canvas" className="flex h-full flex-col items-center bg-background">
 			{/* Main content — centered with upward bias */}
-			<div className="flex flex-1 flex-col items-center justify-center pb-16">
-				<img src="/logo_square.png" alt="Threat Forge" className="mb-6 h-20 w-20 drop-shadow-md" />
+			<div className="flex flex-1 flex-col items-center justify-center pb-16 [@media(max-height:850px)]:pb-0">
+				<img
+					src="/logo_square.png"
+					alt="Threat Forge"
+					className="mb-6 h-20 w-20 drop-shadow-md [@media(max-height:850px)]:mb-3 [@media(max-height:850px)]:h-16 [@media(max-height:850px)]:w-16"
+				/>
 				<h2 className="text-xl font-semibold tracking-tight">Threat Forge</h2>
 				<p className="mt-2 max-w-sm text-center text-sm text-muted-foreground">
 					Create a new threat model or open an existing one to get started.
 				</p>
 
-				<div className="mt-6 flex gap-3">
+				<div className="mt-6 flex gap-3 [@media(max-height:850px)]:mt-4">
 					<button
 						type="button"
 						data-testid="btn-empty-new"
@@ -104,13 +105,13 @@ function EmptyCanvas() {
 					</div>
 				</div>
 
-				<div className="mt-8 h-12 max-w-md">
+				<div className="mt-8 h-12 max-w-md [@media(max-height:850px)]:mt-4 [@media(max-height:850px)]:h-8">
 					<RotatingTip />
 				</div>
 			</div>
 
 			{/* Footer */}
-			<footer className="absolute bottom-0 left-0 right-0 flex items-center justify-center gap-4 border-t border-border/50 px-4 py-3">
+			<footer className="flex w-full shrink-0 items-center justify-center gap-4 border-t border-border/50 px-4 py-3">
 				<span
 					data-testid="empty-canvas-contrast-target"
 					className="text-xs text-foreground opacity-95"


### PR DESCRIPTION
Closes #224

## Summary

- move the welcome footer into normal flex flow so it reserves space instead of overlaying the rotating tip
- compact only the measured short-height properties through 850px while preserving the regular layout above that boundary
- deterministically render every canonical tip at 1280x720 and prove the tip, footer, and footer text remain inside the actual empty-canvas bounds
- cover the configured 1280x800 desktop height and 851px immediately above the compact breakpoint
- retain axe completeness/contrast checks plus real footer and template interactions

## Acceptance criteria

- [x] All 25 canonical tips remain above a fully contained footer at 1280x720
- [x] The footer remains contained at the configured 1280x800 desktop height
- [x] The regular layout is contained immediately above the 850px compact breakpoint
- [x] Axe reports complete, passing contrast results for tip/footer targets
- [x] Template creation, GitHub footer action, tip timing, contrast, and reduced-motion behavior remain usable

## Verification

- catalog-wide geometry/axe regression repeated serially — 3/3 passed
- accessibility, empty-state, and visual specs — 17/17 passed; 5/5 committed visual baselines unchanged
- targeted Biome and frontend/E2E TypeScript — passed
- `git diff --check` — passed
- `npm run ci:local` — passed (1,909 frontend tests; 170 Rust unit tests plus 3 integration tests; web build and Worker dry-run passed)

## Independent preflight

Both applicable lanes were rerun after each revision until convergence:

| Lane | Findings resolved | Final state |
|---|---|---|
| PR reviewer | Footer clipped by app canvas despite fitting browser viewport; responsive cliff through the 800px default; required formatter output | Clean |
| Slop auditor | Removed speculative template-density changes and redundant catalog bookkeeping; aligned geometry with the actual canvas; required formatter output | Clean |

Security and threat-model lanes do not apply: this change touches no trust boundary, IPC, file I/O, cryptography, AI, release path, `.thf` schema, STRIDE logic, or threat generation.

## Owner validation

Inspect the pre-model screen at 1280x720, 1280x800, and a taller viewport to confirm the compact layout retains the intended hierarchy and upward bias, the footer feels intentionally anchored rather than squeezed, and the longest tip remains comfortably separated.