### PR TITLE
feat(security): encrypt browser BYOK API keys at rest

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Built-in rule engine that applies Microsoft's STRIDE-per-element methodology to 
 
 Chat with Claude or GPT about your threat model. The AI sees your full architecture — elements, data flows, trust boundaries, and existing threats — and can suggest new threats, propose mitigations, or answer security questions. One-click to accept AI-suggested threats into your model.
 
-Bring your own API key. Supports Anthropic (Claude Opus 4, Sonnet 4, Haiku 3.5) and OpenAI (GPT-4o, GPT-4o Mini). Desktop keys are AES-256-GCM encrypted at rest; browser storage displays an explicit security warning.
+Bring your own API key. Supports Anthropic (Claude Opus 4, Sonnet 4, Haiku 3.5) and OpenAI (GPT-4o, GPT-4o Mini). Desktop keys are AES-256-GCM encrypted at rest; browser keys are AES-GCM encrypted in IndexedDB under a non-extractable key.
 
 ### Import from Microsoft TMT
 
@@ -223,7 +223,7 @@ All AI calls go directly from the user's machine with the user's API key. No pro
 
 ThreatForge is a security tool — the bar for security in our own code is high.
 
-- **API keys** use AES-256-GCM encrypted storage on desktop; browser storage displays an explicit warning
+- **API keys** use AES-256-GCM encrypted storage on desktop; browser keys are AES-GCM encrypted in IndexedDB under a non-extractable key
 - **AI calls** go directly to the provider — no intermediary server
 - **LLM output** is treated as untrusted; raw HTML is escaped by default
 - **Strict CSP** — no inline scripts, no remote code loading

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,7 +51,7 @@ The following are in scope for security reports:
 
 ThreatForge follows these security principles:
 
-- **API keys** use AES-256-GCM encrypted storage on desktop; the browser stores keys in `localStorage` with an explicit in-app warning. Keys are never written to threat model files
+- **API keys** use AES-256-GCM encrypted storage on desktop; in the browser they are AES-GCM encrypted in IndexedDB under a non-extractable key the browser will not export. Script running on the page can still use the key, which the in-app copy states plainly. Keys are never written to threat model files
 - **AI API calls** go directly from the user's machine with the user's key -- no proxy server
 - **LLM output** is treated as untrusted input; the Markdown renderer escapes raw HTML by default
 - **Native file I/O** is handled by Rust commands; path traversal and arbitrary file access remain explicitly in scope for security reports

--- a/docs/knowledge/architecture.md
+++ b/docs/knowledge/architecture.md
@@ -32,9 +32,10 @@ ThreatForge desktop runtime (Tauri v2)
 - File I/O → Local filesystem (`.thf` files)
 - Auto-Updater → GitHub Releases (desktop; can verify signed update metadata once signing is provisioned)
 
-In the browser, AI requests also go directly to the configured provider. Browser keys use
-local browser storage with an explicit UI warning; desktop keys use the encrypted Rust
-storage path. Browser file operations use import/download adapters instead of Tauri IPC.
+In the browser, AI requests also go directly to the configured provider. Browser keys are
+AES-GCM encrypted in a dedicated IndexedDB database under a non-extractable wrapping key;
+desktop keys use the encrypted Rust storage path. Browser file operations use import/download
+adapters instead of Tauri IPC.
 
 The AI chat path — the provider-neutral message and event model, the browser/desktop
 transport split and why the desktop key stays in Rust, tool-schema generation, context
@@ -355,7 +356,7 @@ npm run ci:docker:build  # Docker lint + test + Tauri build
 
 | Layer | Approach |
 |-------|---------|
-| API Key Storage | Desktop: AES-256-GCM encrypted file in app data directory. Browser: local storage with an explicit UI warning. |
+| API Key Storage | Desktop: AES-256-GCM encrypted file in app data directory. Browser: AES-GCM ciphertext in a dedicated IndexedDB database, wrapped by a non-extractable `CryptoKey`. Script on the origin can still use the key — the residual risk is stated in the UI and mitigated by the CSP. |
 | AI API Calls | Direct from user's machine with user's key; HTTPS only. Provider decoding, request validation, and error redaction are shared and typed — see [`ai-protocol.md`](ai-protocol.md) |
 | File Integrity | Explicit version checks and typed deserialization; unknown fields remain tolerated for forward compatibility |
 | Auto-Update | Tauri updater can verify signed update metadata once signing is provisioned; rollout and end-to-end verification remain roadmap gates |

--- a/docs/knowledge/architecture.md
+++ b/docs/knowledge/architecture.md
@@ -357,7 +357,7 @@ npm run ci:docker:build  # Docker lint + test + Tauri build
 
 | Layer | Approach |
 |-------|---------|
-| API Key Storage | Desktop: AES-256-GCM encrypted file in app data directory. Browser: AES-GCM ciphertext in a dedicated IndexedDB database, wrapped by a non-extractable `CryptoKey`. Script on the origin can still use the key — the residual risk is stated in the UI and mitigated by the CSP. |
+| API Key Storage | Desktop: AES-256-GCM encrypted file in app data directory. Browser: AES-GCM ciphertext in a dedicated IndexedDB database, wrapped by a non-extractable `CryptoKey`. Two residuals are specific to the browser and do not apply to desktop: script on the origin can use the key exactly as the app does (stated in the UI, mitigated by the CSP), and `extractable: false` is an API-level restriction rather than encryption at rest, so read access to the browser profile recovers the wrapping material and the ciphertext together. Only the desktop build keeps the key outside the browser profile. |
 | AI API Calls | Direct from user's machine with user's key; HTTPS only. Provider decoding, request validation, and error redaction are shared and typed — see [`ai-protocol.md`](ai-protocol.md) |
 | File Integrity | Explicit version checks and typed deserialization; unknown fields remain tolerated for forward compatibility |
 | Auto-Update | Tauri updater can verify signed update metadata once signing is provisioned; rollout and end-to-end verification remain roadmap gates |

--- a/docs/knowledge/architecture.md
+++ b/docs/knowledge/architecture.md
@@ -262,8 +262,9 @@ availability reason, and one coalesced status-bar indicator — one report per f
 per write. The in-memory document is always left editable and exportable.
 
 **No credential ever reaches either store.** The layer writes only `.thf` text and the id/order/
-title/preferences manifest, imports no keychain adapter, and uses a namespace disjoint from
-`tf-api-key-`. `src/lib/persistence/no-key-leakage.test.ts` proves this by enumerating every stored
+title/preferences manifest, imports no keychain adapter, and uses a namespace disjoint from the
+`threatforge-keychain` vault (and from the legacy `tf-api-key-` slot it migrates from).
+`src/lib/persistence/no-key-leakage.test.ts` proves this by enumerating every stored
 record after a real autosave cycle.
 
 ### Handoff seams

--- a/docs/knowledge/product-design.md
+++ b/docs/knowledge/product-design.md
@@ -100,7 +100,7 @@ requires a separately scoped issue and privacy review.
 - **File conflicts — planned:** Detecting externally changed `.thf` files and offering recovery is tracked in [roadmap Phase 1](../plans/roadmap.md#phase-1--multi-document-local-first-workspace).
 - **Large models — design target:** Validate responsiveness with representative large-model fixtures before making a shipped performance claim.
 - **Invalid files — shipped:** Schema validation rejects invalid files with user-safe errors.
-- **API key security — shipped:** Desktop keys are AES-256-GCM encrypted at rest; browser keys use `localStorage` with an explicit in-app warning. Keys are never written to threat model files.
+- **API key security — shipped:** Desktop keys are AES-256-GCM encrypted at rest; browser keys are AES-GCM encrypted in IndexedDB under a non-extractable key, with the residual same-origin-script risk stated in the UI. Keys are never written to threat model files.
 
 ## Accessibility
 

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -100,9 +100,15 @@ export async function suppressFirstRunOverlays(page: Page) {
 
 /**
  * Seed a browser API key so the AI panel reaches the chat view without a real
- * provider account. The key is the value `BrowserKeychainAdapter` reads
- * (`tf-api-key-<provider>`); the AI-loop spec pairs it with a routed, canned SSE
- * response so no request ever leaves the machine.
+ * provider account. The AI-loop spec pairs it with a routed, canned SSE response
+ * so no request ever leaves the machine.
+ *
+ * The value is written to the pre-#133 `tf-api-key-<provider>` slot rather than
+ * straight into the encrypted vault, because seeding the vault from an init
+ * script would mean reimplementing the wrapping-key setup in test code. On first
+ * read `BrowserKeychainAdapter` migrates this slot into the vault and erases it,
+ * so the app under test still resolves the key through the real encrypted path —
+ * and this fixture doubles as live coverage of the upgrade an existing user gets.
  */
 export async function seedAnthropicApiKey(page: Page) {
 	await page.addInitScript(() => {

--- a/public/_headers
+++ b/public/_headers
@@ -4,11 +4,13 @@
 # _headers file, so the policy below is served for every route of the web app.
 #
 # The web build is the platform that needs a CSP: it holds the BYOK API key in
-# localStorage (webview-readable), whereas the desktop build keeps the key in Rust
-# and its CSP lives in src-tauri/tauri.conf.json. The primary key defense here is
-# script-src 'self' (with default-src 'self'): no inline or third-party script can
-# execute except the pinned analytics beacon, so an injected payload has no
-# foothold to read localStorage in the first place. connect-src is the
+# IndexedDB as AES-GCM ciphertext under a non-extractable wrapping key (#133),
+# whereas the desktop build keeps the key in Rust and its CSP lives in
+# src-tauri/tauri.conf.json. Encryption at rest does not defend against script on
+# this origin, which can reach the same wrapping key and decrypt exactly as the app
+# does — so script-src 'self' (with default-src 'self') is the primary defense for
+# the key, not a secondary one: no inline or third-party script can execute except
+# the pinned analytics beacon. connect-src is the
 # defense-in-depth backstop — it is kept as narrow as the app's real network
 # surface allows, because a wide allowlist is an exfiltration drop if the primary
 # defense is ever bypassed:

--- a/public/_headers
+++ b/public/_headers
@@ -7,10 +7,10 @@
 # IndexedDB as AES-GCM ciphertext under a non-extractable wrapping key (#133),
 # whereas the desktop build keeps the key in Rust and its CSP lives in
 # src-tauri/tauri.conf.json. Encryption at rest does not defend against script on
-# this origin, which can reach the same wrapping key and decrypt exactly as the app
-# does — so script-src 'self' (with default-src 'self') is the primary defense for
-# the key, not a secondary one: no inline or third-party script can execute except
-# the pinned analytics beacon. connect-src is the
+# this origin, which can reach the same wrapping key and decrypt exactly as the
+# app does — so script-src 'self' (with default-src 'self') is the primary
+# defense for the key, not a secondary one: no inline script can execute, and the
+# only third-party script origin is the analytics beacon below. connect-src is the
 # defense-in-depth backstop — it is kept as narrow as the app's real network
 # surface allows, because a wide allowlist is an exfiltration drop if the primary
 # defense is ever bypassed:
@@ -36,6 +36,16 @@
 # (ReactFlow, shadcn), matching the desktop CSP; inline styles cannot read the key.
 # object-src / base-uri / form-action / frame-ancestors close the plugin, base-tag,
 # form-hijack, and clickjacking vectors that default-src does not cover on its own.
+#
+# Known residual: static.cloudflareinsights.com is allowed in script-src without an
+# integrity hash, because the beacon is versionless and Cloudflare may change it at
+# any time — an SRI hash would break analytics on their next deploy rather than
+# protect anything. That origin is therefore trusted to the same degree as 'self'
+# for key confidentiality: script served from it could read the vault exactly as
+# the app does. The exposure is accepted for a first-party analytics vendor already
+# terminating TLS for this site, and it is the reason no other third-party script
+# origin is admitted. Removing it entirely (self-hosted or server-side analytics)
+# is the only way to close it; see #232.
 /*
   Content-Security-Policy: default-src 'self'; script-src 'self' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://api.anthropic.com https://api.openai.com https://cloudflareinsights.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'
   X-Content-Type-Options: nosniff

--- a/src/components/panels/ai-settings-content.test.tsx
+++ b/src/components/panels/ai-settings-content.test.tsx
@@ -9,14 +9,14 @@ import { DEFAULT_USER_SETTINGS } from "@/types/settings";
 import { AiSettingsContent } from "./ai-settings-content";
 
 let hasKey: (provider: string) => Promise<boolean> = async () => false;
+let loadAdapter: () => Promise<unknown> = async () => ({
+	hasKey: (provider: string) => hasKey(provider),
+	setKey: async () => undefined,
+	deleteKey: async () => undefined,
+});
 
 vi.mock("@/lib/adapters/get-keychain-adapter", () => ({
-	getKeychainAdapter: () =>
-		Promise.resolve({
-			hasKey: (provider: string) => hasKey(provider),
-			setKey: async () => undefined,
-			deleteKey: async () => undefined,
-		}),
+	getKeychainAdapter: () => loadAdapter(),
 }));
 
 function modelSelect(): HTMLSelectElement {
@@ -29,7 +29,13 @@ function providerSelect(): HTMLSelectElement {
 
 beforeEach(() => {
 	localStorage.clear();
+	vi.restoreAllMocks();
 	hasKey = async () => false;
+	loadAdapter = async () => ({
+		hasKey: (provider: string) => hasKey(provider),
+		setKey: async () => undefined,
+		deleteKey: async () => undefined,
+	});
 	useChatStore.setState({ provider: "anthropic" });
 	useSettingsStore.setState({ settings: { ...DEFAULT_USER_SETTINGS } });
 });
@@ -83,20 +89,69 @@ describe("key storage that cannot answer", () => {
 		expect(screen.getByText("API key configured")).toBeInTheDocument();
 	});
 
-	it("says so when the storage adapter itself will not load", async () => {
-		hasKey = async () => {
-			throw new Error("unreachable");
+	it("still applies the status of a provider the user did not touch", async () => {
+		let release: () => void = () => undefined;
+		const stalled = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		hasKey = async (provider) => {
+			await stalled;
+			return provider === "openai";
 		};
-		vi.spyOn(
-			await import("@/lib/adapters/get-keychain-adapter"),
-			"getKeychainAdapter",
-		).mockRejectedValueOnce(new Error("chunk load failed"));
+
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+		fireEvent.change(screen.getByPlaceholderText("sk-ant-..."), {
+			target: { value: "sk-ant-new" },
+		});
+		await act(async () => {
+			fireEvent.click(screen.getByRole("button", { name: "Save" }));
+		});
+		await act(async () => {
+			release();
+			await stalled;
+		});
+
+		// Only the saved provider's answer is stale. Discarding the whole check would leave the
+		// other provider reading "No API key configured" for a key that is really there, until
+		// the panel is closed and reopened.
+		fireEvent.change(providerSelect(), { target: { value: "openai" } });
+		expect(screen.getByText("API key configured")).toBeInTheDocument();
+	});
+
+	it("says so when the storage adapter itself will not load", async () => {
+		loadAdapter = async () => {
+			throw new Error("Failed to fetch dynamically imported module: /assets/x-9f2a1c.js");
+		};
 
 		await act(async () => {
 			render(<AiSettingsContent />);
 		});
 
 		expect(screen.getByText(/Key storage could not be loaded/)).toBeInTheDocument();
+		// A bundle path and content hash are not an explanation, and this is a surface that
+		// otherwise only ever shows messages the app authored.
+		expect(screen.queryByText(/dynamically imported module/)).not.toBeInTheDocument();
+	});
+
+	it("does not put a bundler failure in front of the user when saving", async () => {
+		loadAdapter = async () => {
+			throw new Error("Failed to fetch dynamically imported module: /assets/x-9f2a1c.js");
+		};
+
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+		fireEvent.change(screen.getByPlaceholderText("sk-ant-..."), {
+			target: { value: "sk-ant-new" },
+		});
+		await act(async () => {
+			fireEvent.click(screen.getByRole("button", { name: "Save" }));
+		});
+
+		expect(screen.getByText(/Key storage could not be loaded/)).toBeInTheDocument();
+		expect(screen.queryByText(/dynamically imported module/)).not.toBeInTheDocument();
 	});
 });
 

--- a/src/components/panels/ai-settings-content.test.tsx
+++ b/src/components/panels/ai-settings-content.test.tsx
@@ -9,14 +9,14 @@ import { DEFAULT_USER_SETTINGS } from "@/types/settings";
 import { AiSettingsContent } from "./ai-settings-content";
 
 let hasKey: (provider: string) => Promise<boolean> = async () => false;
-let loadAdapter: () => Promise<unknown> = async () => ({
+let getAdapter: () => Promise<unknown> = async () => ({
 	hasKey: (provider: string) => hasKey(provider),
 	setKey: async () => undefined,
 	deleteKey: async () => undefined,
 });
 
 vi.mock("@/lib/adapters/get-keychain-adapter", () => ({
-	getKeychainAdapter: () => loadAdapter(),
+	getKeychainAdapter: () => getAdapter(),
 }));
 
 function modelSelect(): HTMLSelectElement {
@@ -31,7 +31,7 @@ beforeEach(() => {
 	localStorage.clear();
 	vi.restoreAllMocks();
 	hasKey = async () => false;
-	loadAdapter = async () => ({
+	getAdapter = async () => ({
 		hasKey: (provider: string) => hasKey(provider),
 		setKey: async () => undefined,
 		deleteKey: async () => undefined,
@@ -120,8 +120,76 @@ describe("key storage that cannot answer", () => {
 		expect(screen.getByText("API key configured")).toBeInTheDocument();
 	});
 
+	it("applies a stalled status check after a save that failed", async () => {
+		let release: () => void = () => undefined;
+		const stalled = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		hasKey = async () => {
+			await stalled;
+			return true;
+		};
+		getAdapter = async () => ({
+			hasKey: (provider: string) => hasKey(provider),
+			setKey: async () => {
+				throw new Error("Encrypted key storage in this browser is unavailable.");
+			},
+			deleteKey: async () => undefined,
+		});
+
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+		fireEvent.change(screen.getByPlaceholderText("sk-ant-..."), {
+			target: { value: "sk-ant-new" },
+		});
+		await act(async () => {
+			fireEvent.click(screen.getByRole("button", { name: "Save" }));
+		});
+		await act(async () => {
+			release();
+			await stalled;
+		});
+
+		// Nothing was written, so the check is not stale — it is the only reading of storage the
+		// panel has. Treating the attempt as a mutation would discard it permanently and leave a
+		// user with a key already saved looking at "No API key configured" and no Remove button.
+		expect(screen.getByText("API key configured")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Remove API key" })).toBeInTheDocument();
+	});
+
+	it("treats a removal that left a clear-text copy as removed, with the warning", async () => {
+		class RetainedCopyError extends Error {
+			readonly reason = "legacy-retained";
+		}
+		hasKey = async () => true;
+		getAdapter = async () => ({
+			hasKey: (provider: string) => hasKey(provider),
+			setKey: async () => undefined,
+			deleteKey: async () => {
+				throw new RetainedCopyError(
+					"The API key was removed from encrypted storage, but this browser would not delete an older clear-text copy.",
+				);
+			},
+		});
+
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+		await act(async () => {
+			fireEvent.click(screen.getByRole("button", { name: "Remove API key" }));
+		});
+
+		// The stored key really is gone; the rejection is about residue the adapter could not
+		// erase. Leaving the status alone showed "API key configured" directly underneath a
+		// message saying the key had been removed.
+		expect(screen.getByText(/would not delete an older clear-text copy/)).toBeInTheDocument();
+		expect(screen.getByText("No API key configured")).toBeInTheDocument();
+	});
+
 	it("says so when the storage adapter itself will not load", async () => {
-		loadAdapter = async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+		getAdapter = async () => {
 			throw new Error("Failed to fetch dynamically imported module: /assets/x-9f2a1c.js");
 		};
 
@@ -133,10 +201,17 @@ describe("key storage that cannot answer", () => {
 		// A bundle path and content hash are not an explanation, and this is a surface that
 		// otherwise only ever shows messages the app authored.
 		expect(screen.queryByText(/dynamically imported module/)).not.toBeInTheDocument();
+		// Kept out of the UI, not discarded: a real chunk-load regression has to stay
+		// diagnosable from a console log a user can paste into a bug report.
+		expect(warn).toHaveBeenCalledWith(
+			expect.stringContaining("Key storage adapter failed to load"),
+			expect.objectContaining({ message: expect.stringContaining("dynamically imported") }),
+		);
 	});
 
 	it("does not put a bundler failure in front of the user when saving", async () => {
-		loadAdapter = async () => {
+		vi.spyOn(console, "warn").mockImplementation(() => undefined);
+		getAdapter = async () => {
 			throw new Error("Failed to fetch dynamically imported module: /assets/x-9f2a1c.js");
 		};
 

--- a/src/components/panels/ai-settings-content.test.tsx
+++ b/src/components/panels/ai-settings-content.test.tsx
@@ -31,6 +31,24 @@ beforeEach(() => {
 	useSettingsStore.setState({ settings: { ...DEFAULT_USER_SETTINGS } });
 });
 
+/**
+ * #133 requires the browser's storage limit to be stated in the UI without overstating the
+ * protection. This pins that sentence so it cannot silently regress or drift into a claim
+ * the implementation does not make. `isTauri()` is false under jsdom, so this is the
+ * browser copy.
+ */
+describe("the browser security notice", () => {
+	it("states that the key is encrypted and that page script can still use it", async () => {
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+
+		const notice = screen.getByText(/encrypted before being stored in this browser/i);
+		expect(notice).toHaveTextContent("a key the browser will not export");
+		expect(notice).toHaveTextContent("Anything running on this page can still use the key");
+	});
+});
+
 describe("a current catalog model", () => {
 	it("renders selected, with its description, and no legacy warning", async () => {
 		await act(async () => {

--- a/src/components/panels/ai-settings-content.test.tsx
+++ b/src/components/panels/ai-settings-content.test.tsx
@@ -2,6 +2,7 @@
 
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { LEGACY_RETAINED } from "@/lib/adapters/keychain-adapter";
 import { DEFAULT_ANTHROPIC_MODEL, DEFAULT_OPENAI_MODEL } from "@/lib/ai-models";
 import { useChatStore } from "@/stores/chat-store";
 import { useSettingsStore } from "@/stores/settings-store";
@@ -160,7 +161,7 @@ describe("key storage that cannot answer", () => {
 
 	it("treats a removal that left a clear-text copy as removed, with the warning", async () => {
 		class RetainedCopyError extends Error {
-			readonly reason = "legacy-retained";
+			readonly reason = LEGACY_RETAINED;
 		}
 		hasKey = async () => true;
 		getAdapter = async () => ({

--- a/src/components/panels/ai-settings-content.test.tsx
+++ b/src/components/panels/ai-settings-content.test.tsx
@@ -8,10 +8,12 @@ import { useSettingsStore } from "@/stores/settings-store";
 import { DEFAULT_USER_SETTINGS } from "@/types/settings";
 import { AiSettingsContent } from "./ai-settings-content";
 
+let hasKey: (provider: string) => Promise<boolean> = async () => false;
+
 vi.mock("@/lib/adapters/get-keychain-adapter", () => ({
 	getKeychainAdapter: () =>
 		Promise.resolve({
-			hasKey: async () => false,
+			hasKey: (provider: string) => hasKey(provider),
 			setKey: async () => undefined,
 			deleteKey: async () => undefined,
 		}),
@@ -27,8 +29,75 @@ function providerSelect(): HTMLSelectElement {
 
 beforeEach(() => {
 	localStorage.clear();
+	hasKey = async () => false;
 	useChatStore.setState({ provider: "anthropic" });
 	useSettingsStore.setState({ settings: { ...DEFAULT_USER_SETTINGS } });
+});
+
+describe("key storage that cannot answer", () => {
+	it("reports the fault and still shows the provider that answered", async () => {
+		hasKey = async (provider) => {
+			if (provider === "anthropic") throw new Error("Key storage in this browser is damaged.");
+			return true;
+		};
+
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+
+		// A rejection for one provider used to take the other's status down with it and surface
+		// nothing, so a damaged vault read as "no API key configured" — which invites the user to
+		// enter a key, the one action that cannot help.
+		expect(screen.getByText("Key storage in this browser is damaged.")).toBeInTheDocument();
+		fireEvent.change(providerSelect(), { target: { value: "openai" } });
+		expect(screen.getByText("API key configured")).toBeInTheDocument();
+	});
+
+	it("does not let a slow status check undo a save that landed first", async () => {
+		let release: () => void = () => undefined;
+		const stalled = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		hasKey = async () => {
+			await stalled;
+			return false;
+		};
+
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+		fireEvent.change(screen.getByPlaceholderText("sk-ant-..."), {
+			target: { value: "sk-ant-new" },
+		});
+		await act(async () => {
+			fireEvent.click(screen.getByRole("button", { name: "Save" }));
+		});
+		await act(async () => {
+			release();
+			await stalled;
+		});
+
+		// The check started before the save and reports the vault as it was. Applying it would
+		// tell the user the key they just saved is not there, and replace the confirmation with
+		// a stale reading of storage.
+		expect(screen.getByText("API key configured")).toBeInTheDocument();
+	});
+
+	it("says so when the storage adapter itself will not load", async () => {
+		hasKey = async () => {
+			throw new Error("unreachable");
+		};
+		vi.spyOn(
+			await import("@/lib/adapters/get-keychain-adapter"),
+			"getKeychainAdapter",
+		).mockRejectedValueOnce(new Error("chunk load failed"));
+
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+
+		expect(screen.getByText(/Key storage could not be loaded/)).toBeInTheDocument();
+	});
 });
 
 /**

--- a/src/components/panels/ai-settings-content.tsx
+++ b/src/components/panels/ai-settings-content.tsx
@@ -53,13 +53,23 @@ export function AiSettingsContent() {
 
 	useEffect(() => {
 		async function checkStatus() {
-			try {
-				const adapter = await getKeychainAdapter();
-				const anthropicStatus = await adapter.hasKey("anthropic");
-				const openaiStatus = await adapter.hasKey("openai");
-				setKeyStatus({ anthropic: anthropicStatus, openai: openaiStatus });
-			} catch {
-				// Ignore errors — show as unconfigured
+			const adapter = await getKeychainAdapter().catch(() => null);
+			if (!adapter) return;
+			// Settled independently so one provider's failure does not erase the other's status.
+			// A damaged browser vault rejects for every provider that has a record, and reporting
+			// that as "no API key configured" hides a recoverable fault behind a state the user
+			// would try to fix by entering a key — which is the one thing that will not help.
+			const [anthropic, openai] = await Promise.allSettled([
+				adapter.hasKey("anthropic"),
+				adapter.hasKey("openai"),
+			]);
+			setKeyStatus({
+				anthropic: anthropic.status === "fulfilled" && anthropic.value,
+				openai: openai.status === "fulfilled" && openai.value,
+			});
+			const failure = [anthropic, openai].find((result) => result.status === "rejected");
+			if (failure?.status === "rejected") {
+				setMessage({ type: "error", text: errorText(failure.reason) });
 			}
 		}
 		void checkStatus();

--- a/src/components/panels/ai-settings-content.tsx
+++ b/src/components/panels/ai-settings-content.tsx
@@ -11,13 +11,19 @@ import { useSettingsStore } from "@/stores/settings-store";
 const ADAPTER_LOAD_ERROR = "Key storage could not be loaded. Reload the page and try again.";
 
 /**
- * Load the keychain adapter, or `null` when the module itself will not load.
+ * Load the keychain adapter, replacing a module-load failure with an authored message.
  *
  * Adapters author their own user-safe messages; a failure to load one does not, and would
- * otherwise render a bundle URL and a hash as the explanation.
+ * otherwise render a bundle URL and a hash as the explanation. The cause is logged rather
+ * than dropped, so a real chunk-load regression is still diagnosable from a bug report.
  */
-async function loadAdapter(): Promise<Awaited<ReturnType<typeof getKeychainAdapter>> | null> {
-	return getKeychainAdapter().catch(() => null);
+async function loadAdapter(): Promise<Awaited<ReturnType<typeof getKeychainAdapter>>> {
+	try {
+		return await getKeychainAdapter();
+	} catch (err) {
+		console.warn("Key storage adapter failed to load:", err);
+		throw new Error(ADAPTER_LOAD_ERROR);
+	}
 }
 
 const PROVIDERS: { value: AiProvider; label: string }[] = [
@@ -32,6 +38,19 @@ const PROVIDERS: { value: AiProvider; label: string }[] = [
  */
 function errorText(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Whether `error` reports a removal that succeeded but left a clear-text copy behind.
+ *
+ * The browser adapter deletes the stored key and *then* rejects, because it cannot claim the
+ * credential is gone while a pre-encryption copy is still readable. The removal did happen,
+ * so the panel has to record it and still show the warning. Matched structurally rather than
+ * by importing the browser vault, which would pull IndexedDB code into the desktop bundle.
+ */
+function isRetainedLegacyCopy(error: unknown): boolean {
+	if (!(error instanceof Error) || !("reason" in error)) return false;
+	return error.reason === "legacy-retained";
 }
 
 /** AI settings form content — used inside the settings dialog. */
@@ -71,37 +90,38 @@ export function AiSettingsContent() {
 	useEffect(() => {
 		let current = true;
 		async function checkStatus() {
-			const adapter = await loadAdapter();
-			if (!current) return;
-			if (!adapter) {
-				setMessage({ type: "error", text: ADAPTER_LOAD_ERROR });
-				return;
-			}
-			// Settled independently so one provider's failure does not erase the other's status.
-			// Unreadable storage rejects for both, and a vault too damaged to migrate rejects for
-			// a provider whose pre-encryption key is still waiting to be moved; reporting either
-			// as "no API key configured" points the user at entering a key, which is the one
-			// thing that will not help.
-			const [anthropic, openai] = await Promise.allSettled([
-				adapter.hasKey("anthropic"),
-				adapter.hasKey("openai"),
-			]);
-			if (!current) return;
-			const answers: [AiProvider, PromiseSettledResult<boolean>][] = [
-				["anthropic", anthropic],
-				["openai", openai],
-			];
-			const fresh = answers.filter(([name]) => !mutated.current.has(name));
-			setKeyStatus((prev) => {
-				const next = { ...prev };
-				for (const [name, answer] of fresh) {
-					next[name] = answer.status === "fulfilled" && answer.value;
+			try {
+				const adapter = await loadAdapter();
+				if (!current) return;
+				// Settled independently so one provider's failure does not erase the other's
+				// status. Unreadable storage rejects for both, and a vault too damaged to migrate
+				// rejects for a provider whose pre-encryption key is still waiting to be moved;
+				// reporting either as "no API key configured" points the user at entering a key,
+				// which is the one thing that will not help.
+				const [anthropic, openai] = await Promise.allSettled([
+					adapter.hasKey("anthropic"),
+					adapter.hasKey("openai"),
+				]);
+				if (!current) return;
+				const answers: [AiProvider, PromiseSettledResult<boolean>][] = [
+					["anthropic", anthropic],
+					["openai", openai],
+				];
+				const fresh = answers.filter(([name]) => !mutated.current.has(name));
+				setKeyStatus((prev) => {
+					const next = { ...prev };
+					for (const [name, answer] of fresh) {
+						next[name] = answer.status === "fulfilled" && answer.value;
+					}
+					return next;
+				});
+				const failure = fresh.find(([, answer]) => answer.status === "rejected")?.[1];
+				if (failure?.status === "rejected") {
+					setMessage({ type: "error", text: errorText(failure.reason) });
 				}
-				return next;
-			});
-			const failure = fresh.find(([, answer]) => answer.status === "rejected")?.[1];
-			if (failure?.status === "rejected") {
-				setMessage({ type: "error", text: errorText(failure.reason) });
+			} catch (err) {
+				// Only the adapter load rejects here; `allSettled` never does.
+				if (current) setMessage({ type: "error", text: errorText(err) });
 			}
 		}
 		void checkStatus();
@@ -118,7 +138,6 @@ export function AiSettingsContent() {
 
 		try {
 			const adapter = await loadAdapter();
-			if (!adapter) throw new Error(ADAPTER_LOAD_ERROR);
 			await adapter.setKey(provider, apiKey.trim());
 			// Recorded once the write has actually landed, so a save that fails does not leave
 			// the mount check discarded and the panel stuck reporting no key at all.
@@ -142,16 +161,27 @@ export function AiSettingsContent() {
 		setDeleting(true);
 		setMessage(null);
 
-		try {
-			const adapter = await loadAdapter();
-			if (!adapter) throw new Error(ADAPTER_LOAD_ERROR);
-			await adapter.deleteKey(provider);
+		function recordRemoval() {
 			mutated.current.add(provider);
 			setKeyStatus((prev) => ({ ...prev, [provider]: false }));
+		}
+
+		try {
+			const adapter = await loadAdapter();
+			await adapter.deleteKey(provider);
+			recordRemoval();
 			const successText = isTauri() ? "API key removed." : "API key removed from this browser.";
 			setMessage({ type: "success", text: successText });
 			await checkApiKey(provider);
 		} catch (err) {
+			// A retained clear-text copy is a warning about residue, not a failed removal: the
+			// stored key is gone. Leaving the status alone would show the provider as configured
+			// underneath a message saying it was removed, and would let a slow mount check
+			// overwrite it with the answer from before the delete.
+			if (isRetainedLegacyCopy(err)) {
+				recordRemoval();
+				await checkApiKey(provider);
+			}
 			setMessage({ type: "error", text: errorText(err) });
 		} finally {
 			setDeleting(false);

--- a/src/components/panels/ai-settings-content.tsx
+++ b/src/components/panels/ai-settings-content.tsx
@@ -12,6 +12,15 @@ const PROVIDERS: { value: AiProvider; label: string }[] = [
 	{ value: "openai", label: "OpenAI (GPT)" },
 ];
 
+/**
+ * Render a keychain failure for display. Adapters throw different shapes — the browser vault
+ * throws an `Error` carrying an authored, user-safe message, while the Tauri adapter rejects
+ * with a string from `invoke` — so the message is preferred when there is one.
+ */
+function errorText(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
 /** AI settings form content — used inside the settings dialog. */
 export function AiSettingsContent() {
 	const provider = useChatStore((s) => s.provider);
@@ -70,11 +79,11 @@ export function AiSettingsContent() {
 			setShowKey(false);
 			const successText = isTauri()
 				? "API key saved securely."
-				: "API key saved to browser storage.";
+				: "API key encrypted and saved in this browser.";
 			setMessage({ type: "success", text: successText });
 			await checkApiKey(provider);
 		} catch (err) {
-			setMessage({ type: "error", text: String(err) });
+			setMessage({ type: "error", text: errorText(err) });
 		} finally {
 			setSaving(false);
 		}
@@ -88,11 +97,11 @@ export function AiSettingsContent() {
 			const adapter = await getKeychainAdapter();
 			await adapter.deleteKey(provider);
 			setKeyStatus((prev) => ({ ...prev, [provider]: false }));
-			const successText = isTauri() ? "API key removed." : "API key removed from browser storage.";
+			const successText = isTauri() ? "API key removed." : "API key removed from this browser.";
 			setMessage({ type: "success", text: successText });
 			await checkApiKey(provider);
 		} catch (err) {
-			setMessage({ type: "error", text: String(err) });
+			setMessage({ type: "error", text: errorText(err) });
 		} finally {
 			setDeleting(false);
 		}
@@ -256,7 +265,7 @@ export function AiSettingsContent() {
 			<p className="text-[10px] text-muted-foreground/70">
 				{isTauri()
 					? "API keys are encrypted at rest and stored locally. They are never sent anywhere except the selected AI provider."
-					: "API keys are stored in your browser's localStorage. For stronger security, use the desktop app which encrypts keys at rest. Keys are only sent to the selected AI provider."}
+					: "API keys are encrypted before being stored in this browser, using a key the browser will not export. Anything running on this page can still use the key, so prefer the desktop app on a shared machine. Keys are only sent to the selected AI provider."}
 			</p>
 		</div>
 	);

--- a/src/components/panels/ai-settings-content.tsx
+++ b/src/components/panels/ai-settings-content.tsx
@@ -1,6 +1,7 @@
 import { AlertTriangle, Eye, EyeOff, Loader2, Trash2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { getKeychainAdapter } from "@/lib/adapters/get-keychain-adapter";
+import { LEGACY_RETAINED } from "@/lib/adapters/keychain-adapter";
 import { getDefaultModelId, getModelById, getModelsForProvider } from "@/lib/ai-models";
 import { isTauri } from "@/lib/platform";
 import { cn } from "@/lib/utils";
@@ -50,7 +51,7 @@ function errorText(error: unknown): string {
  */
 function isRetainedLegacyCopy(error: unknown): boolean {
 	if (!(error instanceof Error) || !("reason" in error)) return false;
-	return error.reason === "legacy-retained";
+	return error.reason === LEGACY_RETAINED;
 }
 
 /** AI settings form content — used inside the settings dialog. */

--- a/src/components/panels/ai-settings-content.tsx
+++ b/src/components/panels/ai-settings-content.tsx
@@ -265,7 +265,7 @@ export function AiSettingsContent() {
 			<p className="text-[10px] text-muted-foreground/70">
 				{isTauri()
 					? "API keys are encrypted at rest and stored locally. They are never sent anywhere except the selected AI provider."
-					: "API keys are encrypted before being stored in this browser, using a key the browser will not export. Anything running on this page can still use the key, so prefer the desktop app on a shared machine. Keys are only sent to the selected AI provider."}
+					: "API keys are encrypted before being stored in this browser, using a key the browser will not export. Anything running on this page can still use the key. The desktop app keeps the key outside the browser entirely. Keys are only sent to the selected AI provider."}
 			</p>
 		</div>
 	);

--- a/src/components/panels/ai-settings-content.tsx
+++ b/src/components/panels/ai-settings-content.tsx
@@ -1,5 +1,5 @@
 import { AlertTriangle, Eye, EyeOff, Loader2, Trash2 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { getKeychainAdapter } from "@/lib/adapters/get-keychain-adapter";
 import { getDefaultModelId, getModelById, getModelsForProvider } from "@/lib/ai-models";
 import { isTauri } from "@/lib/platform";
@@ -29,6 +29,9 @@ export function AiSettingsContent() {
 	const settings = useSettingsStore((s) => s.settings);
 	const updateSetting = useSettingsStore((s) => s.updateSetting);
 
+	// Set as soon as the user saves or deletes, so a slow status check that started before it
+	// cannot report the vault as it was and undo what they just did.
+	const mutated = useRef(false);
 	const [apiKey, setApiKey] = useState("");
 	const [saving, setSaving] = useState(false);
 	const [deleting, setDeleting] = useState(false);
@@ -52,32 +55,42 @@ export function AiSettingsContent() {
 	const defaultModelLabel = getModelById(defaultModelId)?.label ?? defaultModelId;
 
 	useEffect(() => {
+		let current = true;
 		async function checkStatus() {
 			const adapter = await getKeychainAdapter().catch(() => null);
-			if (!adapter) return;
+			if (!current || mutated.current) return;
+			if (!adapter) {
+				setMessage({ type: "error", text: "Key storage could not be loaded. Reload and retry." });
+				return;
+			}
 			// Settled independently so one provider's failure does not erase the other's status.
-			// A damaged browser vault rejects for every provider that has a record, and reporting
-			// that as "no API key configured" hides a recoverable fault behind a state the user
-			// would try to fix by entering a key — which is the one thing that will not help.
+			// Unreadable storage rejects for both, and a vault too damaged to migrate rejects for
+			// a provider whose pre-encryption key is still waiting to be moved; reporting either
+			// as "no API key configured" points the user at entering a key, which is the one
+			// thing that will not help.
 			const [anthropic, openai] = await Promise.allSettled([
 				adapter.hasKey("anthropic"),
 				adapter.hasKey("openai"),
 			]);
+			// A save can land while this is in flight, and its result is the newer truth.
+			if (!current || mutated.current) return;
 			setKeyStatus({
 				anthropic: anthropic.status === "fulfilled" && anthropic.value,
 				openai: openai.status === "fulfilled" && openai.value,
 			});
 			const failure = [anthropic, openai].find((result) => result.status === "rejected");
-			if (failure?.status === "rejected") {
-				setMessage({ type: "error", text: errorText(failure.reason) });
-			}
+			if (failure) setMessage({ type: "error", text: errorText(failure.reason) });
 		}
 		void checkStatus();
+		return () => {
+			current = false;
+		};
 	}, []);
 
 	async function handleSave() {
 		if (!apiKey.trim()) return;
 
+		mutated.current = true;
 		setSaving(true);
 		setMessage(null);
 
@@ -100,6 +113,7 @@ export function AiSettingsContent() {
 	}
 
 	async function handleDelete() {
+		mutated.current = true;
 		setDeleting(true);
 		setMessage(null);
 

--- a/src/components/panels/ai-settings-content.tsx
+++ b/src/components/panels/ai-settings-content.tsx
@@ -7,6 +7,19 @@ import { cn } from "@/lib/utils";
 import { type AiProvider, useChatStore } from "@/stores/chat-store";
 import { useSettingsStore } from "@/stores/settings-store";
 
+/** Authored so a bundler or network detail never reaches the user as an error message. */
+const ADAPTER_LOAD_ERROR = "Key storage could not be loaded. Reload the page and try again.";
+
+/**
+ * Load the keychain adapter, or `null` when the module itself will not load.
+ *
+ * Adapters author their own user-safe messages; a failure to load one does not, and would
+ * otherwise render a bundle URL and a hash as the explanation.
+ */
+async function loadAdapter(): Promise<Awaited<ReturnType<typeof getKeychainAdapter>> | null> {
+	return getKeychainAdapter().catch(() => null);
+}
+
 const PROVIDERS: { value: AiProvider; label: string }[] = [
 	{ value: "anthropic", label: "Anthropic (Claude)" },
 	{ value: "openai", label: "OpenAI (GPT)" },
@@ -29,9 +42,10 @@ export function AiSettingsContent() {
 	const settings = useSettingsStore((s) => s.settings);
 	const updateSetting = useSettingsStore((s) => s.updateSetting);
 
-	// Set as soon as the user saves or deletes, so a slow status check that started before it
-	// cannot report the vault as it was and undo what they just did.
-	const mutated = useRef(false);
+	// Providers the user has saved or deleted since mount. A status check that started before
+	// one of those lands would report the vault as it was, so its answer is not applied over
+	// them — but only over them, so the other provider still gets its status and its faults.
+	const mutated = useRef(new Set<AiProvider>());
 	const [apiKey, setApiKey] = useState("");
 	const [saving, setSaving] = useState(false);
 	const [deleting, setDeleting] = useState(false);
@@ -57,10 +71,10 @@ export function AiSettingsContent() {
 	useEffect(() => {
 		let current = true;
 		async function checkStatus() {
-			const adapter = await getKeychainAdapter().catch(() => null);
-			if (!current || mutated.current) return;
+			const adapter = await loadAdapter();
+			if (!current) return;
 			if (!adapter) {
-				setMessage({ type: "error", text: "Key storage could not be loaded. Reload and retry." });
+				setMessage({ type: "error", text: ADAPTER_LOAD_ERROR });
 				return;
 			}
 			// Settled independently so one provider's failure does not erase the other's status.
@@ -72,14 +86,23 @@ export function AiSettingsContent() {
 				adapter.hasKey("anthropic"),
 				adapter.hasKey("openai"),
 			]);
-			// A save can land while this is in flight, and its result is the newer truth.
-			if (!current || mutated.current) return;
-			setKeyStatus({
-				anthropic: anthropic.status === "fulfilled" && anthropic.value,
-				openai: openai.status === "fulfilled" && openai.value,
+			if (!current) return;
+			const answers: [AiProvider, PromiseSettledResult<boolean>][] = [
+				["anthropic", anthropic],
+				["openai", openai],
+			];
+			const fresh = answers.filter(([name]) => !mutated.current.has(name));
+			setKeyStatus((prev) => {
+				const next = { ...prev };
+				for (const [name, answer] of fresh) {
+					next[name] = answer.status === "fulfilled" && answer.value;
+				}
+				return next;
 			});
-			const failure = [anthropic, openai].find((result) => result.status === "rejected");
-			if (failure) setMessage({ type: "error", text: errorText(failure.reason) });
+			const failure = fresh.find(([, answer]) => answer.status === "rejected")?.[1];
+			if (failure?.status === "rejected") {
+				setMessage({ type: "error", text: errorText(failure.reason) });
+			}
 		}
 		void checkStatus();
 		return () => {
@@ -90,13 +113,16 @@ export function AiSettingsContent() {
 	async function handleSave() {
 		if (!apiKey.trim()) return;
 
-		mutated.current = true;
 		setSaving(true);
 		setMessage(null);
 
 		try {
-			const adapter = await getKeychainAdapter();
+			const adapter = await loadAdapter();
+			if (!adapter) throw new Error(ADAPTER_LOAD_ERROR);
 			await adapter.setKey(provider, apiKey.trim());
+			// Recorded once the write has actually landed, so a save that fails does not leave
+			// the mount check discarded and the panel stuck reporting no key at all.
+			mutated.current.add(provider);
 			setKeyStatus((prev) => ({ ...prev, [provider]: true }));
 			setApiKey("");
 			setShowKey(false);
@@ -113,13 +139,14 @@ export function AiSettingsContent() {
 	}
 
 	async function handleDelete() {
-		mutated.current = true;
 		setDeleting(true);
 		setMessage(null);
 
 		try {
-			const adapter = await getKeychainAdapter();
+			const adapter = await loadAdapter();
+			if (!adapter) throw new Error(ADAPTER_LOAD_ERROR);
 			await adapter.deleteKey(provider);
+			mutated.current.add(provider);
 			setKeyStatus((prev) => ({ ...prev, [provider]: false }));
 			const successText = isTauri() ? "API key removed." : "API key removed from this browser.";
 			setMessage({ type: "success", text: successText });

--- a/src/lib/adapters/browser-chat-adapter.test.ts
+++ b/src/lib/adapters/browser-chat-adapter.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { yieldHostTask } from "./test-fixtures/host-task";
 import { resetKeyVault } from "./test-fixtures/key-vault";
 import "fake-indexeddb/auto";
 import { ProtocolException } from "@/lib/ai/protocol/errors";
@@ -160,18 +161,6 @@ async function awaitRequestIssued(): Promise<void> {
 		await yieldHostTask();
 	}
 	expect.unreachable("the transport never issued its request");
-}
-
-/** Yield one real host task. `MessageChannel` is used because `setTimeout` is faked here. */
-function yieldHostTask(): Promise<void> {
-	return new Promise((resolve) => {
-		const channel = new MessageChannel();
-		channel.port1.onmessage = () => {
-			channel.port1.close();
-			resolve();
-		};
-		channel.port2.postMessage(null);
-	});
 }
 
 beforeEach(async () => {

--- a/src/lib/adapters/browser-chat-adapter.test.ts
+++ b/src/lib/adapters/browser-chat-adapter.test.ts
@@ -7,7 +7,9 @@
  * protocol, which the shared mappers own.
  */
 
+import { IDBFactory } from "fake-indexeddb";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "fake-indexeddb/auto";
 import { ProtocolException } from "@/lib/ai/protocol/errors";
 import { buildAnthropicRequestBody } from "@/lib/ai/providers/anthropic";
 import { buildOpenAiRequestBody } from "@/lib/ai/providers/openai";
@@ -131,15 +133,64 @@ function headerRecord(init: RequestInit): Record<string, string> {
 	return Object.fromEntries(new Headers(headers).entries());
 }
 
+/**
+ * Install fake timers for the transport's read-gap timeout only.
+ *
+ * The transport resolves the API key through the encrypted IndexedDB vault before it
+ * fetches, and IndexedDB delivers its events on real host tasks. Faking the whole timer
+ * surface would starve that scheduler and hang the key lookup, so only the two timer
+ * functions `waitForRead` actually uses are replaced.
+ */
+function useTransportFakeTimers(): void {
+	vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+}
+
+/**
+ * Yield real host tasks until the transport has issued its request.
+ *
+ * `open()` resolves the API key through the encrypted IndexedDB vault first, and IndexedDB
+ * delivers its events on real tasks that `advanceTimersByTimeAsync` does not pump. Waiting
+ * for the `fetch` call is what proves the key lookup finished and the read-gap timer the
+ * test is about is now the pending work.
+ */
+async function awaitRequestIssued(): Promise<void> {
+	for (let attempt = 0; attempt < 1000; attempt += 1) {
+		if (vi.mocked(fetch).mock.calls.length > 0) return;
+		await yieldHostTask();
+	}
+	expect.unreachable("the transport never issued its request");
+}
+
+/** Yield one real host task. `MessageChannel` is used because `setTimeout` is faked here. */
+function yieldHostTask(): Promise<void> {
+	return new Promise((resolve) => {
+		const channel = new MessageChannel();
+		channel.port1.onmessage = () => {
+			channel.port1.close();
+			resolve();
+		};
+		channel.port2.postMessage(null);
+	});
+}
+
+/**
+ * Discard every stored key. Since #133 the keychain is an encrypted IndexedDB vault, so
+ * replacing the factory is what leaves the transport with nothing to sign a request with.
+ */
+function clearStoredKeys(): void {
+	globalThis.indexedDB = new IDBFactory();
+}
+
 beforeEach(async () => {
 	vi.stubGlobal("fetch", vi.fn());
+	clearStoredKeys();
 	await new BrowserKeychainAdapter().setKey("anthropic", ANTHROPIC_KEY);
 	await new BrowserKeychainAdapter().setKey("openai", "sk-openai-test-browser-key");
 });
 
 afterEach(() => {
 	vi.unstubAllGlobals();
-	localStorage.clear();
+	clearStoredKeys();
 });
 
 describe("BrowserChatTransport request building", () => {
@@ -218,7 +269,7 @@ describe("BrowserChatTransport request building", () => {
 	});
 
 	it("refuses to send anything when no key is stored", async () => {
-		localStorage.clear();
+		clearStoredKeys();
 		const callbacks = recordingCallbacks();
 
 		await expect(
@@ -230,7 +281,7 @@ describe("BrowserChatTransport request building", () => {
 	});
 
 	it("names the missing key rather than reporting a transport failure", async () => {
-		localStorage.clear();
+		clearStoredKeys();
 
 		await expect(
 			new BrowserChatTransport().open(anthropicRequest, recordingCallbacks()),
@@ -351,13 +402,14 @@ describe("BrowserChatTransport streaming", () => {
 	});
 
 	it("fails a stream that goes silent instead of leaving open() pending forever", async () => {
-		vi.useFakeTimers();
+		useTransportFakeTimers();
 		try {
 			const provider = openResponse();
 			vi.mocked(fetch).mockResolvedValue(provider.response);
 			const callbacks = recordingCallbacks();
 
 			const open = new BrowserChatTransport().open(anthropicRequest, callbacks);
+			await awaitRequestIssued();
 			// Reach the first pending read, then hold the connection open and silent
 			// for one tick short of the relay's 300-second read timeout.
 			await vi.advanceTimersByTimeAsync(299_999);
@@ -380,7 +432,7 @@ describe("BrowserChatTransport streaming", () => {
 	});
 
 	it("keeps a slow but live stream open past the read timeout", async () => {
-		vi.useFakeTimers();
+		useTransportFakeTimers();
 		try {
 			const provider = openResponse();
 			vi.mocked(fetch).mockResolvedValue(provider.response);
@@ -485,7 +537,7 @@ describe("BrowserChatTransport cancellation", () => {
 		// first — the old order — would reject with `no_api_key`; a caller that
 		// aborted before the request even ran wants the stop, and the desktop
 		// transport reports it first, so this one must too.
-		localStorage.clear();
+		clearStoredKeys();
 		const controller = new AbortController();
 		controller.abort();
 		const callbacks = recordingCallbacks();
@@ -598,7 +650,7 @@ describe("BrowserChatTransport failure reporting", () => {
 	});
 
 	it("gives up on a stalled error body instead of leaving open() pending forever", async () => {
-		vi.useFakeTimers();
+		useTransportFakeTimers();
 		try {
 			// A non-2xx whose error body is present but never sends or closes. The
 			// success path already bounds a silent body per-gap; the error path must
@@ -614,6 +666,7 @@ describe("BrowserChatTransport failure reporting", () => {
 			const callbacks = recordingCallbacks();
 
 			const open = new BrowserChatTransport().open(anthropicRequest, callbacks);
+			await awaitRequestIssued();
 			await vi.advanceTimersByTimeAsync(299_999);
 			expect(callbacks.onHttpError).not.toHaveBeenCalled();
 

--- a/src/lib/adapters/browser-chat-adapter.test.ts
+++ b/src/lib/adapters/browser-chat-adapter.test.ts
@@ -7,8 +7,8 @@
  * protocol, which the shared mappers own.
  */
 
-import { IDBFactory } from "fake-indexeddb";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetKeyVault } from "./test-fixtures/key-vault";
 import "fake-indexeddb/auto";
 import { ProtocolException } from "@/lib/ai/protocol/errors";
 import { buildAnthropicRequestBody } from "@/lib/ai/providers/anthropic";
@@ -173,24 +173,16 @@ function yieldHostTask(): Promise<void> {
 	});
 }
 
-/**
- * Discard every stored key. Since #133 the keychain is an encrypted IndexedDB vault, so
- * replacing the factory is what leaves the transport with nothing to sign a request with.
- */
-function clearStoredKeys(): void {
-	globalThis.indexedDB = new IDBFactory();
-}
-
 beforeEach(async () => {
 	vi.stubGlobal("fetch", vi.fn());
-	clearStoredKeys();
+	resetKeyVault();
 	await new BrowserKeychainAdapter().setKey("anthropic", ANTHROPIC_KEY);
 	await new BrowserKeychainAdapter().setKey("openai", "sk-openai-test-browser-key");
 });
 
 afterEach(() => {
 	vi.unstubAllGlobals();
-	clearStoredKeys();
+	resetKeyVault();
 });
 
 describe("BrowserChatTransport request building", () => {
@@ -269,7 +261,7 @@ describe("BrowserChatTransport request building", () => {
 	});
 
 	it("refuses to send anything when no key is stored", async () => {
-		clearStoredKeys();
+		resetKeyVault();
 		const callbacks = recordingCallbacks();
 
 		await expect(
@@ -281,7 +273,7 @@ describe("BrowserChatTransport request building", () => {
 	});
 
 	it("names the missing key rather than reporting a transport failure", async () => {
-		clearStoredKeys();
+		resetKeyVault();
 
 		await expect(
 			new BrowserChatTransport().open(anthropicRequest, recordingCallbacks()),
@@ -439,6 +431,9 @@ describe("BrowserChatTransport streaming", () => {
 			const callbacks = recordingCallbacks();
 
 			const open = new BrowserChatTransport().open(anthropicRequest, callbacks);
+			// The key lookup is an IndexedDB round trip on real host tasks, so wait for the
+			// request to actually be in flight before driving the fake clock.
+			await awaitRequestIssued();
 			// The bound is per-gap, not per-request: a legitimate stream has no
 			// bounded duration, so a keep-alive inside every gap must not expire it.
 			for (let gap = 0; gap < 3; gap += 1) {
@@ -537,7 +532,7 @@ describe("BrowserChatTransport cancellation", () => {
 		// first — the old order — would reject with `no_api_key`; a caller that
 		// aborted before the request even ran wants the stop, and the desktop
 		// transport reports it first, so this one must too.
-		clearStoredKeys();
+		resetKeyVault();
 		const controller = new AbortController();
 		controller.abort();
 		const callbacks = recordingCallbacks();

--- a/src/lib/adapters/browser-chat-adapter.test.ts
+++ b/src/lib/adapters/browser-chat-adapter.test.ts
@@ -15,6 +15,7 @@ import { buildAnthropicRequestBody } from "@/lib/ai/providers/anthropic";
 import { buildOpenAiRequestBody } from "@/lib/ai/providers/openai";
 import type { SseFrame } from "@/lib/ai/providers/sse";
 import { BrowserChatTransport } from "./browser-chat-adapter";
+import { KEY_VAULT_DB_NAME } from "./browser-key-vault";
 import { BrowserKeychainAdapter } from "./browser-keychain-adapter";
 import type { ProviderStreamRequest, TransportCallbacks } from "./chat-adapter";
 import { PROVIDER_ENDPOINTS } from "./provider-endpoints";
@@ -278,6 +279,31 @@ describe("BrowserChatTransport request building", () => {
 		await expect(
 			new BrowserChatTransport().open(anthropicRequest, recordingCallbacks()),
 		).rejects.toMatchObject({ error: { code: "no_api_key" } });
+	});
+
+	it("carries the vault's recovery instruction instead of a generic failure", async () => {
+		// A damaged wrapping key makes every stored key unreadable. Reported as a bare
+		// rejection this would reach the user as "The AI request could not be completed",
+		// which tells them nothing they can act on.
+		const db = await new Promise<IDBDatabase>((resolve, reject) => {
+			const request = globalThis.indexedDB.open(KEY_VAULT_DB_NAME);
+			request.onsuccess = () => resolve(request.result);
+			request.onerror = () => reject(request.error);
+		});
+		await new Promise<void>((resolve, reject) => {
+			const tx = db.transaction("wrap-key", "readwrite");
+			tx.objectStore("wrap-key").put("not-a-crypto-key", "aes-gcm-256-v1");
+			tx.oncomplete = () => resolve();
+			tx.onerror = () => reject(tx.error);
+		});
+		db.close();
+
+		await expect(
+			new BrowserChatTransport().open(anthropicRequest, recordingCallbacks()),
+		).rejects.toMatchObject({
+			error: { code: "no_api_key", message: expect.stringContaining("browser data") },
+		});
+		expect(fetch).not.toHaveBeenCalled();
 	});
 });
 

--- a/src/lib/adapters/browser-chat-adapter.ts
+++ b/src/lib/adapters/browser-chat-adapter.ts
@@ -2,6 +2,7 @@ import { ProtocolException, redactProviderDetail } from "@/lib/ai/protocol/error
 import { createSseDecoder, type SseFrame } from "@/lib/ai/providers/sse";
 import { userSafeProviderError } from "@/lib/ai-provider-errors";
 import type { AiProvider } from "@/stores/chat-store";
+import { KeyVaultError } from "./browser-key-vault";
 import { BrowserKeychainAdapter } from "./browser-keychain-adapter";
 import {
 	type ChatTransport,
@@ -324,7 +325,20 @@ function retryAfterOf(headers: Headers): { retryAfterMs?: number } {
  * so desktop code cannot ask for one (issue #61 step 9).
  */
 async function resolveBrowserApiKey(provider: AiProvider): Promise<string> {
-	const apiKey = await new BrowserKeychainAdapter().getKey(provider);
+	let apiKey: string | null;
+	try {
+		apiKey = await new BrowserKeychainAdapter().getKey(provider);
+	} catch (error) {
+		// The vault authors an actionable sentence for a damaged or unavailable store
+		// ("clear this site's browser data, then add your API key again"). Left as a bare
+		// rejection it would be flattened to the generic transport error, so the user would
+		// be told only that the request failed. Re-raising it as a protocol error keeps the
+		// sentence and routes the caller to the settings prompt, which is the useful response.
+		if (error instanceof KeyVaultError) {
+			throw new ProtocolException({ code: "no_api_key", message: error.message });
+		}
+		throw error;
+	}
 	if (apiKey === null || apiKey === "") {
 		throw missingApiKeyError(provider);
 	}

--- a/src/lib/adapters/browser-key-vault.ts
+++ b/src/lib/adapters/browser-key-vault.ts
@@ -28,6 +28,8 @@
  * key storage never share a namespace; see `src/lib/persistence/no-key-leakage.test.ts`.
  */
 
+import type { LEGACY_RETAINED } from "./keychain-adapter";
+
 /** Key-vault database name. Disjoint from `WORKSPACE_STORAGE_NAMESPACE`. */
 export const KEY_VAULT_DB_NAME = "threatforge-keychain";
 /**
@@ -76,8 +78,9 @@ function retiredKey(id: string): string {
  * holds records it cannot decrypt, a revocation is still answered — the user threw the
  * credential away — and the other two are refused, because the clear-text copy may be the
  * last one there is and the user asked for neither. `"superseded"` and `"dropped"` therefore
- * take the same path as each other today; they are recorded apart so a profile that comes
- * back with a settled slot can be diagnosed, not because the reader treats them differently.
+ * take the same path as each other; they are recorded apart so a profile that comes back with
+ * a settled slot shows why. Only a revocation overwrites an existing marker, so what is
+ * recorded is the first settling event, not the most recent one.
  */
 type RetiredReason = "revoked" | "superseded" | "dropped";
 
@@ -136,7 +139,7 @@ export type KeyVaultErrorReason =
 	 * in this browser's storage. Reported so no caller can claim a key was removed when it
 	 * was not.
 	 */
-	| "legacy-retained";
+	| typeof LEGACY_RETAINED;
 
 /**
  * A vault failure carrying a user-safe message. Raw `DOMException` text and internal detail
@@ -535,10 +538,12 @@ type SlotSettlement = "supersede-slot" | "leave-slot";
  * the marker write fail are the same ones that later destroy the record, so the two are
  * correlated rather than independent.
  *
- * The marker is only ever raised, never lowered: a revocation already recorded for this
- * provider outranks a supersession, and overwriting it would disarm the one path that erases
- * a revoked clear-text credential on a vault that cannot decrypt anything. The read and the
- * write share the transaction, so no concurrent delete can land between them.
+ * The marker a revocation already recorded is never overwritten here, and neither is one from
+ * an earlier settling event: a revocation is the only reason answered on a vault that cannot
+ * decrypt anything, so lowering it would disarm the one path that erases a revoked clear-text
+ * credential, and re-labelling an earlier drop as a supersession would discard the cause
+ * without changing what happens next. The read and the write share the transaction, so no
+ * concurrent delete can land between them.
  *
  * @throws KeyVaultError when the vault cannot be opened or Web Crypto is unavailable. The
  * caller must surface that failure rather than storing the value in clear text.
@@ -566,10 +571,12 @@ export async function putSecret(
 				written = true;
 			};
 			// Chained inside the success callback rather than awaited, to keep the transaction
-			// live across the decision.
+			// live across the decision. The marker write needs no flag of its own: every way it
+			// can fail aborts the transaction, so reaching `oncomplete` means it either landed
+			// or was deliberately skipped.
 			const marker = meta.get(retiredKey(id));
 			marker.onsuccess = () => {
-				if (readRetiredReason(marker.result) === REVOKED) return;
+				if (readRetiredReason(marker.result) !== null) return;
 				meta.put(SUPERSEDED, retiredKey(id));
 			};
 			tx.oncomplete = () => (written ? resolve() : reject(unavailable()));
@@ -651,6 +658,11 @@ export async function hasSecret(id: string): Promise<boolean> {
  * a `localStorage` read that can throw, and a durable record must not be gated on one; and a
  * marker that could be cleared would not be durable. The cost is one small record per
  * provider the user has ever deleted a key for.
+ *
+ * The write is unconditional, where the other two writers defer to an existing marker. A
+ * revocation is the only reason that must override one: it is the only reason answered on a
+ * vault that cannot decrypt anything, so a slot already settled as superseded or dropped has
+ * to be re-settled as revoked when the user throws the credential away.
  */
 export async function retireAndDeleteSecret(id: string): Promise<void> {
 	await withVault(async (db) => {
@@ -675,9 +687,10 @@ export async function retireAndDeleteSecret(id: string): Promise<void> {
  *
  * Does nothing for an `error` this vault did not raise for a stored value.
  *
- * Writes `DROPPED` without checking for a stronger marker, unlike a save: a revocation
- * deletes the record in the same transaction that writes its marker, so once one exists
- * there is no stored value left for this to match against and it returns before writing.
+ * The marker is written only when the provider has none. A revocation must survive: a save
+ * after one re-creates a stored record while the `REVOKED` marker still stands, so this path
+ * can find a matching value to drop with a revocation already recorded, and lowering it would
+ * leave a credential the user threw away sitting readable in clear text on a damaged vault.
  */
 export async function dropUnreadableSecret(id: string, error: KeyVaultError): Promise<void> {
 	if (!corruptRecords.has(error)) return;
@@ -685,6 +698,7 @@ export async function dropUnreadableSecret(id: string, error: KeyVaultError): Pr
 	await withVault(async (db) => {
 		const tx = db.transaction([STORE_SECRETS, STORE_META], "readwrite");
 		const secrets = tx.objectStore(STORE_SECRETS);
+		const meta = tx.objectStore(STORE_META);
 		await new Promise<void>((resolve, reject) => {
 			// Chained inside the callback rather than awaited, to keep the transaction live.
 			const current = secrets.get(id);
@@ -700,7 +714,11 @@ export async function dropUnreadableSecret(id: string, error: KeyVaultError): Pr
 				// Order is immaterial inside one transaction, and a failing request aborts it
 				// into `onerror`, so resolving on `oncomplete` alone is enough here.
 				secrets.delete(id);
-				tx.objectStore(STORE_META).put(DROPPED, retiredKey(id));
+				const marker = meta.get(retiredKey(id));
+				marker.onsuccess = () => {
+					if (readRetiredReason(marker.result) !== null) return;
+					meta.put(DROPPED, retiredKey(id));
+				};
 			};
 			tx.oncomplete = () => resolve();
 			tx.onabort = () => reject(unavailable());

--- a/src/lib/adapters/browser-key-vault.ts
+++ b/src/lib/adapters/browser-key-vault.ts
@@ -49,9 +49,9 @@ const STORE_SECRETS = "secrets";
 /**
  * Holds markers that describe a provider rather than store its secret.
  *
- * Separate from {@link STORE_SECRETS} so every record in that store is a `SecretRecord`:
- * a marker keyed into it would survive `deleteSecret` (which deletes by exact key), but the
- * store's readers would then have to tolerate two unrelated record shapes.
+ * Separate from {@link STORE_SECRETS} so every record in that store is a `SecretRecord`. A
+ * marker keyed into the secrets store would also collide with the provider ids that store
+ * uses as keys, which is what {@link LEGACY_RETIRED_PREFIX} exists to avoid.
  */
 const STORE_META = "meta";
 
@@ -282,13 +282,15 @@ function awaitRequest<T>(request: IDBRequest<T>): Promise<T> {
  * user's only clear-text copy on the strength of it — so the commit is the only honest
  * point to resolve at. This matches `indexeddb-workspace-storage.ts`.
  */
-function awaitWrite(tx: IDBTransaction, request: IDBRequest): Promise<void> {
+function awaitWrite(tx: IDBTransaction, ...requests: IDBRequest[]): Promise<void> {
 	return new Promise((resolve, reject) => {
-		let succeeded = false;
-		request.onsuccess = () => {
-			succeeded = true;
-		};
-		tx.oncomplete = () => (succeeded ? resolve() : reject(unavailable()));
+		let succeeded = 0;
+		for (const request of requests) {
+			request.onsuccess = () => {
+				succeeded += 1;
+			};
+		}
+		tx.oncomplete = () => (succeeded === requests.length ? resolve() : reject(unavailable()));
 		tx.onabort = () => reject(unavailable());
 		tx.onerror = () => reject(unavailable());
 	});
@@ -394,19 +396,24 @@ async function withVault<T>(operation: (db: IDBDatabase) => Promise<T>): Promise
  * @throws KeyVaultError when the vault cannot be opened or Web Crypto is unavailable. The
  * caller must surface that failure rather than storing the value in clear text.
  */
+/** Encrypt `secret` under the vault's wrapping key, minting one if the vault has none. */
+async function encryptSecret(db: IDBDatabase, secret: string): Promise<SecretRecord> {
+	const subtle = requireSubtle();
+	const wrapKey = await getOrCreateWrapKey(db);
+	const iv = globalThis.crypto.getRandomValues(new Uint8Array(IV_BYTES));
+	const encrypted = await subtle.encrypt(
+		{ name: "AES-GCM", iv },
+		wrapKey,
+		new TextEncoder().encode(secret),
+	);
+	// Persisted as a view rather than a raw `ArrayBuffer` so both fields read back through the
+	// same realm-independent check.
+	return { iv, ciphertext: new Uint8Array(encrypted) };
+}
+
 export async function putSecret(id: string, secret: string): Promise<void> {
 	await withVault(async (db) => {
-		const subtle = requireSubtle();
-		const wrapKey = await getOrCreateWrapKey(db);
-		const iv = globalThis.crypto.getRandomValues(new Uint8Array(IV_BYTES));
-		const encrypted = await subtle.encrypt(
-			{ name: "AES-GCM", iv },
-			wrapKey,
-			new TextEncoder().encode(secret),
-		);
-		// Persisted as a view rather than a raw `ArrayBuffer` so both fields read back through
-		// the same realm-independent check.
-		const record: SecretRecord = { iv, ciphertext: new Uint8Array(encrypted) };
+		const record = await encryptSecret(db, secret);
 		const tx = db.transaction(STORE_SECRETS, "readwrite");
 		await awaitWrite(tx, tx.objectStore(STORE_SECRETS).put(record, id));
 	});
@@ -463,37 +470,78 @@ export async function hasSecret(id: string): Promise<boolean> {
 }
 
 /**
- * Delete the secret stored for `id`.
+ * Delete `id`'s secret and mark its pre-#133 clear-text slot as settled, in one transaction.
  *
  * The wrapping key is intentionally left in place: it is shared by every provider, so
  * removing one provider's key must not orphan the others.
- */
-export async function deleteSecret(id: string): Promise<void> {
-	await withVault(async (db) => {
-		const tx = db.transaction(STORE_SECRETS, "readwrite");
-		await awaitWrite(tx, tx.objectStore(STORE_SECRETS).delete(id));
-	});
-}
-
-/**
- * Record that `id`'s pre-#133 clear-text slot is settled and must never be imported again.
+ *
+ * The two halves cannot be separate operations. A delete removes the stored secret that
+ * outranks the clear-text slot, and the marker is the only thing left to stop that slot being
+ * imported again — so any moment in which one has been applied and the other has not is a
+ * window where a revoked credential comes back. IndexedDB serializes overlapping `readwrite`
+ * transactions across connections, and therefore across tabs, so a single transaction is what
+ * makes this indivisible rather than merely well-ordered.
  *
  * The marker lives in the vault rather than in `localStorage` because the only situation that
  * needs it is one where `localStorage` has already proven unreliable: a browser that refuses
  * to erase the clear-text slot cannot be trusted to hold a note saying it was dismissed.
  */
-export async function retireLegacySlot(id: string): Promise<void> {
+export async function retireAndDeleteSecret(id: string): Promise<void> {
 	await withVault(async (db) => {
-		const tx = db.transaction(STORE_META, "readwrite");
-		await awaitWrite(tx, tx.objectStore(STORE_META).put(true, `${LEGACY_RETIRED_PREFIX}${id}`));
+		const tx = db.transaction([STORE_SECRETS, STORE_META], "readwrite");
+		// Both requests are issued before any `await`, because a transaction commits as soon as
+		// its request queue drains and control returns to the event loop.
+		const marked = tx.objectStore(STORE_META).put(true, `${LEGACY_RETIRED_PREFIX}${id}`);
+		const deleted = tx.objectStore(STORE_SECRETS).delete(id);
+		await awaitWrite(tx, marked, deleted);
 	});
 }
 
-/** Report whether {@link retireLegacySlot} has settled `id`'s clear-text slot. */
-export async function isLegacySlotRetired(id: string): Promise<boolean> {
+/**
+ * Store `secret` for `id` only if the vault has neither a secret nor a retirement marker for
+ * it, and report whether it was stored.
+ *
+ * Migration is a check-then-act, and split across transactions it loses to a concurrent
+ * delete: a tab that reads "not retired, not stored", is descheduled while another tab
+ * completes a delete, then resumes and writes, resurrects the revoked key — and because both
+ * tabs' operations individually succeeded, the user is told the delete worked. The
+ * per-provider lock cannot prevent this, as it is module-scoped and so orders only one tab's
+ * calls. Doing the two counts and the put in one transaction closes it: the importing
+ * transaction either wholly precedes the delete, whose marker and delete then apply on top,
+ * or wholly follows it and sees the marker.
+ *
+ * Encryption happens before the transaction opens, since awaiting Web Crypto inside one would
+ * let it commit early. Encrypting a value that then turns out not to need storing is wasted
+ * work in a path that runs once per profile, not a correctness problem.
+ */
+export async function importLegacySecret(id: string, secret: string): Promise<boolean> {
 	return withVault(async (db) => {
-		const store = db.transaction(STORE_META, "readonly").objectStore(STORE_META);
-		const count = await awaitRequest(store.count(`${LEGACY_RETIRED_PREFIX}${id}`));
-		return count > 0;
+		const record = await encryptSecret(db, secret);
+		const tx = db.transaction([STORE_SECRETS, STORE_META], "readwrite");
+		const meta = tx.objectStore(STORE_META);
+		const secrets = tx.objectStore(STORE_SECRETS);
+		return new Promise<boolean>((resolve, reject) => {
+			let stored = false;
+			// Chained inside the success callbacks rather than awaited, to keep the transaction
+			// live across the decision.
+			const retired = meta.count(`${LEGACY_RETIRED_PREFIX}${id}`);
+			retired.onsuccess = () => {
+				// The user deleted this credential. The slot is a stale copy of something revoked.
+				if (retired.result > 0) return;
+				const existing = secrets.count(id);
+				existing.onsuccess = () => {
+					// A stored secret outranks the slot: importing would revert a key the user
+					// replaced while the browser was refusing to erase the old clear-text one.
+					if (existing.result > 0) return;
+					const put = secrets.put(record, id);
+					put.onsuccess = () => {
+						stored = true;
+					};
+				};
+			};
+			tx.oncomplete = () => resolve(stored);
+			tx.onabort = () => reject(unavailable());
+			tx.onerror = () => reject(unavailable());
+		});
 	});
 }

--- a/src/lib/adapters/browser-key-vault.ts
+++ b/src/lib/adapters/browser-key-vault.ts
@@ -8,13 +8,21 @@
  * origin — structured clone moves the handle into IndexedDB, but `exportKey` on it always
  * rejects.
  *
- * What this defends against: inspection of the browser profile on disk, and extensions or
- * tooling that read web storage, which now see ciphertext and an unexportable handle.
+ * What this defends against: casual inspection of web storage. Extensions, devtools, and
+ * tooling that read the origin's storage through the platform APIs now see ciphertext and a
+ * handle whose `exportKey` always rejects, and a scan of the profile for a key-shaped string
+ * no longer finds one.
  *
- * What it does not defend against: script execution on the ThreatForge origin. Such script
- * can reach the same handle and use it to decrypt, exactly as the application does. That
- * residual risk is accepted (#133) and is mitigated separately by the deployed CSP (#156). Do
- * not describe this storage as protecting against a compromised page.
+ * What it does not defend against, and must not be described as defending against:
+ *
+ * - Script execution on the ThreatForge origin. Such script can reach the same handle and use
+ *   it to decrypt, exactly as the application does. That residual risk is accepted (#133) and
+ *   is mitigated separately by the deployed CSP (#156).
+ * - An attacker with read access to the browser profile directory. `extractable: false` is an
+ *   API-level restriction enforced by the Web Crypto implementation, not encryption at rest:
+ *   browsers serialize the wrapping key's material into the same IndexedDB backing store that
+ *   holds the ciphertext, so both are recoverable together off disk. Only the desktop build
+ *   keeps the key out of the browser profile.
  *
  * The database is deliberately separate from the workspace database so document storage and
  * key storage never share a namespace; see `src/lib/persistence/no-key-leakage.test.ts`.
@@ -34,6 +42,13 @@ const WRAP_KEY_ID = "aes-gcm-256-v1";
 /** AES-GCM standard nonce length. A fresh nonce is drawn for every encryption. */
 const IV_BYTES = 12;
 
+/**
+ * How long to wait for `indexedDB.open` before giving up. Opening a local database is a
+ * sub-millisecond operation in a healthy browser, so this only ever fires when the store is
+ * wedged; it is generous enough that a loaded machine never trips it.
+ */
+const OPEN_TIMEOUT_MS = 10_000;
+
 /** Why a vault operation could not complete. */
 export type KeyVaultErrorReason =
 	/** IndexedDB or Web Crypto is missing, blocked, or otherwise unusable here. */
@@ -45,7 +60,13 @@ export type KeyVaultErrorReason =
 	 * distinct from `corrupt` because re-entering a key does not help: the write path needs
 	 * the same wrapping key and fails identically.
 	 */
-	| "vault-corrupt";
+	| "vault-corrupt"
+	/**
+	 * A pre-#133 clear-text slot could not be erased, so a usable credential is still sitting
+	 * in this browser's storage. Reported so no caller can claim a key was removed when it
+	 * was not.
+	 */
+	| "legacy-retained";
 
 /**
  * A vault failure carrying a user-safe message. Raw `DOMException` text and internal detail
@@ -100,16 +121,46 @@ function asBytes(value: unknown): Uint8Array<ArrayBuffer> | null {
 	return Uint8Array.from(new Uint8Array(value.buffer, value.byteOffset, value.byteLength));
 }
 
-/**
- * Report whether a value read back from IndexedDB is a `CryptoKey`.
- *
- * Same realm hazard as {@link asBytes}, and the same reasoning: `instanceof CryptoKey` would
- * be a false negative for a key cloned in another realm, and a false negative here reads as
- * "the vault is damaged" for a vault that is fine. `Symbol.toStringTag` is part of the
- * platform object and survives the boundary, so it is the check that actually holds.
- */
 function isCryptoKey(value: unknown): value is CryptoKey {
 	return Object.prototype.toString.call(value) === "[object CryptoKey]";
+}
+
+/**
+ * Report whether a value read back from IndexedDB is a wrapping key this vault can use.
+ *
+ * The algorithm and usages are checked, not just the type. A `CryptoKey` of the wrong shape
+ * — say encrypt-only, or HMAC — would otherwise be accepted and then fail at `decrypt`,
+ * which reads as "this record is corrupt" and gets the record deleted. Rejecting it here
+ * classifies the fault as vault-wide, which is what it is.
+ *
+ * Unlike the {@link asBytes} hazard, no environment here has been observed to break
+ * `instanceof CryptoKey`; the brand check is deliberate symmetry rather than a fix for a
+ * reproduced failure. It is the right default at this boundary because the cost of a false
+ * negative is severe and silent. `Symbol.toStringTag` cannot be forged through structured
+ * clone, which drops symbol-keyed properties.
+ */
+function isWrapKey(value: unknown): value is CryptoKey {
+	if (!isCryptoKey(value)) return false;
+	return (
+		value.algorithm.name === "AES-GCM" &&
+		value.usages.includes("encrypt") &&
+		value.usages.includes("decrypt")
+	);
+}
+
+/**
+ * Report whether a rejection is a Web Crypto `OperationError`, which is how AES-GCM reports
+ * an authentication failure — the one decrypt failure that really does mean "this record is
+ * damaged" rather than "this vault is broken".
+ *
+ * Checked by name rather than `instanceof DOMException` because that check demonstrably
+ * fails here: the error Node's Web Crypto throws is not an instance of the `DOMException`
+ * jsdom installs as the global, so `instanceof` reports `false` for a genuine authentication
+ * failure. This is the same cross-realm hazard {@link asBytes} guards against.
+ */
+function isOperationError(error: unknown): boolean {
+	if (typeof error !== "object" || error === null || !("name" in error)) return false;
+	return error.name === "OperationError";
 }
 
 /** Recover a secret record from a stored value, or `null` when it is not one. */
@@ -151,29 +202,39 @@ function openVault(): Promise<IDBDatabase> {
 		}
 
 		let settled = false;
+		// Some browsers accept `open()` and then never fire any event — a documented
+		// private-mode failure mode. Without a bound the promise never settles, the settings
+		// spinner never clears, and (because adapter calls are serialized per provider) every
+		// later call for that provider is wedged behind it even after storage recovers.
+		const timer = setTimeout(() => {
+			if (settled) return;
+			settled = true;
+			reject(unavailable());
+		}, OPEN_TIMEOUT_MS);
+
+		const finish = (outcome: () => void): void => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			outcome();
+		};
+
 		request.onupgradeneeded = () => {
 			const db = request.result;
 			if (!db.objectStoreNames.contains(STORE_WRAP)) db.createObjectStore(STORE_WRAP);
 			if (!db.objectStoreNames.contains(STORE_SECRETS)) db.createObjectStore(STORE_SECRETS);
 		};
 		request.onsuccess = () => {
-			// `onblocked` may already have rejected; close the connection rather than leaking it.
+			// A timeout or `onblocked` may already have rejected; close the connection that
+			// arrived late rather than leaking it.
 			if (settled) {
 				request.result.close();
 				return;
 			}
-			settled = true;
-			resolve(request.result);
+			finish(() => resolve(request.result));
 		};
-		request.onerror = () => {
-			settled = true;
-			reject(unavailable());
-		};
-		request.onblocked = () => {
-			if (settled) return;
-			settled = true;
-			reject(unavailable());
-		};
+		request.onerror = () => finish(() => reject(unavailable()));
+		request.onblocked = () => finish(() => reject(unavailable()));
 	});
 }
 
@@ -230,7 +291,7 @@ async function getOrCreateWrapKey(db: IDBDatabase): Promise<CryptoKey> {
 async function readWrapKey(db: IDBDatabase): Promise<CryptoKey | null> {
 	const store = db.transaction(STORE_WRAP, "readonly").objectStore(STORE_WRAP);
 	const stored = await awaitRequest(store.get(WRAP_KEY_ID));
-	if (isCryptoKey(stored)) return stored;
+	if (isWrapKey(stored)) return stored;
 	if (stored !== undefined) {
 		// A record is present but is not a usable key: refuse rather than silently replacing
 		// it, because overwriting would permanently orphan every secret encrypted under it.
@@ -258,12 +319,15 @@ function installWrapKey(db: IDBDatabase, candidate: CryptoKey): Promise<CryptoKe
 		let failure: KeyVaultError | null = null;
 
 		read.onsuccess = () => {
-			if (isCryptoKey(read.result)) {
+			if (isWrapKey(read.result)) {
 				// Another context won the race; adopt its key and write nothing.
 				winner = read.result;
 				return;
 			}
 			if (read.result !== undefined) {
+				// Guards a cross-context TOCTOU only: another tab would have to write a
+				// non-key into the slot between `readWrapKey`'s transaction and this one. No
+				// test reaches it, because the app itself never writes such a value.
 				failure = vaultCorrupt();
 				tx.abort();
 				return;
@@ -348,9 +412,15 @@ export async function getSecret(id: string): Promise<string | null> {
 				wrapKey,
 				record.ciphertext,
 			);
-		} catch {
-			// AES-GCM authentication failed: the record was truncated or tampered with.
-			throw new KeyVaultError("corrupt", CORRUPT_MESSAGE);
+		} catch (error) {
+			// An `OperationError` is an AES-GCM authentication failure: this record really was
+			// truncated or tampered with, and the caller may discard it. Any other rejection is
+			// a fault in the crypto layer, not evidence about this record — classifying it as
+			// `corrupt` would let a transient failure delete a perfectly good key.
+			if (isOperationError(error)) {
+				throw new KeyVaultError("corrupt", CORRUPT_MESSAGE);
+			}
+			throw vaultCorrupt();
 		}
 		return new TextDecoder().decode(plaintext);
 	});

--- a/src/lib/adapters/browser-key-vault.ts
+++ b/src/lib/adapters/browser-key-vault.ts
@@ -65,6 +65,26 @@ function retiredKey(id: string): string {
 	return `legacy-retired:${id}`;
 }
 
+/**
+ * Why a provider's clear-text slot was settled.
+ *
+ * `"revoked"` is the user deleting a credential. `"dropped"` is this vault discarding a
+ * record it could not read, which the user never asked for. Both block re-import, but only a
+ * revocation licenses erasing the clear-text copy while the vault is too damaged to offer a
+ * replacement — a dropped record leaves that copy as the last one there is.
+ */
+type RetiredReason = "revoked" | "dropped";
+
+const REVOKED: RetiredReason = "revoked";
+const DROPPED: RetiredReason = "dropped";
+
+/** Read a provider's retirement marker, or `null` when it has none. */
+function readRetiredReason(stored: unknown): RetiredReason | null {
+	if (stored === REVOKED) return REVOKED;
+	if (stored === DROPPED) return DROPPED;
+	return null;
+}
+
 const WRAP_KEY_ID = "aes-gcm-256-v1";
 
 /** AES-GCM standard nonce length. A fresh nonce is drawn for every encryption. */
@@ -340,7 +360,7 @@ async function getOrCreateWrapKey(db: IDBDatabase, mint: MintPolicy): Promise<Cr
  * cannot read.
  *
  * `"always"` is for re-entry: the user is supplying a fresh credential, so a vault whose key
- * is gone has to be able to start over or they are locked out permanently.
+ * is gone has to be able to start over, or there is no in-app way out.
  * `"only-when-empty"` is for migration, which is not a user asking to store anything — it
  * runs on a read — so it must not decide that unreadable records are disposable.
  */
@@ -370,10 +390,16 @@ async function readWrapKey(db: IDBDatabase): Promise<CryptoKey | null> {
  * caller never encrypts under a wrapping key whose write later aborts, which would leave a
  * permanently undecryptable record behind.
  *
- * Under `"only-when-empty"` the same transaction also counts the secrets, so a vault that
- * still holds records refuses to mint rather than orphaning them. That check belongs here
- * and not in the caller: a caller that looks first and mints second loses to a wrap-key wipe
- * landing in between, which is precisely the state this refuses to create.
+ * Whatever the policy, the same transaction also reads the secrets, so the decision and the
+ * install are indivisible. A caller that looks first and mints second loses to a wrap-key
+ * wipe landing in between, which is the state this exists to prevent.
+ *
+ * Under `"only-when-empty"` a vault that still holds records refuses to mint rather than
+ * orphaning them. Under `"always"` it mints and clears them in the same transaction: those
+ * records cannot be read under the new key, so leaving them is not preservation, it is a
+ * delayed loss that arrives later as a corrupt read — and that read would settle the
+ * provider's clear-text slot, destroying a copy that is still good. Clearing here settles
+ * nothing, so a slot that outlived the damage is still imported afterwards.
  */
 function installWrapKey(
 	db: IDBDatabase,
@@ -381,8 +407,7 @@ function installWrapKey(
 	mint: MintPolicy,
 ): Promise<CryptoKey> {
 	return new Promise((resolve, reject) => {
-		const stores = mint === "always" ? [STORE_WRAP] : [STORE_WRAP, STORE_SECRETS];
-		const tx = db.transaction(stores, "readwrite");
+		const tx = db.transaction([STORE_WRAP, STORE_SECRETS], "readwrite");
 		const read = tx.objectStore(STORE_WRAP).get(WRAP_KEY_ID);
 		let winner: CryptoKey | null = null;
 		let failure: KeyVaultError | null = null;
@@ -401,19 +426,22 @@ function installWrapKey(
 				tx.abort();
 				return;
 			}
-			if (mint === "always") {
-				winner = candidate;
-				tx.objectStore(STORE_WRAP).put(candidate, WRAP_KEY_ID);
-				return;
-			}
-			const stored = tx.objectStore(STORE_SECRETS).count();
+			const secrets = tx.objectStore(STORE_SECRETS);
+			const stored = secrets.count();
 			stored.onsuccess = () => {
 				if (stored.result > 0) {
-					// Records survive but their key does not. A new key cannot read them, so
-					// minting one would convert a diagnosable vault into permanently silent loss.
-					failure = vaultCorrupt();
-					tx.abort();
-					return;
+					if (mint === "only-when-empty") {
+						// Records survive but their key does not. A new key cannot read them, so
+						// minting one would convert a diagnosable vault into permanently silent loss.
+						failure = vaultCorrupt();
+						tx.abort();
+						return;
+					}
+					// The user is re-entering a credential, so the vault has to start over. The
+					// records going with it are already unreadable; discarding them here rather
+					// than leaving them to be found broken later is what keeps a surviving
+					// clear-text copy importable.
+					secrets.clear();
 				}
 				winner = candidate;
 				tx.objectStore(STORE_WRAP).put(candidate, WRAP_KEY_ID);
@@ -556,7 +584,7 @@ export async function retireAndDeleteSecret(id: string): Promise<void> {
 		const tx = db.transaction([STORE_SECRETS, STORE_META], "readwrite");
 		// Both requests are issued before any `await`, because a transaction commits as soon as
 		// its request queue drains and control returns to the event loop.
-		const marked = tx.objectStore(STORE_META).put(true, retiredKey(id));
+		const marked = tx.objectStore(STORE_META).put(REVOKED, retiredKey(id));
 		const deleted = tx.objectStore(STORE_SECRETS).delete(id);
 		await awaitWrite(tx, marked, deleted);
 	});
@@ -595,7 +623,7 @@ export async function dropUnreadableSecret(id: string, error: KeyVaultError): Pr
 				// Order is immaterial inside one transaction, and a failing request aborts it
 				// into `onerror`, so resolving on `oncomplete` alone is enough here.
 				secrets.delete(id);
-				tx.objectStore(STORE_META).put(true, retiredKey(id));
+				tx.objectStore(STORE_META).put(DROPPED, retiredKey(id));
 			};
 			tx.oncomplete = () => resolve();
 			tx.onabort = () => reject(unavailable());
@@ -630,23 +658,23 @@ function sameRecord(a: SecretRecord, b: SecretRecord): boolean {
  */
 export async function importLegacySecret(id: string, secret: string): Promise<void> {
 	return withVault(async (db) => {
-		// Read-only pre-check, so an import that is going to decline never reaches
-		// `encryptSecret`. Encrypting mints a wrapping key when the vault has none, which would
-		// turn the diagnosable "records exist but the key is gone" state into a silent one —
-		// the invariant `getSecret` documents. The authoritative answer is still the
-		// in-transaction check below; this only declines early, so the two cannot disagree in a
-		// way that stores something they would not.
+		// Read-only pre-check, so an import that is going to decline never opens a write
+		// transaction. The authoritative answer is still the in-transaction check below; this
+		// only declines early, so the two cannot disagree in a way that stores something they
+		// would not.
 		const check = db.transaction([STORE_SECRETS, STORE_META], "readonly");
 		// All three handlers are attached in this task, so none of them can miss its event.
-		const [retiredCount, existingCount, storedCount] = await Promise.all([
-			awaitRequest(check.objectStore(STORE_META).count(retiredKey(id))),
+		const [retiredMarker, existingCount, storedCount] = await Promise.all([
+			awaitRequest(check.objectStore(STORE_META).get(retiredKey(id))),
 			awaitRequest(check.objectStore(STORE_SECRETS).count(id)),
 			awaitRequest(check.objectStore(STORE_SECRETS).count()),
 		]);
-		// Answerable without a wrapping key, and answered first: the marker is a durable record
-		// that the user revoked this credential, so the slot is a stale copy that should still
-		// be erased on sight even while the vault is damaged.
-		if (retiredCount > 0) return;
+		const retired = readRetiredReason(retiredMarker);
+		// Answerable without a wrapping key, and answered first: a revocation is a durable
+		// record that the user threw this credential away, so the stale clear-text copy is
+		// erased on sight even while the vault is damaged. A `"dropped"` marker is not that —
+		// the user never asked for it — so it waits behind the guard below.
+		if (retired === REVOKED) return;
 		// Every other outcome needs the wrapping key, so a vault that has records and cannot
 		// produce one is refused rather than answered. Declining here would let the caller
 		// erase the clear-text slot, which on an unreadable vault is the user's only remaining
@@ -654,6 +682,7 @@ export async function importLegacySecret(id: string, secret: string): Promise<vo
 		// atomic and authoritative; this one only makes the answer diagnosable and keeps a
 		// readable copy alive.
 		if (storedCount > 0 && !(await readWrapKey(db))) throw vaultCorrupt();
+		if (retired) return;
 		if (existingCount > 0) return;
 
 		const record = await encryptSecret(db, secret, "only-when-empty");
@@ -663,10 +692,11 @@ export async function importLegacySecret(id: string, secret: string): Promise<vo
 		return new Promise<void>((resolve, reject) => {
 			// Chained inside the success callbacks rather than awaited, to keep the transaction
 			// live across the decision.
-			const retired = meta.count(retiredKey(id));
-			retired.onsuccess = () => {
-				// The user deleted this credential. The slot is a stale copy of something revoked.
-				if (retired.result > 0) return;
+			const marker = meta.get(retiredKey(id));
+			marker.onsuccess = () => {
+				// This vault has already settled the credential, by revocation or by dropping an
+				// unreadable record. Either way the slot is a copy of something superseded.
+				if (readRetiredReason(marker.result)) return;
 				const existing = secrets.count(id);
 				existing.onsuccess = () => {
 					// A stored secret outranks the slot: importing would revert a key the user

--- a/src/lib/adapters/browser-key-vault.ts
+++ b/src/lib/adapters/browser-key-vault.ts
@@ -47,10 +47,11 @@ const STORE_WRAP = "wrap-key";
 /** Holds one ciphertext record per provider. */
 const STORE_SECRETS = "secrets";
 /**
- * Holds markers that must outlive the records they describe.
+ * Holds markers that describe a provider rather than store its secret.
  *
- * Separate from {@link STORE_SECRETS} because a marker's whole purpose is to survive the
- * deletion of that provider's secret.
+ * Separate from {@link STORE_SECRETS} so every record in that store is a `SecretRecord`:
+ * a marker keyed into it would survive `deleteSecret` (which deletes by exact key), but the
+ * store's readers would then have to tolerate two unrelated record shapes.
  */
 const STORE_META = "meta";
 
@@ -108,7 +109,7 @@ export class KeyVaultError extends Error {
 }
 
 const UNAVAILABLE_MESSAGE =
-	"Encrypted key storage is unavailable in this browser, so the API key cannot be stored.";
+	"Encrypted key storage is unavailable in this browser. Check that this site is allowed to store data, then try again.";
 const CORRUPT_MESSAGE = "The stored API key could not be read and needs to be entered again.";
 const VAULT_CORRUPT_MESSAGE =
 	"Encrypted key storage in this browser is damaged. Clear this site's browser data, then add your API key again.";

--- a/src/lib/adapters/browser-key-vault.ts
+++ b/src/lib/adapters/browser-key-vault.ts
@@ -49,17 +49,22 @@ const STORE_SECRETS = "secrets";
 /**
  * Holds markers that describe a provider rather than store its secret.
  *
- * Separate from {@link STORE_SECRETS} so every record in that store is a `SecretRecord`: a
- * marker keyed into it would survive a delete by exact key, and every reader of that store
- * would have to tolerate two unrelated record shapes.
+ * Separate from {@link STORE_SECRETS} so every record in that store is a `SecretRecord`, and
+ * no reader of it has to tolerate two unrelated record shapes.
  */
 const STORE_META = "meta";
 
 /**
- * Marker key prefix recording that a provider's pre-#133 clear-text slot has been dealt with
+ * Key of the marker recording that a provider's pre-#133 clear-text slot has been dealt with
  * and must never be imported again.
+ *
+ * Built in one place because the pre-check, the authoritative guard and both writers must
+ * agree; a guard that reads a different key than the writer writes reads as "not retired"
+ * forever, and the caller erases the clear-text slot on the strength of it.
  */
-const LEGACY_RETIRED_PREFIX = "legacy-retired:";
+function retiredKey(id: string): string {
+	return `legacy-retired:${id}`;
+}
 
 const WRAP_KEY_ID = "aes-gcm-256-v1";
 
@@ -114,9 +119,10 @@ export class KeyVaultError extends Error {
  * Held here rather than on the error so nothing that logs or serializes a `KeyVaultError` can
  * pick up stored ciphertext, and keyed weakly so it disappears with the error.
  */
-const corruptRecords = new WeakMap<KeyVaultError, SecretRecord>();
+const corruptRecords = new WeakMap<KeyVaultError, SecretRecord | null>();
 
-function corruptRecord(record: SecretRecord): KeyVaultError {
+/** `null` records that the stored value did not read back as a record at all. */
+function corruptRecord(record: SecretRecord | null): KeyVaultError {
 	const error = new KeyVaultError("corrupt", CORRUPT_MESSAGE);
 	corruptRecords.set(error, record);
 	return error;
@@ -449,8 +455,7 @@ export async function getSecret(id: string): Promise<string | null> {
 		const stored = await awaitRequest(store.get(id));
 		if (stored === undefined) return null;
 		const record = readSecretRecord(stored);
-		// Unreadable as a record at all, so there is nothing to compare a later drop against.
-		if (!record) throw new KeyVaultError("corrupt", CORRUPT_MESSAGE);
+		if (!record) throw corruptRecord(null);
 
 		const wrapKey = await readWrapKey(db);
 		if (!wrapKey) throw vaultCorrupt();
@@ -502,17 +507,17 @@ export async function hasSecret(id: string): Promise<boolean> {
  * to erase the clear-text slot cannot be trusted to hold a note saying it was dismissed.
  *
  * It is written on every delete, including for providers that never had a clear-text slot,
- * and there is no way to clear one. Both are deliberate: deciding whether a slot exists would
- * mean reading `localStorage`, which is exactly the source this marker exists to stop
- * trusting, and a marker that could be cleared would not be a durable record of the user's
- * intent. The cost is one small record per provider the user has ever deleted a key for.
+ * and there is no way to clear one. Both are deliberate: whether a slot exists is decided by
+ * a `localStorage` read that can throw or lie, and a durable record must not be gated on one;
+ * and a marker that could be cleared would not be durable. The cost is one small record per
+ * provider the user has ever deleted a key for.
  */
 export async function retireAndDeleteSecret(id: string): Promise<void> {
 	await withVault(async (db) => {
 		const tx = db.transaction([STORE_SECRETS, STORE_META], "readwrite");
 		// Both requests are issued before any `await`, because a transaction commits as soon as
 		// its request queue drains and control returns to the event loop.
-		const marked = tx.objectStore(STORE_META).put(true, `${LEGACY_RETIRED_PREFIX}${id}`);
+		const marked = tx.objectStore(STORE_META).put(true, retiredKey(id));
 		const deleted = tx.objectStore(STORE_SECRETS).delete(id);
 		await awaitWrite(tx, marked, deleted);
 	});
@@ -521,19 +526,18 @@ export async function retireAndDeleteSecret(id: string): Promise<void> {
 /**
  * Drop the record that `error` was raised for, and settle `id`'s clear-text slot with it.
  *
- * Conditional on the stored bytes still being the ones that failed to decrypt. Reading,
+ * Conditional on the stored value still being the one that could not be read. Reading,
  * decrypting and then deleting spans several transactions, so another tab can save a working
  * key in between — and deleting by id alone would throw that key away and leave behind a
- * retirement marker no path can clear. Comparing inside the write transaction makes the drop
- * apply only to the damaged record it was decided for.
+ * retirement marker no path can clear. Re-reading inside the write transaction makes the drop
+ * apply only to the damaged value it was decided for. A key saved concurrently reads back as
+ * a well-formed record, so it is never the thing dropped.
  *
- * Does nothing when `error` carries no record, which is the case for a value too malformed to
- * read back as one. There is nothing to compare then, and dropping unconditionally is the
- * behaviour this exists to avoid.
+ * Does nothing for an `error` this vault did not raise for a stored value.
  */
 export async function dropUnreadableSecret(id: string, error: KeyVaultError): Promise<void> {
-	const expected = corruptRecords.get(error);
-	if (!expected) return;
+	if (!corruptRecords.has(error)) return;
+	const expected = corruptRecords.get(error) ?? null;
 	await withVault(async (db) => {
 		const tx = db.transaction([STORE_SECRETS, STORE_META], "readwrite");
 		const secrets = tx.objectStore(STORE_SECRETS);
@@ -541,10 +545,18 @@ export async function dropUnreadableSecret(id: string, error: KeyVaultError): Pr
 			// Chained inside the callback rather than awaited, to keep the transaction live.
 			const current = secrets.get(id);
 			current.onsuccess = () => {
+				if (current.result === undefined) return;
 				const stored = readSecretRecord(current.result);
-				if (!stored || !sameRecord(stored, expected)) return;
+				// A value that never parsed is identified by still not parsing: there are no
+				// bytes to compare, but "unreadable" is itself the fact that was established,
+				// and anything written since would parse.
+				const isSameValue =
+					expected === null ? stored === null : stored !== null && sameRecord(stored, expected);
+				if (!isSameValue) return;
+				// Order is immaterial inside one transaction, and a failing request aborts it
+				// into `onerror`, so resolving on `oncomplete` alone is enough here.
 				secrets.delete(id);
-				tx.objectStore(STORE_META).put(true, `${LEGACY_RETIRED_PREFIX}${id}`);
+				tx.objectStore(STORE_META).put(true, retiredKey(id));
 			};
 			tx.oncomplete = () => resolve();
 			tx.onabort = () => reject(unavailable());
@@ -579,16 +591,27 @@ function sameRecord(a: SecretRecord, b: SecretRecord): boolean {
  */
 export async function importLegacySecret(id: string, secret: string): Promise<void> {
 	return withVault(async (db) => {
-		// Read-only pre-check, purely so the common declines cost nothing and, more importantly,
-		// so `encryptSecret` is not reached on a read. Encrypting mints a wrapping key when the
-		// vault has none, which would turn the diagnosable "records exist but the key is gone"
-		// state into a silent one — the invariant `getSecret` documents. The authoritative
-		// answer is still the in-transaction check below; this only declines early.
+		// Read-only pre-check, so an import that is going to decline never reaches
+		// `encryptSecret`. Encrypting mints a wrapping key when the vault has none, which would
+		// turn the diagnosable "records exist but the key is gone" state into a silent one —
+		// the invariant `getSecret` documents. The authoritative answer is still the
+		// in-transaction check below; this only declines early, so the two cannot disagree in a
+		// way that stores something they would not.
 		const check = db.transaction([STORE_SECRETS, STORE_META], "readonly");
-		const retiredEarly = check.objectStore(STORE_META).count(`${LEGACY_RETIRED_PREFIX}${id}`);
-		const existingEarly = check.objectStore(STORE_SECRETS).count(id);
-		if ((await awaitRequest(retiredEarly)) > 0) return;
-		if ((await awaitRequest(existingEarly)) > 0) return;
+		// All three handlers are attached in this task, so none of them can miss its event.
+		const [retiredCount, existingCount, storedCount] = await Promise.all([
+			awaitRequest(check.objectStore(STORE_META).count(retiredKey(id))),
+			awaitRequest(check.objectStore(STORE_SECRETS).count(id)),
+			awaitRequest(check.objectStore(STORE_SECRETS).count()),
+		]);
+		// Checked before either decline, because both of them are answers, and this vault is in
+		// no state to give one. The wrapping key is shared, so minting a replacement would
+		// orphan every record already stored under the old one — and declining would let the
+		// caller erase the clear-text slot, which on an unreadable vault is the user's only
+		// remaining copy. Failing keeps the state diagnosable and both copies intact.
+		if (storedCount > 0 && !(await readWrapKey(db))) throw vaultCorrupt();
+		if (retiredCount > 0) return;
+		if (existingCount > 0) return;
 
 		const record = await encryptSecret(db, secret);
 		const tx = db.transaction([STORE_SECRETS, STORE_META], "readwrite");
@@ -597,7 +620,7 @@ export async function importLegacySecret(id: string, secret: string): Promise<vo
 		return new Promise<void>((resolve, reject) => {
 			// Chained inside the success callbacks rather than awaited, to keep the transaction
 			// live across the decision.
-			const retired = meta.count(`${LEGACY_RETIRED_PREFIX}${id}`);
+			const retired = meta.count(retiredKey(id));
 			retired.onsuccess = () => {
 				// The user deleted this credential. The slot is a stale copy of something revoked.
 				if (retired.result > 0) return;

--- a/src/lib/adapters/browser-key-vault.ts
+++ b/src/lib/adapters/browser-key-vault.ts
@@ -1,0 +1,294 @@
+/**
+ * Encrypted-at-rest storage for browser BYOK API keys.
+ *
+ * The browser has no OS keychain, so the key has to live in a web store. Rather than the
+ * clear text `localStorage` this replaces, the vault keeps a non-extractable AES-GCM
+ * `CryptoKey` in IndexedDB and persists only ciphertext. `extractable: false` means the
+ * wrapping material cannot be read back out of the browser even by code running on this
+ * origin — structured clone moves the handle into IndexedDB, but `exportKey` on it always
+ * rejects.
+ *
+ * What this defends against: inspection of the browser profile on disk, and extensions or
+ * tooling that read web storage, which now see ciphertext and an unexportable handle.
+ *
+ * What it does not defend against: script execution on the ThreatForge origin. Such script
+ * can reach the same handle and use it to decrypt, exactly as the application does. That
+ * residual risk is accepted (#133) and is mitigated separately by the strict CSP (#156). Do
+ * not describe this storage as protecting against a compromised page.
+ *
+ * The database is deliberately separate from the workspace database so document storage and
+ * key storage never share a namespace; see `src/lib/persistence/no-key-leakage.test.ts`.
+ */
+
+/** Key-vault database name. Disjoint from `WORKSPACE_STORAGE_NAMESPACE`. */
+export const KEY_VAULT_DB_NAME = "threatforge-keychain";
+const KEY_VAULT_DB_VERSION = 1;
+
+/** Holds the single non-extractable wrapping key. */
+const STORE_WRAP = "wrap-key";
+/** Holds one ciphertext record per provider. */
+const STORE_SECRETS = "secrets";
+
+const WRAP_KEY_ID = "aes-gcm-256-v1";
+
+/** AES-GCM standard nonce length. A fresh nonce is drawn for every encryption. */
+const IV_BYTES = 12;
+
+/** Why a vault operation could not complete. */
+export type KeyVaultErrorReason =
+	/** IndexedDB or Web Crypto is missing, blocked, or otherwise unusable here. */
+	| "unavailable"
+	/** A stored record exists but could not be decrypted into a usable key. */
+	| "corrupt";
+
+/**
+ * A vault failure carrying a user-safe message. Raw `DOMException` text and internal detail
+ * are never propagated, so nothing about the stored key or the host can leak through an
+ * error surfaced in the UI.
+ */
+export class KeyVaultError extends Error {
+	readonly reason: KeyVaultErrorReason;
+
+	constructor(reason: KeyVaultErrorReason, message: string) {
+		super(message);
+		this.name = "KeyVaultError";
+		this.reason = reason;
+	}
+}
+
+const UNAVAILABLE_MESSAGE =
+	"Encrypted key storage is unavailable in this browser, so the API key cannot be stored.";
+const CORRUPT_MESSAGE = "The stored API key could not be read and needs to be entered again.";
+
+function unavailable(): KeyVaultError {
+	return new KeyVaultError("unavailable", UNAVAILABLE_MESSAGE);
+}
+
+/** A stored secret: the AES-GCM nonce and ciphertext for one provider's key. */
+interface SecretRecord {
+	iv: Uint8Array<ArrayBuffer>;
+	ciphertext: Uint8Array<ArrayBuffer>;
+}
+
+/**
+ * Coerce a value read back from IndexedDB into bytes.
+ *
+ * Structured clone can hand back a typed array constructed in a different realm from the
+ * one running this check, so `value instanceof Uint8Array` is unreliable. `ArrayBuffer.isView`
+ * tests the internal slot instead and holds across realms, which is the property needed here.
+ */
+function asBytes(value: unknown): Uint8Array<ArrayBuffer> | null {
+	if (!ArrayBuffer.isView(value)) return null;
+	// Copied rather than aliased so the result is always backed by a plain `ArrayBuffer`,
+	// which is what Web Crypto accepts as a `BufferSource`.
+	return Uint8Array.from(new Uint8Array(value.buffer, value.byteOffset, value.byteLength));
+}
+
+/** Recover a secret record from a stored value, or `null` when it is not one. */
+function readSecretRecord(value: unknown): SecretRecord | null {
+	if (typeof value !== "object" || value === null) return null;
+	const candidate = value as Record<string, unknown>;
+	const iv = asBytes(candidate.iv);
+	const ciphertext = asBytes(candidate.ciphertext);
+	if (!iv || !ciphertext) return null;
+	return { iv, ciphertext };
+}
+
+/**
+ * Resolve Web Crypto, rejecting when `subtle` is absent. `crypto.subtle` is only exposed in
+ * secure contexts, so an insecure origin fails here rather than silently degrading.
+ */
+function requireSubtle(): SubtleCrypto {
+	const subtle = globalThis.crypto?.subtle;
+	if (!subtle) throw unavailable();
+	return subtle;
+}
+
+/** Open the vault database, creating both stores on first use. */
+function openVault(): Promise<IDBDatabase> {
+	return new Promise((resolve, reject) => {
+		const factory = globalThis.indexedDB;
+		if (!factory) {
+			reject(unavailable());
+			return;
+		}
+
+		let request: IDBOpenDBRequest;
+		try {
+			request = factory.open(KEY_VAULT_DB_NAME, KEY_VAULT_DB_VERSION);
+		} catch {
+			// Some private-mode browsers throw synchronously from `open()`.
+			reject(unavailable());
+			return;
+		}
+
+		request.onupgradeneeded = () => {
+			const db = request.result;
+			if (!db.objectStoreNames.contains(STORE_WRAP)) db.createObjectStore(STORE_WRAP);
+			if (!db.objectStoreNames.contains(STORE_SECRETS)) db.createObjectStore(STORE_SECRETS);
+		};
+		request.onsuccess = () => resolve(request.result);
+		request.onerror = () => reject(unavailable());
+		request.onblocked = () => reject(unavailable());
+	});
+}
+
+/** Await one IndexedDB request, mapping any failure to a user-safe vault error. */
+function awaitRequest<T>(request: IDBRequest<T>): Promise<T> {
+	return new Promise((resolve, reject) => {
+		request.onsuccess = () => resolve(request.result);
+		request.onerror = () => reject(unavailable());
+	});
+}
+
+/**
+ * Return the vault's wrapping key, generating it on first use.
+ *
+ * Key generation is awaited outside any transaction, because an IndexedDB transaction
+ * commits as soon as the event loop drains with no pending request against it — holding one
+ * open across `generateKey` would silently drop the write.
+ */
+async function getOrCreateWrapKey(db: IDBDatabase): Promise<CryptoKey> {
+	const subtle = requireSubtle();
+
+	const existing = await readWrapKey(db);
+	if (existing) return existing;
+
+	const candidate = await subtle.generateKey({ name: "AES-GCM", length: 256 }, false, [
+		"encrypt",
+		"decrypt",
+	]);
+	return installWrapKey(db, candidate);
+}
+
+/** Read the stored wrapping key, or `null` when the vault has not been initialized yet. */
+async function readWrapKey(db: IDBDatabase): Promise<CryptoKey | null> {
+	const store = db.transaction(STORE_WRAP, "readonly").objectStore(STORE_WRAP);
+	const stored = await awaitRequest(store.get(WRAP_KEY_ID));
+	if (stored instanceof CryptoKey) return stored;
+	if (stored !== undefined) {
+		// A record is present but is not a usable key: refuse rather than silently replacing
+		// it, because overwriting would permanently orphan every secret encrypted under it.
+		throw new KeyVaultError("corrupt", CORRUPT_MESSAGE);
+	}
+	return null;
+}
+
+/**
+ * Store `candidate` as the wrapping key unless another context installed one first, and
+ * return whichever key won.
+ *
+ * The re-read and the write are chained inside the request callback so they share one live
+ * `readwrite` transaction. That makes the check-and-set atomic: two tabs initializing the
+ * vault concurrently converge on a single key instead of the second overwriting the first
+ * and orphaning everything already encrypted under it.
+ */
+function installWrapKey(db: IDBDatabase, candidate: CryptoKey): Promise<CryptoKey> {
+	return new Promise((resolve, reject) => {
+		const store = db.transaction(STORE_WRAP, "readwrite").objectStore(STORE_WRAP);
+		const read = store.get(WRAP_KEY_ID);
+		read.onerror = () => reject(unavailable());
+		read.onsuccess = () => {
+			const stored = read.result;
+			if (stored instanceof CryptoKey) {
+				resolve(stored);
+				return;
+			}
+			if (stored !== undefined) {
+				reject(new KeyVaultError("corrupt", CORRUPT_MESSAGE));
+				return;
+			}
+			const write = store.put(candidate, WRAP_KEY_ID);
+			write.onerror = () => reject(unavailable());
+			write.onsuccess = () => resolve(candidate);
+		};
+	});
+}
+
+/** Run `operation` against an open vault, always closing the connection. */
+async function withVault<T>(operation: (db: IDBDatabase) => Promise<T>): Promise<T> {
+	const db = await openVault();
+	try {
+		return await operation(db);
+	} finally {
+		db.close();
+	}
+}
+
+/**
+ * Encrypt `secret` under the vault's wrapping key and store it for `id`.
+ *
+ * @throws KeyVaultError when the vault cannot be opened or Web Crypto is unavailable. The
+ * caller must surface that failure rather than storing the value in clear text.
+ */
+export async function putSecret(id: string, secret: string): Promise<void> {
+	await withVault(async (db) => {
+		const subtle = requireSubtle();
+		const wrapKey = await getOrCreateWrapKey(db);
+		const iv = globalThis.crypto.getRandomValues(new Uint8Array(IV_BYTES));
+		const encrypted = await subtle.encrypt(
+			{ name: "AES-GCM", iv },
+			wrapKey,
+			new TextEncoder().encode(secret),
+		);
+		// Persisted as a view rather than a raw `ArrayBuffer` so both fields read back through
+		// the same realm-independent check.
+		const record: SecretRecord = { iv, ciphertext: new Uint8Array(encrypted) };
+		const store = db.transaction(STORE_SECRETS, "readwrite").objectStore(STORE_SECRETS);
+		await awaitRequest(store.put(record, id));
+	});
+}
+
+/**
+ * Decrypt and return the secret stored for `id`, or `null` when none is stored.
+ *
+ * @throws KeyVaultError with reason `corrupt` when a record exists but cannot be decrypted,
+ * which is reported distinctly from "no key stored" so the UI can prompt for re-entry.
+ */
+export async function getSecret(id: string): Promise<string | null> {
+	return withVault(async (db) => {
+		const subtle = requireSubtle();
+		const store = db.transaction(STORE_SECRETS, "readonly").objectStore(STORE_SECRETS);
+		const stored = await awaitRequest(store.get(id));
+		if (stored === undefined) return null;
+		const record = readSecretRecord(stored);
+		if (!record) throw new KeyVaultError("corrupt", CORRUPT_MESSAGE);
+
+		const wrapKey = await getOrCreateWrapKey(db);
+		let plaintext: ArrayBuffer;
+		try {
+			plaintext = await subtle.decrypt(
+				{ name: "AES-GCM", iv: record.iv },
+				wrapKey,
+				record.ciphertext,
+			);
+		} catch {
+			// AES-GCM authentication failed: the record was truncated, tampered with, or was
+			// written under a wrapping key that no longer exists.
+			throw new KeyVaultError("corrupt", CORRUPT_MESSAGE);
+		}
+		return new TextDecoder().decode(plaintext);
+	});
+}
+
+/** Report whether a secret is stored for `id` without decrypting it. */
+export async function hasSecret(id: string): Promise<boolean> {
+	return withVault(async (db) => {
+		const store = db.transaction(STORE_SECRETS, "readonly").objectStore(STORE_SECRETS);
+		const count = await awaitRequest(store.count(id));
+		return count > 0;
+	});
+}
+
+/**
+ * Delete the secret stored for `id`.
+ *
+ * The wrapping key is intentionally left in place: it is shared by every provider, so
+ * removing one provider's key must not orphan the others.
+ */
+export async function deleteSecret(id: string): Promise<void> {
+	await withVault(async (db) => {
+		const store = db.transaction(STORE_SECRETS, "readwrite").objectStore(STORE_SECRETS);
+		await awaitRequest(store.delete(id));
+	});
+}

--- a/src/lib/adapters/browser-key-vault.ts
+++ b/src/lib/adapters/browser-key-vault.ts
@@ -86,7 +86,10 @@ function retiredKey(id: string): string {
  *
  * Only `retireAndDeleteSecret` overwrites a marker that already stands. The other writers
  * defer to whatever is there, so a value this build does not recognise is preserved rather
- * than downgraded to one it does.
+ * than downgraded to one it does. The revocation is exempt on purpose: `"revoked"` is the
+ * strongest marker this build has, and a user throwing a credential away must always be
+ * recordable. That is the one place an unrecognised value is replaced, and the trade is
+ * deliberate — a marker that cannot be written is a revocation that cannot be enforced.
  */
 type RetiredReason = "revoked" | "settled";
 
@@ -541,12 +544,15 @@ type SlotSettlement = "supersede-slot" | "leave-slot";
  * the marker write fail are the same ones that later destroy the record, so the two are
  * correlated rather than independent.
  *
- * A marker already recorded for this provider is never overwritten. Rewriting one that stands
- * changes nothing this build reads, but it is a request that can fail, and it shares the
- * transaction with the ciphertext — so a per-record meta fault would turn a save that used to
- * commit into a rejection. It would also clobber a marker shape written by some later build,
- * which this build cannot interpret and so must not downgrade. The read and the write share
- * the transaction, so no concurrent delete can land between them.
+ * A marker already recorded for this provider is never overwritten. This path only ever
+ * writes `SETTLED`, so rewriting a standing marker can only hold it level or lower it: a
+ * revocation would be downgraded, disarming the one path that erases a revoked clear-text
+ * credential on a vault that cannot offer a replacement, and a shape written by some later
+ * build would be replaced by one this build happens to understand. Even where the value is
+ * unchanged the write is a request that can fail, and it shares the transaction with the
+ * ciphertext, so a per-record meta fault would turn a save that used to commit into a
+ * rejection. The read and the write share the transaction, so no concurrent delete can land
+ * between them.
  *
  * @throws KeyVaultError when the vault cannot be opened or Web Crypto is unavailable. The
  * caller must surface that failure rather than storing the value in clear text.
@@ -667,7 +673,8 @@ export async function hasSecret(id: string): Promise<boolean> {
  * stands. This is the one direction that must override: a slot already settled for some other
  * reason has to be re-settled as revoked when the user throws the credential away, because
  * that is what makes the stale clear-text copy erasable on a vault too damaged to offer a
- * replacement. Every other re-settling would only rewrite a decision with an equal one.
+ * replacement. It is safe to make unconditional for the same reason: a revocation is the
+ * strongest marker, so this write never lowers what it replaces.
  */
 export async function retireAndDeleteSecret(id: string): Promise<void> {
 	await withVault(async (db) => {
@@ -692,7 +699,7 @@ export async function retireAndDeleteSecret(id: string): Promise<void> {
  *
  * Does nothing for an `error` this vault did not raise for a stored value.
  *
- * The marker defers to any marker already recorded, which matters most for a revocation. A
+ * This path defers to any marker already recorded, which matters most for a revocation. A
  * save after one re-creates a stored record while the `REVOKED` marker still stands, so this
  * path can find a matching value to drop with a revocation in place, and lowering it would
  * leave a credential the user threw away sitting readable in clear text on a damaged vault.

--- a/src/lib/adapters/browser-key-vault.ts
+++ b/src/lib/adapters/browser-key-vault.ts
@@ -49,9 +49,9 @@ const STORE_SECRETS = "secrets";
 /**
  * Holds markers that describe a provider rather than store its secret.
  *
- * Separate from {@link STORE_SECRETS} so every record in that store is a `SecretRecord`. A
- * marker keyed into the secrets store would also collide with the provider ids that store
- * uses as keys, which is what {@link LEGACY_RETIRED_PREFIX} exists to avoid.
+ * Separate from {@link STORE_SECRETS} so every record in that store is a `SecretRecord`: a
+ * marker keyed into it would survive a delete by exact key, and every reader of that store
+ * would have to tolerate two unrelated record shapes.
  */
 const STORE_META = "meta";
 
@@ -106,6 +106,20 @@ export class KeyVaultError extends Error {
 		this.name = "KeyVaultError";
 		this.reason = reason;
 	}
+}
+
+/**
+ * The record each `corrupt` error was raised for.
+ *
+ * Held here rather than on the error so nothing that logs or serializes a `KeyVaultError` can
+ * pick up stored ciphertext, and keyed weakly so it disappears with the error.
+ */
+const corruptRecords = new WeakMap<KeyVaultError, SecretRecord>();
+
+function corruptRecord(record: SecretRecord): KeyVaultError {
+	const error = new KeyVaultError("corrupt", CORRUPT_MESSAGE);
+	corruptRecords.set(error, record);
+	return error;
 }
 
 const UNAVAILABLE_MESSAGE =
@@ -390,12 +404,6 @@ async function withVault<T>(operation: (db: IDBDatabase) => Promise<T>): Promise
 	}
 }
 
-/**
- * Encrypt `secret` under the vault's wrapping key and store it for `id`.
- *
- * @throws KeyVaultError when the vault cannot be opened or Web Crypto is unavailable. The
- * caller must surface that failure rather than storing the value in clear text.
- */
 /** Encrypt `secret` under the vault's wrapping key, minting one if the vault has none. */
 async function encryptSecret(db: IDBDatabase, secret: string): Promise<SecretRecord> {
 	const subtle = requireSubtle();
@@ -411,6 +419,12 @@ async function encryptSecret(db: IDBDatabase, secret: string): Promise<SecretRec
 	return { iv, ciphertext: new Uint8Array(encrypted) };
 }
 
+/**
+ * Encrypt `secret` under the vault's wrapping key and store it for `id`.
+ *
+ * @throws KeyVaultError when the vault cannot be opened or Web Crypto is unavailable. The
+ * caller must surface that failure rather than storing the value in clear text.
+ */
 export async function putSecret(id: string, secret: string): Promise<void> {
 	await withVault(async (db) => {
 		const record = await encryptSecret(db, secret);
@@ -435,6 +449,7 @@ export async function getSecret(id: string): Promise<string | null> {
 		const stored = await awaitRequest(store.get(id));
 		if (stored === undefined) return null;
 		const record = readSecretRecord(stored);
+		// Unreadable as a record at all, so there is nothing to compare a later drop against.
 		if (!record) throw new KeyVaultError("corrupt", CORRUPT_MESSAGE);
 
 		const wrapKey = await readWrapKey(db);
@@ -452,7 +467,7 @@ export async function getSecret(id: string): Promise<string | null> {
 			// a fault in the crypto layer, not evidence about this record — classifying it as
 			// `corrupt` would let a transient failure delete a perfectly good key.
 			if (isOperationError(error)) {
-				throw new KeyVaultError("corrupt", CORRUPT_MESSAGE);
+				throw corruptRecord(record);
 			}
 			throw vaultCorrupt();
 		}
@@ -485,6 +500,12 @@ export async function hasSecret(id: string): Promise<boolean> {
  * The marker lives in the vault rather than in `localStorage` because the only situation that
  * needs it is one where `localStorage` has already proven unreliable: a browser that refuses
  * to erase the clear-text slot cannot be trusted to hold a note saying it was dismissed.
+ *
+ * It is written on every delete, including for providers that never had a clear-text slot,
+ * and there is no way to clear one. Both are deliberate: deciding whether a slot exists would
+ * mean reading `localStorage`, which is exactly the source this marker exists to stop
+ * trusting, and a marker that could be cleared would not be a durable record of the user's
+ * intent. The cost is one small record per provider the user has ever deleted a key for.
  */
 export async function retireAndDeleteSecret(id: string): Promise<void> {
 	await withVault(async (db) => {
@@ -498,8 +519,51 @@ export async function retireAndDeleteSecret(id: string): Promise<void> {
 }
 
 /**
- * Store `secret` for `id` only if the vault has neither a secret nor a retirement marker for
- * it, and report whether it was stored.
+ * Drop the record that `error` was raised for, and settle `id`'s clear-text slot with it.
+ *
+ * Conditional on the stored bytes still being the ones that failed to decrypt. Reading,
+ * decrypting and then deleting spans several transactions, so another tab can save a working
+ * key in between — and deleting by id alone would throw that key away and leave behind a
+ * retirement marker no path can clear. Comparing inside the write transaction makes the drop
+ * apply only to the damaged record it was decided for.
+ *
+ * Does nothing when `error` carries no record, which is the case for a value too malformed to
+ * read back as one. There is nothing to compare then, and dropping unconditionally is the
+ * behaviour this exists to avoid.
+ */
+export async function dropUnreadableSecret(id: string, error: KeyVaultError): Promise<void> {
+	const expected = corruptRecords.get(error);
+	if (!expected) return;
+	await withVault(async (db) => {
+		const tx = db.transaction([STORE_SECRETS, STORE_META], "readwrite");
+		const secrets = tx.objectStore(STORE_SECRETS);
+		await new Promise<void>((resolve, reject) => {
+			// Chained inside the callback rather than awaited, to keep the transaction live.
+			const current = secrets.get(id);
+			current.onsuccess = () => {
+				const stored = readSecretRecord(current.result);
+				if (!stored || !sameRecord(stored, expected)) return;
+				secrets.delete(id);
+				tx.objectStore(STORE_META).put(true, `${LEGACY_RETIRED_PREFIX}${id}`);
+			};
+			tx.oncomplete = () => resolve();
+			tx.onabort = () => reject(unavailable());
+			tx.onerror = () => reject(unavailable());
+		});
+	});
+}
+
+function sameRecord(a: SecretRecord, b: SecretRecord): boolean {
+	return (
+		a.iv.length === b.iv.length &&
+		a.ciphertext.length === b.ciphertext.length &&
+		a.iv.every((byte, index) => byte === b.iv[index]) &&
+		a.ciphertext.every((byte, index) => byte === b.ciphertext[index])
+	);
+}
+
+/**
+ * Store `secret` for `id` only if the vault has neither a secret nor a retirement marker.
  *
  * Migration is a check-then-act, and split across transactions it loses to a concurrent
  * delete: a tab that reads "not retired, not stored", is descheduled while another tab
@@ -510,18 +574,27 @@ export async function retireAndDeleteSecret(id: string): Promise<void> {
  * transaction either wholly precedes the delete, whose marker and delete then apply on top,
  * or wholly follows it and sees the marker.
  *
- * Encryption happens before the transaction opens, since awaiting Web Crypto inside one would
- * let it commit early. Encrypting a value that then turns out not to need storing is wasted
- * work in a path that runs once per profile, not a correctness problem.
+ * Encryption happens before the write transaction opens, since awaiting Web Crypto inside one
+ * would let it commit early.
  */
-export async function importLegacySecret(id: string, secret: string): Promise<boolean> {
+export async function importLegacySecret(id: string, secret: string): Promise<void> {
 	return withVault(async (db) => {
+		// Read-only pre-check, purely so the common declines cost nothing and, more importantly,
+		// so `encryptSecret` is not reached on a read. Encrypting mints a wrapping key when the
+		// vault has none, which would turn the diagnosable "records exist but the key is gone"
+		// state into a silent one — the invariant `getSecret` documents. The authoritative
+		// answer is still the in-transaction check below; this only declines early.
+		const check = db.transaction([STORE_SECRETS, STORE_META], "readonly");
+		const retiredEarly = check.objectStore(STORE_META).count(`${LEGACY_RETIRED_PREFIX}${id}`);
+		const existingEarly = check.objectStore(STORE_SECRETS).count(id);
+		if ((await awaitRequest(retiredEarly)) > 0) return;
+		if ((await awaitRequest(existingEarly)) > 0) return;
+
 		const record = await encryptSecret(db, secret);
 		const tx = db.transaction([STORE_SECRETS, STORE_META], "readwrite");
 		const meta = tx.objectStore(STORE_META);
 		const secrets = tx.objectStore(STORE_SECRETS);
-		return new Promise<boolean>((resolve, reject) => {
-			let stored = false;
+		return new Promise<void>((resolve, reject) => {
 			// Chained inside the success callbacks rather than awaited, to keep the transaction
 			// live across the decision.
 			const retired = meta.count(`${LEGACY_RETIRED_PREFIX}${id}`);
@@ -533,13 +606,10 @@ export async function importLegacySecret(id: string, secret: string): Promise<bo
 					// A stored secret outranks the slot: importing would revert a key the user
 					// replaced while the browser was refusing to erase the old clear-text one.
 					if (existing.result > 0) return;
-					const put = secrets.put(record, id);
-					put.onsuccess = () => {
-						stored = true;
-					};
+					secrets.put(record, id);
 				};
 			};
-			tx.oncomplete = () => resolve(stored);
+			tx.oncomplete = () => resolve();
 			tx.onabort = () => reject(unavailable());
 			tx.onerror = () => reject(unavailable());
 		});

--- a/src/lib/adapters/browser-key-vault.ts
+++ b/src/lib/adapters/browser-key-vault.ts
@@ -4,9 +4,9 @@
  * The browser has no OS keychain, so the key has to live in a web store. Rather than the
  * clear text `localStorage` this replaces, the vault keeps a non-extractable AES-GCM
  * `CryptoKey` in IndexedDB and persists only ciphertext. `extractable: false` means the
- * wrapping material cannot be read back out of the browser even by code running on this
- * origin — structured clone moves the handle into IndexedDB, but `exportKey` on it always
- * rejects.
+ * wrapping material cannot be read back out through the Web Crypto API, even by code running
+ * on this origin — structured clone moves the handle into IndexedDB, but `exportKey` on it
+ * always rejects.
  *
  * What this defends against: casual inspection of web storage. Extensions, devtools, and
  * tooling that read the origin's storage through the platform APIs now see ciphertext and a
@@ -30,12 +30,35 @@
 
 /** Key-vault database name. Disjoint from `WORKSPACE_STORAGE_NAMESPACE`. */
 export const KEY_VAULT_DB_NAME = "threatforge-keychain";
-const KEY_VAULT_DB_VERSION = 1;
+/**
+ * Key-vault schema version.
+ *
+ * Exported so tests can construct a database at exactly this version; opening at any other
+ * version triggers an upgrade and silently repairs the state a test is trying to arrange.
+ *
+ * Version 2 adds {@link STORE_META}. #133 has not shipped, so no version-1 database exists
+ * outside a development profile; the bump exists so those profiles gain the store instead of
+ * failing every operation with a missing-store error.
+ */
+export const KEY_VAULT_DB_VERSION = 2;
 
 /** Holds the single non-extractable wrapping key. */
 const STORE_WRAP = "wrap-key";
 /** Holds one ciphertext record per provider. */
 const STORE_SECRETS = "secrets";
+/**
+ * Holds markers that must outlive the records they describe.
+ *
+ * Separate from {@link STORE_SECRETS} because a marker's whole purpose is to survive the
+ * deletion of that provider's secret.
+ */
+const STORE_META = "meta";
+
+/**
+ * Marker key prefix recording that a provider's pre-#133 clear-text slot has been dealt with
+ * and must never be imported again.
+ */
+const LEGACY_RETIRED_PREFIX = "legacy-retired:";
 
 const WRAP_KEY_ID = "aes-gcm-256-v1";
 
@@ -202,10 +225,12 @@ function openVault(): Promise<IDBDatabase> {
 		}
 
 		let settled = false;
-		// Some browsers accept `open()` and then never fire any event — a documented
-		// private-mode failure mode. Without a bound the promise never settles, the settings
-		// spinner never clears, and (because adapter calls are serialized per provider) every
-		// later call for that provider is wedged behind it even after storage recovers.
+		// A browser can accept `open()` and then never fire any event; the long-standing
+		// WebKit report is the case actually observed in the wild, and any storage layer that
+		// stalls produces the same shape. Without a bound the promise never settles, the
+		// settings spinner never clears, and (because adapter calls are serialized per
+		// provider) every later call for that provider is wedged behind it even after storage
+		// recovers.
 		const timer = setTimeout(() => {
 			if (settled) return;
 			settled = true;
@@ -223,6 +248,7 @@ function openVault(): Promise<IDBDatabase> {
 			const db = request.result;
 			if (!db.objectStoreNames.contains(STORE_WRAP)) db.createObjectStore(STORE_WRAP);
 			if (!db.objectStoreNames.contains(STORE_SECRETS)) db.createObjectStore(STORE_SECRETS);
+			if (!db.objectStoreNames.contains(STORE_META)) db.createObjectStore(STORE_META);
 		};
 		request.onsuccess = () => {
 			// A timeout or `onblocked` may already have rejected; close the connection that
@@ -445,5 +471,28 @@ export async function deleteSecret(id: string): Promise<void> {
 	await withVault(async (db) => {
 		const tx = db.transaction(STORE_SECRETS, "readwrite");
 		await awaitWrite(tx, tx.objectStore(STORE_SECRETS).delete(id));
+	});
+}
+
+/**
+ * Record that `id`'s pre-#133 clear-text slot is settled and must never be imported again.
+ *
+ * The marker lives in the vault rather than in `localStorage` because the only situation that
+ * needs it is one where `localStorage` has already proven unreliable: a browser that refuses
+ * to erase the clear-text slot cannot be trusted to hold a note saying it was dismissed.
+ */
+export async function retireLegacySlot(id: string): Promise<void> {
+	await withVault(async (db) => {
+		const tx = db.transaction(STORE_META, "readwrite");
+		await awaitWrite(tx, tx.objectStore(STORE_META).put(true, `${LEGACY_RETIRED_PREFIX}${id}`));
+	});
+}
+
+/** Report whether {@link retireLegacySlot} has settled `id`'s clear-text slot. */
+export async function isLegacySlotRetired(id: string): Promise<boolean> {
+	return withVault(async (db) => {
+		const store = db.transaction(STORE_META, "readonly").objectStore(STORE_META);
+		const count = await awaitRequest(store.count(`${LEGACY_RETIRED_PREFIX}${id}`));
+		return count > 0;
 	});
 }

--- a/src/lib/adapters/browser-key-vault.ts
+++ b/src/lib/adapters/browser-key-vault.ts
@@ -59,8 +59,7 @@ const STORE_META = "meta";
  * and must never be imported again.
  *
  * Built in one place because the pre-check, the authoritative guard and both writers must
- * agree; a guard that reads a different key than the writer writes reads as "not retired"
- * forever, and the caller erases the clear-text slot on the strength of it.
+ * agree on it.
  */
 function retiredKey(id: string): string {
 	return `legacy-retired:${id}`;
@@ -323,7 +322,7 @@ function awaitWrite(tx: IDBTransaction, ...requests: IDBRequest[]): Promise<void
  * commits as soon as the event loop drains with no pending request against it — holding one
  * open across `generateKey` would silently drop the write.
  */
-async function getOrCreateWrapKey(db: IDBDatabase): Promise<CryptoKey> {
+async function getOrCreateWrapKey(db: IDBDatabase, mint: MintPolicy): Promise<CryptoKey> {
 	const subtle = requireSubtle();
 
 	const existing = await readWrapKey(db);
@@ -333,8 +332,19 @@ async function getOrCreateWrapKey(db: IDBDatabase): Promise<CryptoKey> {
 		"encrypt",
 		"decrypt",
 	]);
-	return installWrapKey(db, candidate);
+	return installWrapKey(db, candidate, mint);
 }
+
+/**
+ * Whether a caller may create the vault's wrapping key when the vault holds records it
+ * cannot read.
+ *
+ * `"always"` is for re-entry: the user is supplying a fresh credential, so a vault whose key
+ * is gone has to be able to start over or they are locked out permanently.
+ * `"only-when-empty"` is for migration, which is not a user asking to store anything — it
+ * runs on a read — so it must not decide that unreadable records are disposable.
+ */
+type MintPolicy = "always" | "only-when-empty";
 
 /** Read the stored wrapping key, or `null` when the vault has not been initialized yet. */
 async function readWrapKey(db: IDBDatabase): Promise<CryptoKey | null> {
@@ -359,10 +369,20 @@ async function readWrapKey(db: IDBDatabase): Promise<CryptoKey | null> {
  * and orphaning everything already encrypted under it. Resolution waits for the commit so a
  * caller never encrypts under a wrapping key whose write later aborts, which would leave a
  * permanently undecryptable record behind.
+ *
+ * Under `"only-when-empty"` the same transaction also counts the secrets, so a vault that
+ * still holds records refuses to mint rather than orphaning them. That check belongs here
+ * and not in the caller: a caller that looks first and mints second loses to a wrap-key wipe
+ * landing in between, which is precisely the state this refuses to create.
  */
-function installWrapKey(db: IDBDatabase, candidate: CryptoKey): Promise<CryptoKey> {
+function installWrapKey(
+	db: IDBDatabase,
+	candidate: CryptoKey,
+	mint: MintPolicy,
+): Promise<CryptoKey> {
 	return new Promise((resolve, reject) => {
-		const tx = db.transaction(STORE_WRAP, "readwrite");
+		const stores = mint === "always" ? [STORE_WRAP] : [STORE_WRAP, STORE_SECRETS];
+		const tx = db.transaction(stores, "readwrite");
 		const read = tx.objectStore(STORE_WRAP).get(WRAP_KEY_ID);
 		let winner: CryptoKey | null = null;
 		let failure: KeyVaultError | null = null;
@@ -381,8 +401,23 @@ function installWrapKey(db: IDBDatabase, candidate: CryptoKey): Promise<CryptoKe
 				tx.abort();
 				return;
 			}
-			winner = candidate;
-			tx.objectStore(STORE_WRAP).put(candidate, WRAP_KEY_ID);
+			if (mint === "always") {
+				winner = candidate;
+				tx.objectStore(STORE_WRAP).put(candidate, WRAP_KEY_ID);
+				return;
+			}
+			const stored = tx.objectStore(STORE_SECRETS).count();
+			stored.onsuccess = () => {
+				if (stored.result > 0) {
+					// Records survive but their key does not. A new key cannot read them, so
+					// minting one would convert a diagnosable vault into permanently silent loss.
+					failure = vaultCorrupt();
+					tx.abort();
+					return;
+				}
+				winner = candidate;
+				tx.objectStore(STORE_WRAP).put(candidate, WRAP_KEY_ID);
+			};
 		};
 
 		tx.oncomplete = () => (winner ? resolve(winner) : reject(failure ?? unavailable()));
@@ -411,9 +446,13 @@ async function withVault<T>(operation: (db: IDBDatabase) => Promise<T>): Promise
 }
 
 /** Encrypt `secret` under the vault's wrapping key, minting one if the vault has none. */
-async function encryptSecret(db: IDBDatabase, secret: string): Promise<SecretRecord> {
+async function encryptSecret(
+	db: IDBDatabase,
+	secret: string,
+	mint: MintPolicy,
+): Promise<SecretRecord> {
 	const subtle = requireSubtle();
-	const wrapKey = await getOrCreateWrapKey(db);
+	const wrapKey = await getOrCreateWrapKey(db, mint);
 	const iv = globalThis.crypto.getRandomValues(new Uint8Array(IV_BYTES));
 	const encrypted = await subtle.encrypt(
 		{ name: "AES-GCM", iv },
@@ -433,7 +472,7 @@ async function encryptSecret(db: IDBDatabase, secret: string): Promise<SecretRec
  */
 export async function putSecret(id: string, secret: string): Promise<void> {
 	await withVault(async (db) => {
-		const record = await encryptSecret(db, secret);
+		const record = await encryptSecret(db, secret, "always");
 		const tx = db.transaction(STORE_SECRETS, "readwrite");
 		await awaitWrite(tx, tx.objectStore(STORE_SECRETS).put(record, id));
 	});
@@ -508,8 +547,8 @@ export async function hasSecret(id: string): Promise<boolean> {
  *
  * It is written on every delete, including for providers that never had a clear-text slot,
  * and there is no way to clear one. Both are deliberate: whether a slot exists is decided by
- * a `localStorage` read that can throw or lie, and a durable record must not be gated on one;
- * and a marker that could be cleared would not be durable. The cost is one small record per
+ * a `localStorage` read that can throw, and a durable record must not be gated on one; and a
+ * marker that could be cleared would not be durable. The cost is one small record per
  * provider the user has ever deleted a key for.
  */
 export async function retireAndDeleteSecret(id: string): Promise<void> {
@@ -604,16 +643,20 @@ export async function importLegacySecret(id: string, secret: string): Promise<vo
 			awaitRequest(check.objectStore(STORE_SECRETS).count(id)),
 			awaitRequest(check.objectStore(STORE_SECRETS).count()),
 		]);
-		// Checked before either decline, because both of them are answers, and this vault is in
-		// no state to give one. The wrapping key is shared, so minting a replacement would
-		// orphan every record already stored under the old one — and declining would let the
-		// caller erase the clear-text slot, which on an unreadable vault is the user's only
-		// remaining copy. Failing keeps the state diagnosable and both copies intact.
-		if (storedCount > 0 && !(await readWrapKey(db))) throw vaultCorrupt();
+		// Answerable without a wrapping key, and answered first: the marker is a durable record
+		// that the user revoked this credential, so the slot is a stale copy that should still
+		// be erased on sight even while the vault is damaged.
 		if (retiredCount > 0) return;
+		// Every other outcome needs the wrapping key, so a vault that has records and cannot
+		// produce one is refused rather than answered. Declining here would let the caller
+		// erase the clear-text slot, which on an unreadable vault is the user's only remaining
+		// copy. `encryptSecret` will not mint over surviving records either — that refusal is
+		// atomic and authoritative; this one only makes the answer diagnosable and keeps a
+		// readable copy alive.
+		if (storedCount > 0 && !(await readWrapKey(db))) throw vaultCorrupt();
 		if (existingCount > 0) return;
 
-		const record = await encryptSecret(db, secret);
+		const record = await encryptSecret(db, secret, "only-when-empty");
 		const tx = db.transaction([STORE_SECRETS, STORE_META], "readwrite");
 		const meta = tx.objectStore(STORE_META);
 		const secrets = tx.objectStore(STORE_SECRETS);

--- a/src/lib/adapters/browser-key-vault.ts
+++ b/src/lib/adapters/browser-key-vault.ts
@@ -13,7 +13,7 @@
  *
  * What it does not defend against: script execution on the ThreatForge origin. Such script
  * can reach the same handle and use it to decrypt, exactly as the application does. That
- * residual risk is accepted (#133) and is mitigated separately by the strict CSP (#156). Do
+ * residual risk is accepted (#133) and is mitigated separately by the deployed CSP (#156). Do
  * not describe this storage as protecting against a compromised page.
  *
  * The database is deliberately separate from the workspace database so document storage and
@@ -38,13 +38,20 @@ const IV_BYTES = 12;
 export type KeyVaultErrorReason =
 	/** IndexedDB or Web Crypto is missing, blocked, or otherwise unusable here. */
 	| "unavailable"
-	/** A stored record exists but could not be decrypted into a usable key. */
-	| "corrupt";
+	/** One provider's record exists but could not be decrypted. Re-entering that key fixes it. */
+	| "corrupt"
+	/**
+	 * The wrapping key itself is unusable, so no provider's record can be decrypted. This is
+	 * distinct from `corrupt` because re-entering a key does not help: the write path needs
+	 * the same wrapping key and fails identically.
+	 */
+	| "vault-corrupt";
 
 /**
  * A vault failure carrying a user-safe message. Raw `DOMException` text and internal detail
  * are never propagated, so nothing about the stored key or the host can leak through an
- * error surfaced in the UI.
+ * error surfaced in the UI. {@link withVault} enforces that by remapping every non-vault
+ * error it sees.
  */
 export class KeyVaultError extends Error {
 	readonly reason: KeyVaultErrorReason;
@@ -59,9 +66,15 @@ export class KeyVaultError extends Error {
 const UNAVAILABLE_MESSAGE =
 	"Encrypted key storage is unavailable in this browser, so the API key cannot be stored.";
 const CORRUPT_MESSAGE = "The stored API key could not be read and needs to be entered again.";
+const VAULT_CORRUPT_MESSAGE =
+	"Encrypted key storage in this browser is damaged. Clear this site's browser data, then add your API key again.";
 
 function unavailable(): KeyVaultError {
 	return new KeyVaultError("unavailable", UNAVAILABLE_MESSAGE);
+}
+
+function vaultCorrupt(): KeyVaultError {
+	return new KeyVaultError("vault-corrupt", VAULT_CORRUPT_MESSAGE);
 }
 
 /** A stored secret: the AES-GCM nonce and ciphertext for one provider's key. */
@@ -73,15 +86,30 @@ interface SecretRecord {
 /**
  * Coerce a value read back from IndexedDB into bytes.
  *
- * Structured clone can hand back a typed array constructed in a different realm from the
- * one running this check, so `value instanceof Uint8Array` is unreliable. `ArrayBuffer.isView`
- * tests the internal slot instead and holds across realms, which is the property needed here.
+ * `value instanceof Uint8Array` compares against one realm's constructor, and a value that
+ * arrived through structured clone need not have been constructed in that realm — under
+ * vitest, jsdom's `window.Uint8Array` and the Node realm that materializes stored records
+ * are different constructors, so `instanceof` returns false for a perfectly good array.
+ * `ArrayBuffer.isView` tests the internal slot instead and holds regardless of realm, which
+ * is the property a deserialization boundary needs.
  */
 function asBytes(value: unknown): Uint8Array<ArrayBuffer> | null {
 	if (!ArrayBuffer.isView(value)) return null;
 	// Copied rather than aliased so the result is always backed by a plain `ArrayBuffer`,
 	// which is what Web Crypto accepts as a `BufferSource`.
 	return Uint8Array.from(new Uint8Array(value.buffer, value.byteOffset, value.byteLength));
+}
+
+/**
+ * Report whether a value read back from IndexedDB is a `CryptoKey`.
+ *
+ * Same realm hazard as {@link asBytes}, and the same reasoning: `instanceof CryptoKey` would
+ * be a false negative for a key cloned in another realm, and a false negative here reads as
+ * "the vault is damaged" for a vault that is fine. `Symbol.toStringTag` is part of the
+ * platform object and survives the boundary, so it is the check that actually holds.
+ */
+function isCryptoKey(value: unknown): value is CryptoKey {
+	return Object.prototype.toString.call(value) === "[object CryptoKey]";
 }
 
 /** Recover a secret record from a stored value, or `null` when it is not one. */
@@ -122,22 +150,59 @@ function openVault(): Promise<IDBDatabase> {
 			return;
 		}
 
+		let settled = false;
 		request.onupgradeneeded = () => {
 			const db = request.result;
 			if (!db.objectStoreNames.contains(STORE_WRAP)) db.createObjectStore(STORE_WRAP);
 			if (!db.objectStoreNames.contains(STORE_SECRETS)) db.createObjectStore(STORE_SECRETS);
 		};
-		request.onsuccess = () => resolve(request.result);
-		request.onerror = () => reject(unavailable());
-		request.onblocked = () => reject(unavailable());
+		request.onsuccess = () => {
+			// `onblocked` may already have rejected; close the connection rather than leaking it.
+			if (settled) {
+				request.result.close();
+				return;
+			}
+			settled = true;
+			resolve(request.result);
+		};
+		request.onerror = () => {
+			settled = true;
+			reject(unavailable());
+		};
+		request.onblocked = () => {
+			if (settled) return;
+			settled = true;
+			reject(unavailable());
+		};
 	});
 }
 
-/** Await one IndexedDB request, mapping any failure to a user-safe vault error. */
+/** Await one IndexedDB read request, mapping any failure to a user-safe vault error. */
 function awaitRequest<T>(request: IDBRequest<T>): Promise<T> {
 	return new Promise((resolve, reject) => {
 		request.onsuccess = () => resolve(request.result);
 		request.onerror = () => reject(unavailable());
+	});
+}
+
+/**
+ * Await a write, resolving only once its transaction has committed.
+ *
+ * A successful `IDBRequest` does not mean the data is durable: the transaction can still
+ * abort afterwards on a commit-time quota or I/O failure, and the write is then lost.
+ * Callers here treat a resolved write as authoritative — the legacy migration erases the
+ * user's only clear-text copy on the strength of it — so the commit is the only honest
+ * point to resolve at. This matches `indexeddb-workspace-storage.ts`.
+ */
+function awaitWrite(tx: IDBTransaction, request: IDBRequest): Promise<void> {
+	return new Promise((resolve, reject) => {
+		let succeeded = false;
+		request.onsuccess = () => {
+			succeeded = true;
+		};
+		tx.oncomplete = () => (succeeded ? resolve() : reject(unavailable()));
+		tx.onabort = () => reject(unavailable());
+		tx.onerror = () => reject(unavailable());
 	});
 }
 
@@ -165,11 +230,11 @@ async function getOrCreateWrapKey(db: IDBDatabase): Promise<CryptoKey> {
 async function readWrapKey(db: IDBDatabase): Promise<CryptoKey | null> {
 	const store = db.transaction(STORE_WRAP, "readonly").objectStore(STORE_WRAP);
 	const stored = await awaitRequest(store.get(WRAP_KEY_ID));
-	if (stored instanceof CryptoKey) return stored;
+	if (isCryptoKey(stored)) return stored;
 	if (stored !== undefined) {
 		// A record is present but is not a usable key: refuse rather than silently replacing
 		// it, because overwriting would permanently orphan every secret encrypted under it.
-		throw new KeyVaultError("corrupt", CORRUPT_MESSAGE);
+		throw vaultCorrupt();
 	}
 	return null;
 }
@@ -181,35 +246,52 @@ async function readWrapKey(db: IDBDatabase): Promise<CryptoKey | null> {
  * The re-read and the write are chained inside the request callback so they share one live
  * `readwrite` transaction. That makes the check-and-set atomic: two tabs initializing the
  * vault concurrently converge on a single key instead of the second overwriting the first
- * and orphaning everything already encrypted under it.
+ * and orphaning everything already encrypted under it. Resolution waits for the commit so a
+ * caller never encrypts under a wrapping key whose write later aborts, which would leave a
+ * permanently undecryptable record behind.
  */
 function installWrapKey(db: IDBDatabase, candidate: CryptoKey): Promise<CryptoKey> {
 	return new Promise((resolve, reject) => {
-		const store = db.transaction(STORE_WRAP, "readwrite").objectStore(STORE_WRAP);
-		const read = store.get(WRAP_KEY_ID);
-		read.onerror = () => reject(unavailable());
+		const tx = db.transaction(STORE_WRAP, "readwrite");
+		const read = tx.objectStore(STORE_WRAP).get(WRAP_KEY_ID);
+		let winner: CryptoKey | null = null;
+		let failure: KeyVaultError | null = null;
+
 		read.onsuccess = () => {
-			const stored = read.result;
-			if (stored instanceof CryptoKey) {
-				resolve(stored);
+			if (isCryptoKey(read.result)) {
+				// Another context won the race; adopt its key and write nothing.
+				winner = read.result;
 				return;
 			}
-			if (stored !== undefined) {
-				reject(new KeyVaultError("corrupt", CORRUPT_MESSAGE));
+			if (read.result !== undefined) {
+				failure = vaultCorrupt();
+				tx.abort();
 				return;
 			}
-			const write = store.put(candidate, WRAP_KEY_ID);
-			write.onerror = () => reject(unavailable());
-			write.onsuccess = () => resolve(candidate);
+			winner = candidate;
+			tx.objectStore(STORE_WRAP).put(candidate, WRAP_KEY_ID);
 		};
+
+		tx.oncomplete = () => (winner ? resolve(winner) : reject(failure ?? unavailable()));
+		tx.onabort = () => reject(failure ?? unavailable());
+		tx.onerror = () => reject(failure ?? unavailable());
 	});
 }
 
-/** Run `operation` against an open vault, always closing the connection. */
+/**
+ * Run `operation` against an open vault, always closing the connection.
+ *
+ * Anything that is not already a {@link KeyVaultError} is remapped, so a raw `DOMException`
+ * from `transaction()` or a Web Crypto rejection cannot reach the UI with internal detail
+ * attached. Only messages authored in this module are ever surfaced.
+ */
 async function withVault<T>(operation: (db: IDBDatabase) => Promise<T>): Promise<T> {
 	const db = await openVault();
 	try {
 		return await operation(db);
+	} catch (error) {
+		if (error instanceof KeyVaultError) throw error;
+		throw unavailable();
 	} finally {
 		db.close();
 	}
@@ -234,16 +316,19 @@ export async function putSecret(id: string, secret: string): Promise<void> {
 		// Persisted as a view rather than a raw `ArrayBuffer` so both fields read back through
 		// the same realm-independent check.
 		const record: SecretRecord = { iv, ciphertext: new Uint8Array(encrypted) };
-		const store = db.transaction(STORE_SECRETS, "readwrite").objectStore(STORE_SECRETS);
-		await awaitRequest(store.put(record, id));
+		const tx = db.transaction(STORE_SECRETS, "readwrite");
+		await awaitWrite(tx, tx.objectStore(STORE_SECRETS).put(record, id));
 	});
 }
 
 /**
  * Decrypt and return the secret stored for `id`, or `null` when none is stored.
  *
- * @throws KeyVaultError with reason `corrupt` when a record exists but cannot be decrypted,
- * which is reported distinctly from "no key stored" so the UI can prompt for re-entry.
+ * @throws KeyVaultError with reason `corrupt` when this record exists but cannot be
+ * decrypted, or `vault-corrupt` when the wrapping key itself is unusable and no record can
+ * be read. Reading never creates key material: minting a wrapping key here would turn a
+ * diagnosable "records exist but the key is gone" state into records that are silently
+ * undecryptable forever.
  */
 export async function getSecret(id: string): Promise<string | null> {
 	return withVault(async (db) => {
@@ -254,7 +339,8 @@ export async function getSecret(id: string): Promise<string | null> {
 		const record = readSecretRecord(stored);
 		if (!record) throw new KeyVaultError("corrupt", CORRUPT_MESSAGE);
 
-		const wrapKey = await getOrCreateWrapKey(db);
+		const wrapKey = await readWrapKey(db);
+		if (!wrapKey) throw vaultCorrupt();
 		let plaintext: ArrayBuffer;
 		try {
 			plaintext = await subtle.decrypt(
@@ -263,8 +349,7 @@ export async function getSecret(id: string): Promise<string | null> {
 				record.ciphertext,
 			);
 		} catch {
-			// AES-GCM authentication failed: the record was truncated, tampered with, or was
-			// written under a wrapping key that no longer exists.
+			// AES-GCM authentication failed: the record was truncated or tampered with.
 			throw new KeyVaultError("corrupt", CORRUPT_MESSAGE);
 		}
 		return new TextDecoder().decode(plaintext);
@@ -288,7 +373,7 @@ export async function hasSecret(id: string): Promise<boolean> {
  */
 export async function deleteSecret(id: string): Promise<void> {
 	await withVault(async (db) => {
-		const store = db.transaction(STORE_SECRETS, "readwrite").objectStore(STORE_SECRETS);
-		await awaitRequest(store.delete(id));
+		const tx = db.transaction(STORE_SECRETS, "readwrite");
+		await awaitWrite(tx, tx.objectStore(STORE_SECRETS).delete(id));
 	});
 }

--- a/src/lib/adapters/browser-key-vault.ts
+++ b/src/lib/adapters/browser-key-vault.ts
@@ -673,8 +673,10 @@ export async function hasSecret(id: string): Promise<boolean> {
  * stands. This is the one direction that must override: a slot already settled for some other
  * reason has to be re-settled as revoked when the user throws the credential away, because
  * that is what makes the stale clear-text copy erasable on a vault too damaged to offer a
- * replacement. It is safe to make unconditional for the same reason: a revocation is the
- * strongest marker, so this write never lowers what it replaces.
+ * replacement. Against the two values this build knows, a revocation never lowers what it
+ * replaces. Against a value written by a later build it makes the same trade `RetiredReason`
+ * makes on the read side, and for the same reason: a marker of unknown strength is not a
+ * reason to leave a credential the user has just revoked recoverable.
  */
 export async function retireAndDeleteSecret(id: string): Promise<void> {
 	await withVault(async (db) => {

--- a/src/lib/adapters/browser-key-vault.ts
+++ b/src/lib/adapters/browser-key-vault.ts
@@ -70,23 +70,24 @@ function retiredKey(id: string): string {
 /**
  * Why a provider's clear-text slot was settled.
  *
- * `"revoked"` is the user deleting a credential. `"superseded"` is a stored key replacing a
- * clear-text slot the browser would not erase. `"dropped"` is this vault discarding a record
- * it could not read, which the user never asked for.
+ * `"revoked"` is the user deleting a credential. `"settled"` is everything else that stops a
+ * slot being importable: a stored key replacing one the browser would not erase, and this
+ * vault discarding a record it could not read.
  *
- * All three block re-import. Only `"revoked"` changes what happens next: while the vault
+ * Both block re-import, and the distinction carries exactly one decision. While the vault
  * holds records it cannot decrypt, a revocation is still answered — the user threw the
- * credential away — and the other two are refused, because the clear-text copy may be the
- * last one there is and the user asked for neither. `"superseded"` and `"dropped"` therefore
- * take the same path as each other; they are recorded apart so a profile that comes back with
- * a settled slot shows why. Only a revocation overwrites an existing marker, so what is
- * recorded is the first settling event, not the most recent one.
+ * credential away — and anything else is refused, because the clear-text copy may be the last
+ * one there is and the user asked for neither.
+ *
+ * The causes behind `"settled"` are not recorded apart. Nothing reads them: no code path,
+ * surface or diagnostic distinguishes a supersession from a drop, so naming them would
+ * describe the writers rather than anything the vault decides. Two named values rather than a
+ * boolean because the marker is persisted, and a name states which decision it licenses.
  */
-type RetiredReason = "revoked" | "superseded" | "dropped";
+type RetiredReason = "revoked" | "settled";
 
 const REVOKED: RetiredReason = "revoked";
-const SUPERSEDED: RetiredReason = "superseded";
-const DROPPED: RetiredReason = "dropped";
+const SETTLED: RetiredReason = "settled";
 
 /**
  * Read a provider's retirement marker, or `null` when it has none.
@@ -96,18 +97,16 @@ const DROPPED: RetiredReason = "dropped";
  * exists to prevent — so an unreadable marker is still a marker. Only `undefined`, which is
  * what IndexedDB returns for a key that was never written, means no marker.
  *
- * That default is also what handles `true`, the shape written before markers carried a
- * reason. It is deliberately not read as a revocation: both the delete path and the
- * unreadable-record path wrote it, so all it establishes is that re-import was declined.
- * Reading it as a revocation would license erasing a clear-text slot on a damaged vault,
- * which is more authority than that shape ever carried, and on a profile whose marker came
- * from a dropped record it would destroy the copy the `"dropped"` reason exists to keep.
+ * The default covers a marker from a build this one does not understand, and the shapes
+ * earlier builds on this branch wrote: bare `true`, and the `"superseded"` and `"dropped"`
+ * values `"settled"` replaced. None is read as a revocation. A revocation licenses erasing a
+ * clear-text slot on a vault that can offer no replacement, and an unrecognised marker
+ * establishes only that re-import was already declined.
  */
 function readRetiredReason(stored: unknown): RetiredReason | null {
 	if (stored === undefined) return null;
 	if (stored === REVOKED) return REVOKED;
-	if (stored === SUPERSEDED) return SUPERSEDED;
-	return DROPPED;
+	return SETTLED;
 }
 
 const WRAP_KEY_ID = "aes-gcm-256-v1";
@@ -538,12 +537,10 @@ type SlotSettlement = "supersede-slot" | "leave-slot";
  * the marker write fail are the same ones that later destroy the record, so the two are
  * correlated rather than independent.
  *
- * The marker a revocation already recorded is never overwritten here, and neither is one from
- * an earlier settling event: a revocation is the only reason answered on a vault that cannot
- * decrypt anything, so lowering it would disarm the one path that erases a revoked clear-text
- * credential, and re-labelling an earlier drop as a supersession would discard the cause
- * without changing what happens next. The read and the write share the transaction, so no
- * concurrent delete can land between them.
+ * A revocation already recorded for this provider is never overwritten. It is the only reason
+ * answered on a vault that cannot decrypt anything, so lowering it would disarm the one path
+ * that erases a revoked clear-text credential. The read and the write share the transaction,
+ * so no concurrent delete can land between them.
  *
  * @throws KeyVaultError when the vault cannot be opened or Web Crypto is unavailable. The
  * caller must surface that failure rather than storing the value in clear text.
@@ -564,22 +561,22 @@ export async function putSecret(
 		}
 		const tx = db.transaction([STORE_SECRETS, STORE_META], "readwrite");
 		const meta = tx.objectStore(STORE_META);
-		const stored = tx.objectStore(STORE_SECRETS).put(record, id);
+		// Issued before the promise body so the ciphertext write is queued ahead of the marker
+		// read, and before any `await`, since a transaction commits once its queue drains.
+		tx.objectStore(STORE_SECRETS).put(record, id);
 		return new Promise<void>((resolve, reject) => {
-			let written = false;
-			stored.onsuccess = () => {
-				written = true;
-			};
-			// Chained inside the success callback rather than awaited, to keep the transaction
-			// live across the decision. The marker write needs no flag of its own: every way it
-			// can fail aborts the transaction, so reaching `oncomplete` means it either landed
-			// or was deliberately skipped.
+			// The marker read is chained inside a success callback rather than awaited, to keep
+			// the transaction live across the decision.
 			const marker = meta.get(retiredKey(id));
 			marker.onsuccess = () => {
-				if (readRetiredReason(marker.result) !== null) return;
-				meta.put(SUPERSEDED, retiredKey(id));
+				if (readRetiredReason(marker.result) === REVOKED) return;
+				meta.put(SETTLED, retiredKey(id));
 			};
-			tx.oncomplete = () => (written ? resolve() : reject(unavailable()));
+			// Neither write is tracked with a flag. A failed request fires `error`, which
+			// bubbles to the transaction and aborts it, so `oncomplete` already means both
+			// landed. A flag on the marker would be worse than redundant: it is written
+			// conditionally, so a cleared flag could not tell a deliberate skip from a loss.
+			tx.oncomplete = () => resolve();
 			tx.onabort = () => reject(unavailable());
 			tx.onerror = () => reject(unavailable());
 		});
@@ -659,10 +656,10 @@ export async function hasSecret(id: string): Promise<boolean> {
  * marker that could be cleared would not be durable. The cost is one small record per
  * provider the user has ever deleted a key for.
  *
- * The write is unconditional, where the other two writers defer to an existing marker. A
- * revocation is the only reason that must override one: it is the only reason answered on a
- * vault that cannot decrypt anything, so a slot already settled as superseded or dropped has
- * to be re-settled as revoked when the user throws the credential away.
+ * The write is unconditional, where the other two writers defer to a revocation. This is the
+ * one direction that must override: a slot already settled for some other reason has to be
+ * re-settled as revoked when the user throws the credential away, because that is what makes
+ * the stale clear-text copy erasable on a vault too damaged to offer a replacement.
  */
 export async function retireAndDeleteSecret(id: string): Promise<void> {
 	await withVault(async (db) => {
@@ -687,10 +684,10 @@ export async function retireAndDeleteSecret(id: string): Promise<void> {
  *
  * Does nothing for an `error` this vault did not raise for a stored value.
  *
- * The marker is written only when the provider has none. A revocation must survive: a save
- * after one re-creates a stored record while the `REVOKED` marker still stands, so this path
- * can find a matching value to drop with a revocation already recorded, and lowering it would
- * leave a credential the user threw away sitting readable in clear text on a damaged vault.
+ * The marker defers to a revocation already recorded. A save after one re-creates a stored
+ * record while the `REVOKED` marker still stands, so this path can find a matching value to
+ * drop with a revocation in place, and lowering it would leave a credential the user threw
+ * away sitting readable in clear text on a damaged vault.
  */
 export async function dropUnreadableSecret(id: string, error: KeyVaultError): Promise<void> {
 	if (!corruptRecords.has(error)) return;
@@ -716,8 +713,8 @@ export async function dropUnreadableSecret(id: string, error: KeyVaultError): Pr
 				secrets.delete(id);
 				const marker = meta.get(retiredKey(id));
 				marker.onsuccess = () => {
-					if (readRetiredReason(marker.result) !== null) return;
-					meta.put(DROPPED, retiredKey(id));
+					if (readRetiredReason(marker.result) === REVOKED) return;
+					meta.put(SETTLED, retiredKey(id));
 				};
 			};
 			tx.oncomplete = () => resolve();
@@ -789,8 +786,8 @@ export async function importLegacySecret(id: string, secret: string): Promise<vo
 			// live across the decision.
 			const marker = meta.get(retiredKey(id));
 			marker.onsuccess = () => {
-				// This vault has already settled the credential, by revocation or by dropping an
-				// unreadable record. Either way the slot is a copy of something superseded.
+				// This vault has already settled the credential, by revocation or by a save or
+				// drop that outranked the slot. Either way it is a copy of something superseded.
 				if (readRetiredReason(marker.result)) return;
 				const existing = secrets.count(id);
 				existing.onsuccess = () => {

--- a/src/lib/adapters/browser-key-vault.ts
+++ b/src/lib/adapters/browser-key-vault.ts
@@ -72,10 +72,12 @@ function retiredKey(id: string): string {
  * clear-text slot the browser would not erase. `"dropped"` is this vault discarding a record
  * it could not read, which the user never asked for.
  *
- * All three block re-import. They differ only while the vault holds records it cannot
- * decrypt: there a revocation is still answered, because the user threw the credential away,
- * and the other two are refused, because the clear-text copy may be the last one there is and
- * the user asked for neither. On a readable vault all three discard the slot alike.
+ * All three block re-import. Only `"revoked"` changes what happens next: while the vault
+ * holds records it cannot decrypt, a revocation is still answered — the user threw the
+ * credential away — and the other two are refused, because the clear-text copy may be the
+ * last one there is and the user asked for neither. `"superseded"` and `"dropped"` therefore
+ * take the same path as each other today; they are recorded apart so a profile that comes
+ * back with a settled slot can be diagnosed, not because the reader treats them differently.
  */
 type RetiredReason = "revoked" | "superseded" | "dropped";
 
@@ -91,12 +93,16 @@ const DROPPED: RetiredReason = "dropped";
  * exists to prevent — so an unreadable marker is still a marker. Only `undefined`, which is
  * what IndexedDB returns for a key that was never written, means no marker.
  *
- * `true` is the shape written before markers carried a reason, and it only ever meant an
- * unconditional decline, which is what a revocation is.
+ * That default is also what handles `true`, the shape written before markers carried a
+ * reason. It is deliberately not read as a revocation: both the delete path and the
+ * unreadable-record path wrote it, so all it establishes is that re-import was declined.
+ * Reading it as a revocation would license erasing a clear-text slot on a damaged vault,
+ * which is more authority than that shape ever carried, and on a profile whose marker came
+ * from a dropped record it would destroy the copy the `"dropped"` reason exists to keep.
  */
 function readRetiredReason(stored: unknown): RetiredReason | null {
 	if (stored === undefined) return null;
-	if (stored === REVOKED || stored === true) return REVOKED;
+	if (stored === REVOKED) return REVOKED;
 	if (stored === SUPERSEDED) return SUPERSEDED;
 	return DROPPED;
 }
@@ -509,16 +515,67 @@ async function encryptSecret(
 }
 
 /**
+ * Whether a save must also record that it superseded a pre-#133 clear-text slot.
+ *
+ * Not inferable inside the vault: only the adapter can see `localStorage`. Passed rather
+ * than defaulted so a caller storing a secret has to decide, since guessing wrong in the
+ * `"leave-slot"` direction is what lets a replaced credential come back.
+ */
+type SlotSettlement = "supersede-slot" | "leave-slot";
+
+/**
  * Encrypt `secret` under the vault's wrapping key and store it for `id`.
+ *
+ * Under `"supersede-slot"` the ciphertext and the retirement marker are written in one
+ * transaction. They cannot be two operations: the stored record is the only thing outranking
+ * a clear-text slot the browser refused to erase, and that record does not survive the vault
+ * being restarted after its wrapping key is lost. A save that committed the record and then
+ * failed to write the marker — quota, eviction, a closed tab — would report success and leave
+ * the superseded credential ready to come back as the active key. The conditions that make
+ * the marker write fail are the same ones that later destroy the record, so the two are
+ * correlated rather than independent.
+ *
+ * The marker is only ever raised, never lowered: a revocation already recorded for this
+ * provider outranks a supersession, and overwriting it would disarm the one path that erases
+ * a revoked clear-text credential on a vault that cannot decrypt anything. The read and the
+ * write share the transaction, so no concurrent delete can land between them.
  *
  * @throws KeyVaultError when the vault cannot be opened or Web Crypto is unavailable. The
  * caller must surface that failure rather than storing the value in clear text.
  */
-export async function putSecret(id: string, secret: string): Promise<void> {
+export async function putSecret(
+	id: string,
+	secret: string,
+	settlement: SlotSettlement,
+): Promise<void> {
 	await withVault(async (db) => {
+		// Encryption finishes before any transaction opens, since awaiting Web Crypto inside
+		// one would let it commit early.
 		const record = await encryptSecret(db, secret, "always");
-		const tx = db.transaction(STORE_SECRETS, "readwrite");
-		await awaitWrite(tx, tx.objectStore(STORE_SECRETS).put(record, id));
+		if (settlement === "leave-slot") {
+			const tx = db.transaction(STORE_SECRETS, "readwrite");
+			await awaitWrite(tx, tx.objectStore(STORE_SECRETS).put(record, id));
+			return;
+		}
+		const tx = db.transaction([STORE_SECRETS, STORE_META], "readwrite");
+		const meta = tx.objectStore(STORE_META);
+		const stored = tx.objectStore(STORE_SECRETS).put(record, id);
+		return new Promise<void>((resolve, reject) => {
+			let written = false;
+			stored.onsuccess = () => {
+				written = true;
+			};
+			// Chained inside the success callback rather than awaited, to keep the transaction
+			// live across the decision.
+			const marker = meta.get(retiredKey(id));
+			marker.onsuccess = () => {
+				if (readRetiredReason(marker.result) === REVOKED) return;
+				meta.put(SUPERSEDED, retiredKey(id));
+			};
+			tx.oncomplete = () => (written ? resolve() : reject(unavailable()));
+			tx.onabort = () => reject(unavailable());
+			tx.onerror = () => reject(unavailable());
+		});
 	});
 }
 
@@ -595,26 +652,6 @@ export async function hasSecret(id: string): Promise<boolean> {
  * marker that could be cleared would not be durable. The cost is one small record per
  * provider the user has ever deleted a key for.
  */
-/**
- * Record that `id`'s clear-text slot has been superseded by a stored key.
- *
- * A stored record is what stops a slot the browser refuses to erase from overwriting a key
- * the user replaced. That record is not permanent: restarting the vault after its wrapping
- * key is lost clears it, and then nothing outranks the slot and the replaced credential comes
- * back on the next read. This marker is the ranking fact made durable, written at the one
- * moment it is known — a save that found the slot still readable afterwards.
- *
- * It is not a revocation. The user replaced a credential rather than throwing one away, and
- * the slot may still be the only readable copy on a damaged vault, so it declines re-import
- * without licensing an erase.
- */
-export async function markSupersededSlot(id: string): Promise<void> {
-	await withVault(async (db) => {
-		const tx = db.transaction(STORE_META, "readwrite");
-		await awaitWrite(tx, tx.objectStore(STORE_META).put(SUPERSEDED, retiredKey(id)));
-	});
-}
-
 export async function retireAndDeleteSecret(id: string): Promise<void> {
 	await withVault(async (db) => {
 		const tx = db.transaction([STORE_SECRETS, STORE_META], "readwrite");
@@ -637,6 +674,10 @@ export async function retireAndDeleteSecret(id: string): Promise<void> {
  * a well-formed record, so it is never the thing dropped.
  *
  * Does nothing for an `error` this vault did not raise for a stored value.
+ *
+ * Writes `DROPPED` without checking for a stronger marker, unlike a save: a revocation
+ * deletes the record in the same transaction that writes its marker, so once one exists
+ * there is no stored value left for this to match against and it returns before writing.
  */
 export async function dropUnreadableSecret(id: string, error: KeyVaultError): Promise<void> {
 	if (!corruptRecords.has(error)) return;

--- a/src/lib/adapters/browser-key-vault.ts
+++ b/src/lib/adapters/browser-key-vault.ts
@@ -83,6 +83,10 @@ function retiredKey(id: string): string {
  * surface or diagnostic distinguishes a supersession from a drop, so naming them would
  * describe the writers rather than anything the vault decides. Two named values rather than a
  * boolean because the marker is persisted, and a name states which decision it licenses.
+ *
+ * Only `retireAndDeleteSecret` overwrites a marker that already stands. The other writers
+ * defer to whatever is there, so a value this build does not recognise is preserved rather
+ * than downgraded to one it does.
  */
 type RetiredReason = "revoked" | "settled";
 
@@ -344,16 +348,16 @@ function awaitRequest<T>(request: IDBRequest<T>): Promise<T> {
  * Callers here treat a resolved write as authoritative — the legacy migration erases the
  * user's only clear-text copy on the strength of it — so the commit is the only honest
  * point to resolve at. This matches `indexeddb-workspace-storage.ts`.
+ *
+ * Takes only the transaction. A failed request fires `error`, which bubbles to the
+ * transaction and aborts it, so reaching `oncomplete` already means every request the caller
+ * issued succeeded; tracking them individually would add a branch nothing can reach. Callers
+ * must issue their requests before awaiting, since a transaction commits as soon as its queue
+ * drains and control returns to the event loop.
  */
-function awaitWrite(tx: IDBTransaction, ...requests: IDBRequest[]): Promise<void> {
+function awaitWrite(tx: IDBTransaction): Promise<void> {
 	return new Promise((resolve, reject) => {
-		let succeeded = 0;
-		for (const request of requests) {
-			request.onsuccess = () => {
-				succeeded += 1;
-			};
-		}
-		tx.oncomplete = () => (succeeded === requests.length ? resolve() : reject(unavailable()));
+		tx.oncomplete = () => resolve();
 		tx.onabort = () => reject(unavailable());
 		tx.onerror = () => reject(unavailable());
 	});
@@ -537,10 +541,12 @@ type SlotSettlement = "supersede-slot" | "leave-slot";
  * the marker write fail are the same ones that later destroy the record, so the two are
  * correlated rather than independent.
  *
- * A revocation already recorded for this provider is never overwritten. It is the only reason
- * answered on a vault that cannot decrypt anything, so lowering it would disarm the one path
- * that erases a revoked clear-text credential. The read and the write share the transaction,
- * so no concurrent delete can land between them.
+ * A marker already recorded for this provider is never overwritten. Rewriting one that stands
+ * changes nothing this build reads, but it is a request that can fail, and it shares the
+ * transaction with the ciphertext — so a per-record meta fault would turn a save that used to
+ * commit into a rejection. It would also clobber a marker shape written by some later build,
+ * which this build cannot interpret and so must not downgrade. The read and the write share
+ * the transaction, so no concurrent delete can land between them.
  *
  * @throws KeyVaultError when the vault cannot be opened or Web Crypto is unavailable. The
  * caller must surface that failure rather than storing the value in clear text.
@@ -556,7 +562,8 @@ export async function putSecret(
 		const record = await encryptSecret(db, secret, "always");
 		if (settlement === "leave-slot") {
 			const tx = db.transaction(STORE_SECRETS, "readwrite");
-			await awaitWrite(tx, tx.objectStore(STORE_SECRETS).put(record, id));
+			tx.objectStore(STORE_SECRETS).put(record, id);
+			await awaitWrite(tx);
 			return;
 		}
 		const tx = db.transaction([STORE_SECRETS, STORE_META], "readwrite");
@@ -569,13 +576,13 @@ export async function putSecret(
 			// the transaction live across the decision.
 			const marker = meta.get(retiredKey(id));
 			marker.onsuccess = () => {
-				if (readRetiredReason(marker.result) === REVOKED) return;
+				if (readRetiredReason(marker.result) !== null) return;
 				meta.put(SETTLED, retiredKey(id));
 			};
 			// Neither write is tracked with a flag. A failed request fires `error`, which
-			// bubbles to the transaction and aborts it, so `oncomplete` already means both
-			// landed. A flag on the marker would be worse than redundant: it is written
-			// conditionally, so a cleared flag could not tell a deliberate skip from a loss.
+			// bubbles to the transaction and aborts it, so reaching `oncomplete` means every
+			// write that was issued landed. A flag on the marker would be worse than redundant:
+			// the write is conditional, so a cleared flag could not tell a skip from a loss.
 			tx.oncomplete = () => resolve();
 			tx.onabort = () => reject(unavailable());
 			tx.onerror = () => reject(unavailable());
@@ -656,19 +663,20 @@ export async function hasSecret(id: string): Promise<boolean> {
  * marker that could be cleared would not be durable. The cost is one small record per
  * provider the user has ever deleted a key for.
  *
- * The write is unconditional, where the other two writers defer to a revocation. This is the
- * one direction that must override: a slot already settled for some other reason has to be
- * re-settled as revoked when the user throws the credential away, because that is what makes
- * the stale clear-text copy erasable on a vault too damaged to offer a replacement.
+ * The write is unconditional, where the other two writers defer to any marker that already
+ * stands. This is the one direction that must override: a slot already settled for some other
+ * reason has to be re-settled as revoked when the user throws the credential away, because
+ * that is what makes the stale clear-text copy erasable on a vault too damaged to offer a
+ * replacement. Every other re-settling would only rewrite a decision with an equal one.
  */
 export async function retireAndDeleteSecret(id: string): Promise<void> {
 	await withVault(async (db) => {
 		const tx = db.transaction([STORE_SECRETS, STORE_META], "readwrite");
-		// Both requests are issued before any `await`, because a transaction commits as soon as
+		// Both requests are issued before the `await`, because a transaction commits as soon as
 		// its request queue drains and control returns to the event loop.
-		const marked = tx.objectStore(STORE_META).put(REVOKED, retiredKey(id));
-		const deleted = tx.objectStore(STORE_SECRETS).delete(id);
-		await awaitWrite(tx, marked, deleted);
+		tx.objectStore(STORE_META).put(REVOKED, retiredKey(id));
+		tx.objectStore(STORE_SECRETS).delete(id);
+		await awaitWrite(tx);
 	});
 }
 
@@ -684,10 +692,10 @@ export async function retireAndDeleteSecret(id: string): Promise<void> {
  *
  * Does nothing for an `error` this vault did not raise for a stored value.
  *
- * The marker defers to a revocation already recorded. A save after one re-creates a stored
- * record while the `REVOKED` marker still stands, so this path can find a matching value to
- * drop with a revocation in place, and lowering it would leave a credential the user threw
- * away sitting readable in clear text on a damaged vault.
+ * The marker defers to any marker already recorded, which matters most for a revocation. A
+ * save after one re-creates a stored record while the `REVOKED` marker still stands, so this
+ * path can find a matching value to drop with a revocation in place, and lowering it would
+ * leave a credential the user threw away sitting readable in clear text on a damaged vault.
  */
 export async function dropUnreadableSecret(id: string, error: KeyVaultError): Promise<void> {
 	if (!corruptRecords.has(error)) return;
@@ -713,7 +721,7 @@ export async function dropUnreadableSecret(id: string, error: KeyVaultError): Pr
 				secrets.delete(id);
 				const marker = meta.get(retiredKey(id));
 				marker.onsuccess = () => {
-					if (readRetiredReason(marker.result) === REVOKED) return;
+					if (readRetiredReason(marker.result) !== null) return;
 					meta.put(SETTLED, retiredKey(id));
 				};
 			};

--- a/src/lib/adapters/browser-key-vault.ts
+++ b/src/lib/adapters/browser-key-vault.ts
@@ -68,21 +68,37 @@ function retiredKey(id: string): string {
 /**
  * Why a provider's clear-text slot was settled.
  *
- * `"revoked"` is the user deleting a credential. `"dropped"` is this vault discarding a
- * record it could not read, which the user never asked for. Both block re-import, but only a
- * revocation licenses erasing the clear-text copy while the vault is too damaged to offer a
- * replacement — a dropped record leaves that copy as the last one there is.
+ * `"revoked"` is the user deleting a credential. `"superseded"` is a stored key replacing a
+ * clear-text slot the browser would not erase. `"dropped"` is this vault discarding a record
+ * it could not read, which the user never asked for.
+ *
+ * All three block re-import. They differ only while the vault holds records it cannot
+ * decrypt: there a revocation is still answered, because the user threw the credential away,
+ * and the other two are refused, because the clear-text copy may be the last one there is and
+ * the user asked for neither. On a readable vault all three discard the slot alike.
  */
-type RetiredReason = "revoked" | "dropped";
+type RetiredReason = "revoked" | "superseded" | "dropped";
 
 const REVOKED: RetiredReason = "revoked";
+const SUPERSEDED: RetiredReason = "superseded";
 const DROPPED: RetiredReason = "dropped";
 
-/** Read a provider's retirement marker, or `null` when it has none. */
+/**
+ * Read a provider's retirement marker, or `null` when it has none.
+ *
+ * Fails closed on anything present but unrecognised. A false negative here re-imports a
+ * clear-text credential the vault has already settled — the exact resurrection the marker
+ * exists to prevent — so an unreadable marker is still a marker. Only `undefined`, which is
+ * what IndexedDB returns for a key that was never written, means no marker.
+ *
+ * `true` is the shape written before markers carried a reason, and it only ever meant an
+ * unconditional decline, which is what a revocation is.
+ */
 function readRetiredReason(stored: unknown): RetiredReason | null {
-	if (stored === REVOKED) return REVOKED;
-	if (stored === DROPPED) return DROPPED;
-	return null;
+	if (stored === undefined) return null;
+	if (stored === REVOKED || stored === true) return REVOKED;
+	if (stored === SUPERSEDED) return SUPERSEDED;
+	return DROPPED;
 }
 
 const WRAP_KEY_ID = "aes-gcm-256-v1";
@@ -579,6 +595,26 @@ export async function hasSecret(id: string): Promise<boolean> {
  * marker that could be cleared would not be durable. The cost is one small record per
  * provider the user has ever deleted a key for.
  */
+/**
+ * Record that `id`'s clear-text slot has been superseded by a stored key.
+ *
+ * A stored record is what stops a slot the browser refuses to erase from overwriting a key
+ * the user replaced. That record is not permanent: restarting the vault after its wrapping
+ * key is lost clears it, and then nothing outranks the slot and the replaced credential comes
+ * back on the next read. This marker is the ranking fact made durable, written at the one
+ * moment it is known — a save that found the slot still readable afterwards.
+ *
+ * It is not a revocation. The user replaced a credential rather than throwing one away, and
+ * the slot may still be the only readable copy on a damaged vault, so it declines re-import
+ * without licensing an erase.
+ */
+export async function markSupersededSlot(id: string): Promise<void> {
+	await withVault(async (db) => {
+		const tx = db.transaction(STORE_META, "readwrite");
+		await awaitWrite(tx, tx.objectStore(STORE_META).put(SUPERSEDED, retiredKey(id)));
+	});
+}
+
 export async function retireAndDeleteSecret(id: string): Promise<void> {
 	await withVault(async (db) => {
 		const tx = db.transaction([STORE_SECRETS, STORE_META], "readwrite");
@@ -672,8 +708,8 @@ export async function importLegacySecret(id: string, secret: string): Promise<vo
 		const retired = readRetiredReason(retiredMarker);
 		// Answerable without a wrapping key, and answered first: a revocation is a durable
 		// record that the user threw this credential away, so the stale clear-text copy is
-		// erased on sight even while the vault is damaged. A `"dropped"` marker is not that —
-		// the user never asked for it — so it waits behind the guard below.
+		// erased on sight even while the vault is damaged. The other reasons are not that —
+		// the user asked for neither — so they wait behind the guard below.
 		if (retired === REVOKED) return;
 		// Every other outcome needs the wrapping key, so a vault that has records and cannot
 		// produce one is refused rather than answered. Declining here would let the caller

--- a/src/lib/adapters/browser-keychain-adapter.test.ts
+++ b/src/lib/adapters/browser-keychain-adapter.test.ts
@@ -100,6 +100,18 @@ function wipeWrapKeyAfterRead(): void {
 	});
 }
 
+/** Write a raw value into the vault's meta store, standing in for another build. */
+async function writeMetaValue(key: string, value: unknown): Promise<void> {
+	const db = await openVaultDb();
+	await new Promise<void>((resolve, reject) => {
+		const tx = db.transaction("meta", "readwrite");
+		tx.objectStore("meta").put(value, key);
+		tx.oncomplete = () => resolve();
+		tx.onerror = () => reject(tx.error);
+	});
+	db.close();
+}
+
 /** Replace the contents of the wrap-key store, simulating a damaged vault. */
 async function writeWrapKeyStore(entries: [unknown, string][]): Promise<void> {
 	const db = await openVaultDb();
@@ -586,10 +598,56 @@ describe("recovering from an unreadable record", () => {
 		await expect(adapter.setKey("anthropic", "sk-ant-reentered")).resolves.toBeUndefined();
 		expect(await adapter.getKey("anthropic")).toBe("sk-ant-reentered");
 		// The record that predates the new key cannot be read under it. Recovery does not
-		// resurrect it — it is dropped on the next read, so the panel stops claiming a key the
-		// user cannot use.
+		// resurrect it — starting the vault over discards it in the same transaction that
+		// installs the new key, so the panel stops claiming a key the user cannot use.
 		expect(await adapter.getKey("openai")).toBeNull();
 		expect(await adapter.hasKey("openai")).toBe(false);
+	});
+
+	it("still honours a revocation recorded before markers carried a reason", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		await adapter.setKey("openai", "sk-openai-stored");
+		await adapter.deleteKey("anthropic");
+		// The shape earlier builds on this branch wrote. It only ever meant an unconditional
+		// decline, and reading it as "no marker" hands back the credential the user revoked.
+		await writeMetaValue("legacy-retired:anthropic", true);
+		await writeWrapKeyStore([]);
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-revoked");
+
+		// Read on a damaged vault, which is where the reasons stop being interchangeable: only
+		// a revocation is answered without a wrapping key. Reading the old shape as anything
+		// weaker would leave the revoked copy sitting in clear text.
+		expect(await adapter.getKey("anthropic")).toBeNull();
+		expect(localStorage.getItem(LEGACY_SLOT)).toBeNull();
+	});
+
+	it("does not create key material on a read after a record was dropped", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		await corruptStoredRecord("anthropic");
+		expect(await adapter.getKey("anthropic")).toBeNull();
+		await writeWrapKeyStore([]);
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-cleartext");
+
+		// The vault is empty now, so nothing is stranded and the marker answers on its own. What
+		// must not happen is reaching the encrypt step to get there: that mints a wrapping key,
+		// and a read must never create key material whatever the vault happens to hold.
+		expect(await adapter.getKey("anthropic")).toBeNull();
+		expect(await countWrapKeys()).toBe(0);
+	});
+
+	it("treats a marker it cannot recognise as a marker", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		await adapter.deleteKey("anthropic");
+		await writeMetaValue("legacy-retired:anthropic", { reason: "from-a-later-build" });
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-revoked");
+
+		// A marker written by a build this one does not understand still says the vault settled
+		// this credential. Reading it as absence re-imports something already dealt with, so an
+		// unrecognised marker declines rather than failing open.
+		expect(await adapter.getKey("anthropic")).toBeNull();
 	});
 
 	it("recovers a clear-text copy left behind when the vault is started over", async () => {
@@ -685,6 +743,44 @@ describe("a clear-text slot that will not erase", () => {
 	function refuseLegacyRemoval(): MockInstance<Storage["removeItem"]> {
 		return vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => undefined);
 	}
+
+	it("does not reinstate a replaced key when the vault is started over", async () => {
+		refuseLegacyRemoval();
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-old");
+		const adapter = new BrowserKeychainAdapter();
+		// The old clear-text key migrates in; the browser will not erase the slot.
+		expect(await adapter.getKey("anthropic")).toBe("sk-ant-old");
+		await adapter.setKey("anthropic", "sk-ant-rotated");
+		await writeWrapKeyStore([]);
+
+		// A save for an unrelated provider restarts the vault, taking the record that outranked
+		// the slot with it. Nothing about that says the user wants their old key back, and
+		// reinstating it would hand a credential they deliberately rotated away from to every
+		// outbound request — triggered by a save for a different provider entirely.
+		await adapter.setKey("openai", "sk-openai-new");
+
+		expect(await adapter.getKey("anthropic")).toBeNull();
+		expect(await adapter.getKey("openai")).toBe("sk-openai-new");
+	});
+
+	it("keeps a superseded clear-text copy while the vault cannot offer a replacement", async () => {
+		const refusal = refuseLegacyRemoval();
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-old");
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", "sk-ant-rotated");
+		await adapter.setKey("openai", "sk-openai-stored");
+		await writeWrapKeyStore([]);
+		// The browser starts allowing removals again, so from here an erase would really land.
+		refusal.mockRestore();
+
+		const error = await adapter.getKey("anthropic").catch((caught: unknown) => caught);
+
+		// Replacing a key is not throwing one away. With the vault unable to decrypt the
+		// replacement, the superseded copy is the only readable credential left, so it is kept
+		// and the damage is reported instead of quietly erasing it.
+		expect((error as KeyVaultError).reason).toBe("vault-corrupt");
+		expect(localStorage.getItem(LEGACY_SLOT)).toBe("sk-ant-old");
+	});
 
 	/**
 	 * Make any transaction touching the vault's marker store fail, leaving the rest working.

--- a/src/lib/adapters/browser-keychain-adapter.test.ts
+++ b/src/lib/adapters/browser-keychain-adapter.test.ts
@@ -651,6 +651,21 @@ describe("recovering from an unreadable record", () => {
 		expect(localStorage.getItem(LEGACY_SLOT)).toBe("sk-ant-still-good");
 	});
 
+	it("does not overwrite a marker it cannot recognise when a record is dropped", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		await corruptStoredRecord("anthropic");
+		const foreign = { reason: "revoked-by-policy", v: 3 };
+		await writeMetaValue("legacy-retired:anthropic", foreign);
+
+		expect(await adapter.getKey("anthropic")).toBeNull();
+
+		// The same rule as the save path: this build writes only `settled`, so overwriting a
+		// marker it cannot interpret can only hold it level or lower it. The drop path needs
+		// its own witness because it is a separate guard.
+		expect(await readMetaValue("legacy-retired:anthropic")).toEqual(foreign);
+	});
+
 	it("does not create key material on a read after a record was dropped", async () => {
 		const adapter = new BrowserKeychainAdapter();
 		await adapter.setKey("anthropic", SECRET);
@@ -1173,7 +1188,22 @@ describe("two tabs acting on the same provider", () => {
 	 * test to time out silently on a park that is never hit — a park landing somewhere
 	 * harmless would let these tests pass vacuously.
 	 */
-	function parkVaultOpen(nth: number): { reached: Promise<void>; release: () => void } {
+	interface Park {
+		/** Resolves once the park is hit, and rejects if it never is. */
+		reached: Promise<void>;
+		/** Let the parked operation continue. */
+		release: () => void;
+	}
+
+	/**
+	 * The scaffolding both parks share: a gate to hold on, and a `reached` that fails loudly.
+	 *
+	 * A park that lands somewhere harmless, or never lands at all, would let a race test pass
+	 * without sampling the race. `arrive()` is what a spy calls when it recognises its target;
+	 * if nothing calls it within the deadline, `reached` rejects with `missDescription()`
+	 * rather than leaving the test to time out with no explanation.
+	 */
+	function createPark(missDescription: () => string): Park & { arrive: () => Promise<void> } {
 		let release = () => {};
 		const gate = new Promise<void>((resolve) => {
 			release = resolve;
@@ -1184,12 +1214,28 @@ describe("two tabs acting on the same provider", () => {
 			signalReached = resolve;
 			signalMissed = reject;
 		});
-		const realOpen = globalThis.indexedDB.open.bind(globalThis.indexedDB);
+		const missed = setTimeout(() => signalMissed(new Error(missDescription())), 3_000);
+		// Every park must be awaited through `reached` — that await is what turns a missed park
+		// into a failure. This only keeps a test that aborts before reaching its await from
+		// emitting a late rejection that would be attributed to whichever test ran next.
+		void reached.catch(() => undefined);
+		return {
+			reached,
+			release,
+			arrive: () => {
+				clearTimeout(missed);
+				signalReached();
+				return gate;
+			},
+		};
+	}
+
+	function parkVaultOpen(nth: number): Park {
 		let seen = 0;
-		const missed = setTimeout(
-			() => signalMissed(new Error(`park never reached: wanted vault open #${nth}, saw ${seen}`)),
-			3_000,
+		const { reached, release, arrive } = createPark(
+			() => `park never reached: wanted vault open #${nth}, saw ${seen}`,
 		);
+		const realOpen = globalThis.indexedDB.open.bind(globalThis.indexedDB);
 		vi.spyOn(globalThis.indexedDB, "open").mockImplementation((name, version) => {
 			seen += 1;
 			if (seen !== nth) return realOpen(name, version);
@@ -1200,9 +1246,7 @@ describe("two tabs acting on the same provider", () => {
 				onblocked: null,
 				result: undefined,
 			} as unknown as IDBOpenDBRequest;
-			clearTimeout(missed);
-			signalReached();
-			void gate.then(() => {
+			void arrive().then(() => {
 				const real = realOpen(name, version);
 				const forward = (handler: keyof IDBOpenDBRequest) => (event: Event) => {
 					Object.defineProperty(parked, "result", { value: real.result, configurable: true });
@@ -1231,36 +1275,28 @@ describe("two tabs acting on the same provider", () => {
 	 * `importLegacySecret` reads the marker and the record count once before encrypting, then
 	 * re-reads both inside the write transaction. Parking a connection cannot sample the gap
 	 * between those two reads, because it stalls the tab before the pre-check rather than
-	 * after it. Encryption is the only await that sits in the middle, so gating the first
-	 * `subtle.encrypt` call is what puts another tab inside the window the in-transaction
-	 * guards exist to close.
+	 * after it. Encryption is the last await before the write transaction opens, so gating it
+	 * is what puts another tab inside the window the in-transaction guards exist to close.
+	 *
+	 * The park is identified by the plaintext being encrypted rather than by call order. An
+	 * ordinal would silently move to an unrelated `encrypt` the moment a test gained a setup
+	 * step that stores a key, and the migration would then run unparked while the test still
+	 * passed — the vacuous pass these tests exist to rule out.
 	 */
-	function parkMigrationEncrypt(): { reached: Promise<void>; release: () => void } {
-		let release = () => {};
-		const gate = new Promise<void>((resolve) => {
-			release = resolve;
-		});
-		let signalReached = () => {};
-		let signalMissed = (_reason: Error) => {};
-		const reached = new Promise<void>((resolve, reject) => {
-			signalReached = resolve;
-			signalMissed = reject;
-		});
-		const missed = setTimeout(
-			() => signalMissed(new Error("migration never reached encrypt")),
-			3_000,
+	function parkEncryptOf(plaintext: string): Park {
+		const seen: string[] = [];
+		const { reached, release, arrive } = createPark(
+			() => `park never reached: nothing encrypted ${plaintext}, saw [${seen.join(", ")}]`,
 		);
 		const realEncrypt = globalThis.crypto.subtle.encrypt.bind(globalThis.crypto.subtle);
-		let seen = 0;
 		vi.spyOn(globalThis.crypto.subtle, "encrypt").mockImplementation(async (...args) => {
-			seen += 1;
-			if (seen > 1) return realEncrypt(...args);
-			clearTimeout(missed);
-			signalReached();
-			await gate;
+			const [, , data] = args;
+			const encoded = new TextDecoder().decode(data as BufferSource);
+			seen.push(encoded);
+			if (encoded !== plaintext) return realEncrypt(...args);
+			await arrive();
 			return realEncrypt(...args);
 		});
-		void reached.catch(() => undefined);
 		return { reached, release };
 	}
 
@@ -1271,7 +1307,7 @@ describe("two tabs acting on the same provider", () => {
 
 		// Tab B has read an unsettled slot and an empty vault, and is now encrypting what it
 		// captured. Both reads were true when it made them.
-		const suspended = parkMigrationEncrypt();
+		const suspended = parkEncryptOf("sk-ant-revoked");
 		const migrating = tabB.getKey("anthropic");
 		await suspended.reached;
 
@@ -1295,7 +1331,7 @@ describe("two tabs acting on the same provider", () => {
 		const tabB = await openSecondTab();
 		const tabA = new BrowserKeychainAdapter();
 
-		const suspended = parkMigrationEncrypt();
+		const suspended = parkEncryptOf("sk-ant-old");
 		const migrating = tabB.getKey("anthropic");
 		await suspended.reached;
 
@@ -1339,7 +1375,7 @@ describe("two tabs acting on the same provider", () => {
 		// check and the write, so what this samples is the coarser ordering: a tab that opens
 		// its migration connection before the delete must still not hand back the revoked
 		// value. The narrower gap is covered by the two encrypt-parked tests above.
-		await expect(read).resolves.not.toBe("sk-ant-revoked");
+		await expect(read).resolves.toBeNull();
 
 		expect(await tabA.getKey("anthropic")).toBeNull();
 		expect(await tabB.getKey("anthropic")).toBeNull();
@@ -1423,6 +1459,124 @@ describe("durability and ordering", () => {
 		// commit time. The legacy migration erases the user's only clear-text copy on the
 		// strength of this resolution, so resolving early would risk destroying the key.
 		expect(order).toEqual(["committed", "resolved"]);
+	});
+
+	/**
+	 * Abort the transaction of the next write to `store`, after its request has succeeded.
+	 *
+	 * This is the failure `awaitWrite` exists for and the one no other fault helper reaches:
+	 * `failMetaStore` throws from `transaction()` before any handler is attached, and a
+	 * rejected request never reaches commit. A transaction that aborts after its requests
+	 * succeeded is what a commit-time quota or I/O failure looks like, and the only signal is
+	 * `onabort`. Resolving there instead of rejecting turns every writer into a silent
+	 * success — worst of all the migration, which erases the user's only clear-text copy on
+	 * the strength of that resolution.
+	 */
+	function abortWriteTo(store: string): void {
+		const realPut = IDBObjectStore.prototype.put;
+		const realDelete = IDBObjectStore.prototype.delete;
+		const abortOnSuccess = function (this: IDBObjectStore, request: IDBRequest): IDBRequest {
+			if (this.name === store) {
+				request.addEventListener("success", () => request.transaction?.abort());
+			}
+			return request;
+		};
+		vi.spyOn(IDBObjectStore.prototype, "put").mockImplementation(function (
+			this: IDBObjectStore,
+			...args: Parameters<IDBObjectStore["put"]>
+		) {
+			return abortOnSuccess.call(this, realPut.apply(this, args));
+		});
+		vi.spyOn(IDBObjectStore.prototype, "delete").mockImplementation(function (
+			this: IDBObjectStore,
+			...args: Parameters<IDBObjectStore["delete"]>
+		) {
+			return abortOnSuccess.call(this, realDelete.apply(this, args));
+		});
+	}
+
+	it("does not report a save whose transaction aborted at commit", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		abortWriteTo("secrets");
+
+		await expect(adapter.setKey("anthropic", "sk-ant-replacement")).rejects.toMatchObject({
+			reason: "unavailable",
+		});
+
+		// Reporting success here would show the settings panel a key the vault does not hold,
+		// and every request would then fail with the old one still silently in place.
+		vi.restoreAllMocks();
+		expect(await adapter.getKey("anthropic")).toBe(SECRET);
+	});
+
+	it("does not report a save that supersedes a clear-text slot when its transaction aborts", async () => {
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-only-copy");
+		const adapter = new BrowserKeychainAdapter();
+		abortWriteTo("secrets");
+
+		await expect(adapter.setKey("anthropic", "sk-ant-new")).rejects.toMatchObject({
+			reason: "unavailable",
+		});
+
+		// A save over a clear-text slot erases that slot once it has committed. Resolving on an
+		// aborted transaction would erase it with nothing stored, so the user would lose the
+		// old key and the new one at once while the panel showed the save as successful. This
+		// path is separate from the plain save: it writes the marker too, so it commits through
+		// its own handlers rather than the shared `awaitWrite`.
+		vi.restoreAllMocks();
+		expect(localStorage.getItem(LEGACY_SLOT)).toBe("sk-ant-only-copy");
+		expect(await countSecrets()).toBe(0);
+	});
+
+	it("does not report a revocation whose transaction aborted at commit", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		abortWriteTo("secrets");
+
+		await expect(adapter.deleteKey("anthropic")).rejects.toMatchObject({
+			reason: "unavailable",
+		});
+
+		// A delete that reports success while the record survives is the worst direction to
+		// fail in: the user believes a credential is gone and stops rotating it.
+		vi.restoreAllMocks();
+		expect(await adapter.getKey("anthropic")).toBe(SECRET);
+		expect(await readMetaValue("legacy-retired:anthropic")).toBeUndefined();
+	});
+
+	it("does not erase the clear-text slot when the import transaction aborts", async () => {
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-only-copy");
+		const adapter = new BrowserKeychainAdapter();
+		abortWriteTo("secrets");
+
+		await expect(adapter.getKey("anthropic")).rejects.toMatchObject({
+			reason: "unavailable",
+		});
+
+		// The migration erases the slot only once the import has committed. If the import
+		// resolved on an aborted transaction the slot would go while nothing was stored, and
+		// the user's only copy of the credential would be gone with no error anywhere.
+		vi.restoreAllMocks();
+		expect(localStorage.getItem(LEGACY_SLOT)).toBe("sk-ant-only-copy");
+		expect(await countSecrets()).toBe(0);
+	});
+
+	it("does not report an unreadable record dropped when its transaction aborts", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		await corruptStoredRecord("anthropic");
+		abortWriteTo("secrets");
+
+		// The drop is what lets the panel offer a clean re-entry, so reporting it done while
+		// the damaged record survives would leave the user re-entering a key into a vault that
+		// keeps answering with the broken one.
+		await expect(adapter.getKey("anthropic")).rejects.toMatchObject({
+			reason: "unavailable",
+		});
+
+		vi.restoreAllMocks();
+		expect(await countSecrets()).toBe(1);
 	});
 
 	it("does not resurrect a key when a read races a delete", async () => {

--- a/src/lib/adapters/browser-keychain-adapter.test.ts
+++ b/src/lib/adapters/browser-keychain-adapter.test.ts
@@ -1,8 +1,8 @@
-import { IDBFactory } from "fake-indexeddb";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "fake-indexeddb/auto";
 import { KEY_VAULT_DB_NAME, KeyVaultError } from "./browser-key-vault";
 import { BrowserKeychainAdapter } from "./browser-keychain-adapter";
+import { resetKeyVault } from "./test-fixtures/key-vault";
 
 /**
  * #133: browser BYOK keys are encrypted at rest under a non-extractable wrapping key.
@@ -57,7 +57,9 @@ function describeStoredValue(value: unknown): string {
 		);
 	}
 	if (typeof value !== "object" || value === null) return String(value);
-	if (value.constructor?.name === "CryptoKey") return "CryptoKey";
+	// Branded the same way production does, so this helper cannot disagree with the
+	// vault about what counts as a key.
+	if (Object.prototype.toString.call(value) === "[object CryptoKey]") return "CryptoKey";
 	return Object.values(value).map(describeStoredValue).join(",");
 }
 
@@ -99,12 +101,15 @@ async function countWrapKeys(): Promise<number> {
 }
 
 beforeEach(() => {
-	globalThis.indexedDB = new IDBFactory();
+	resetKeyVault();
 	localStorage.clear();
 });
 
 afterEach(() => {
 	vi.restoreAllMocks();
+	// Restored here, not only at the end of the tests that install them: a test that fails
+	// while timers are faked would otherwise hang every test that follows it.
+	vi.useRealTimers();
 });
 
 describe("BrowserKeychainAdapter encrypted storage", () => {
@@ -392,6 +397,25 @@ describe("recovering from an unreadable record", () => {
 		expect((error as KeyVaultError).reason).toBe("vault-corrupt");
 	});
 
+	it("does not discard a record when the crypto layer itself fails", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+
+		// Not an authentication failure — a fault in the platform. Read as "this record is
+		// corrupt" it would delete a perfectly good key, and since the user's re-entry would
+		// meet the same fault, they would loop through save-and-vanish indefinitely.
+		const decrypt = vi
+			.spyOn(crypto.subtle, "decrypt")
+			.mockRejectedValue(new Error("crypto unavailable"));
+
+		const error = await adapter.getKey("anthropic").catch((caught: unknown) => caught);
+		expect((error as KeyVaultError).reason).toBe("vault-corrupt");
+
+		decrypt.mockRestore();
+		// The record was never touched, so the key is readable again once the fault clears.
+		expect(await adapter.getKey("anthropic")).toBe(SECRET);
+	});
+
 	it("never creates key material on the read path", async () => {
 		const adapter = new BrowserKeychainAdapter();
 		await adapter.setKey("anthropic", SECRET);
@@ -403,6 +427,124 @@ describe("recovering from an unreadable record", () => {
 		// Minting a wrapping key here would convert a diagnosable "the key is gone" state into
 		// records that are silently undecryptable under a brand-new key.
 		expect(await countWrapKeys()).toBe(0);
+	});
+});
+
+describe("storage that never responds", () => {
+	/** Yield one real host task. `MessageChannel` is used because `setTimeout` is faked here. */
+	function yieldRealTask(): Promise<void> {
+		return new Promise((resolve) => {
+			const channel = new MessageChannel();
+			channel.port1.onmessage = () => {
+				channel.port1.close();
+				resolve();
+			};
+			channel.port2.postMessage(null);
+		});
+	}
+
+	it("gives up on a wedged open rather than hanging the caller forever", async () => {
+		vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+		// Safari and Firefox private mode are both known to accept `open()` and then fire no
+		// event at all. An unbounded wait leaves the settings panel spinning forever, and
+		// because adapter calls are serialized per provider, wedges every later call too.
+		const open = vi.spyOn(globalThis.indexedDB, "open").mockReturnValue({
+			onsuccess: null,
+			onerror: null,
+			onblocked: null,
+			onupgradeneeded: null,
+		} as unknown as IDBOpenDBRequest);
+		const adapter = new BrowserKeychainAdapter();
+
+		const pending = adapter.getKey("anthropic").catch((caught: unknown) => caught);
+		await vi.advanceTimersByTimeAsync(10_000);
+		// Raced rather than awaited directly: nothing but the vault's own bound can settle
+		// this call, so an unbounded implementation would hang the suite instead of failing it.
+		const error = await Promise.race([pending, yieldRealTask().then(() => "still pending")]);
+
+		expect(error).toBeInstanceOf(KeyVaultError);
+		expect((error as KeyVaultError).reason).toBe("unavailable");
+
+		open.mockRestore();
+		vi.useRealTimers();
+		// The provider is not left wedged: a later call runs against recovered storage.
+		await adapter.setKey("anthropic", SECRET);
+		expect(await adapter.getKey("anthropic")).toBe(SECRET);
+	});
+});
+
+describe("a clear-text slot that will not erase", () => {
+	/** Make `localStorage.removeItem` a no-op, as a browser refusing the removal would. */
+	function refuseLegacyRemoval(): void {
+		vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => undefined);
+	}
+
+	it("does not let the stale slot overwrite a newly saved key", async () => {
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-old-cleartext");
+		refuseLegacyRemoval();
+		const adapter = new BrowserKeychainAdapter();
+
+		await adapter.setKey("anthropic", SECRET);
+
+		// Migration must not run again once the vault holds a key, or every later read would
+		// silently revert the user to the clear-text value they just replaced.
+		expect(await adapter.getKey("anthropic")).toBe(SECRET);
+		expect(await adapter.getKey("anthropic")).toBe(SECRET);
+	});
+
+	it("refuses to report a key as removed while a clear-text copy survives", async () => {
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-old-cleartext");
+		refuseLegacyRemoval();
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+
+		// Telling a user who is removing a possibly-compromised key that it is gone, while it
+		// is still readable in clear text, is the most dangerous lie this adapter could tell.
+		const error = await adapter.deleteKey("anthropic").catch((caught: unknown) => caught);
+
+		expect(error).toBeInstanceOf(KeyVaultError);
+		expect((error as KeyVaultError).reason).toBe("legacy-retained");
+		// The encrypted copy is still removed; only the claim of completeness is withheld.
+		expect(localStorage.getItem(LEGACY_SLOT)).toBe("sk-ant-old-cleartext");
+	});
+});
+
+describe("a wrapping key of the wrong shape", () => {
+	it("is rejected as a vault fault rather than destroying the stored record", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+
+		// A real CryptoKey that cannot decrypt. Accepted, it would fail at `decrypt`, read as
+		// "this record is corrupt", and get a perfectly good ciphertext deleted.
+		//
+		// Two defenses cover this — the wrapping key is rejected on shape, and a non-
+		// authentication decrypt failure is not classified as record corruption — so removing
+		// either one alone leaves this passing. It is kept as the end-to-end property because
+		// the property, not the mechanism, is what must hold.
+		const encryptOnly = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, false, [
+			"encrypt",
+		]);
+		await writeWrapKeyStore([[encryptOnly, "aes-gcm-256-v1"]]);
+
+		const error = await adapter.getKey("anthropic").catch((caught: unknown) => caught);
+
+		expect((error as KeyVaultError).reason).toBe("vault-corrupt");
+		// The record survives, so restoring the correct wrapping key would recover it.
+		expect(await adapter.hasKey("anthropic")).toBe(true);
+	});
+
+	it("refuses to save under it rather than reporting a save that cannot be read back", async () => {
+		const encryptOnly = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, false, [
+			"encrypt",
+		]);
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		await writeWrapKeyStore([[encryptOnly, "aes-gcm-256-v1"]]);
+
+		// Otherwise the panel reports success and the key vanishes on the next read, forever.
+		await expect(adapter.setKey("anthropic", "sk-ant-second")).rejects.toBeInstanceOf(
+			KeyVaultError,
+		);
 	});
 });
 

--- a/src/lib/adapters/browser-keychain-adapter.test.ts
+++ b/src/lib/adapters/browser-keychain-adapter.test.ts
@@ -604,22 +604,36 @@ describe("recovering from an unreadable record", () => {
 		expect(await adapter.hasKey("openai")).toBe(false);
 	});
 
-	it("still honours a revocation recorded before markers carried a reason", async () => {
+	it("still declines a slot settled before markers carried a reason", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		await adapter.deleteKey("anthropic");
+		// The shape earlier builds on this branch wrote. Reading it as "no marker" hands back
+		// the credential the read is supposed to have settled.
+		await writeMetaValue("legacy-retired:anthropic", true);
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-settled");
+
+		expect(await adapter.getKey("anthropic")).toBeNull();
+		// A healthy vault discards a settled slot whatever the reason, so the residue goes too.
+		expect(localStorage.getItem(LEGACY_SLOT)).toBeNull();
+	});
+
+	it("does not erase a clear-text copy on the strength of a marker that predates reasons", async () => {
 		const adapter = new BrowserKeychainAdapter();
 		await adapter.setKey("anthropic", SECRET);
 		await adapter.setKey("openai", "sk-openai-stored");
-		await adapter.deleteKey("anthropic");
-		// The shape earlier builds on this branch wrote. It only ever meant an unconditional
-		// decline, and reading it as "no marker" hands back the credential the user revoked.
 		await writeMetaValue("legacy-retired:anthropic", true);
 		await writeWrapKeyStore([]);
-		localStorage.setItem(LEGACY_SLOT, "sk-ant-revoked");
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-still-good");
 
-		// Read on a damaged vault, which is where the reasons stop being interchangeable: only
-		// a revocation is answered without a wrapping key. Reading the old shape as anything
-		// weaker would leave the revoked copy sitting in clear text.
-		expect(await adapter.getKey("anthropic")).toBeNull();
-		expect(localStorage.getItem(LEGACY_SLOT)).toBeNull();
+		const error = await adapter.getKey("anthropic").catch((caught: unknown) => caught);
+
+		// Both the delete path and the dropped-record path wrote `true`, so it establishes only
+		// that re-import was declined. Reading it as a revocation would license erasing this
+		// copy on a vault that can offer no replacement — more authority than that shape ever
+		// carried, and on a profile whose marker came from a drop it destroys a good key.
+		expect((error as KeyVaultError).reason).toBe("vault-corrupt");
+		expect(localStorage.getItem(LEGACY_SLOT)).toBe("sk-ant-still-good");
 	});
 
 	it("does not create key material on a read after a record was dropped", async () => {
@@ -801,6 +815,17 @@ describe("a clear-text slot that will not erase", () => {
 		});
 	}
 
+	it("does not settle a slot the profile never had", async () => {
+		const adapter = new BrowserKeychainAdapter();
+
+		await adapter.setKey("anthropic", SECRET);
+
+		// Markers are durable and uncleared, so writing one per save on a profile created after
+		// #133 — where no clear-text slot has ever existed — is litter, and it would decline an
+		// import that could only ever be legitimate.
+		expect(await countStore("meta")).toBe(0);
+	});
+
 	it("does not let the stale slot overwrite a newly saved key", async () => {
 		localStorage.setItem(LEGACY_SLOT, "sk-ant-old-cleartext");
 		refuseLegacyRemoval();
@@ -890,6 +915,51 @@ describe("a clear-text slot that will not erase", () => {
 		// trying to remove, and can retry — rather than the revoked clear-text value coming
 		// back in its place.
 		expect(await adapter.getKey("anthropic")).toBe(SECRET);
+	});
+
+	it("does not let a later save weaken a revocation already recorded", async () => {
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-compromised");
+		const refusal = refuseLegacyRemoval();
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		await expect(adapter.deleteKey("anthropic")).rejects.toBeInstanceOf(KeyVaultError);
+
+		// The user revoked the key, was told a clear-text copy survived, and enters a new one.
+		// The save settles the slot too, but the reasons are not equal: only a revocation is
+		// answered on a vault that cannot decrypt anything. Writing the weaker reason over the
+		// stronger one disarms the single path that erases the revoked copy.
+		await adapter.setKey("anthropic", "sk-ant-replacement");
+		await writeWrapKeyStore([]);
+		refusal.mockRestore();
+
+		const error = await adapter.getKey("anthropic").catch((caught: unknown) => caught);
+
+		// The damaged vault is still reported — the replacement is unreadable and re-entering a
+		// key is the only fix. What the revocation decides is the clear-text residue: it is
+		// erased on sight, where a supersession in the same state is kept.
+		expect((error as KeyVaultError).reason).toBe("vault-corrupt");
+		expect(localStorage.getItem(LEGACY_SLOT)).toBeNull();
+	});
+
+	it("fails the save rather than storing a key whose supersession went unrecorded", async () => {
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-old");
+		refuseLegacyRemoval();
+		const adapter = new BrowserKeychainAdapter();
+		const metaFailure = failMetaStore();
+
+		// The marker is the only durable statement that the stored key outranks the slot, and
+		// the record that would otherwise carry that fact does not survive the vault being
+		// restarted. A save that committed the ciphertext and lost the marker would report
+		// success and leave the replaced credential ready to come back as the active key —
+		// under exactly the storage pressure that later destroys the record.
+		await expect(adapter.setKey("anthropic", "sk-ant-rotated")).rejects.toBeInstanceOf(
+			KeyVaultError,
+		);
+
+		metaFailure.mockRestore();
+		// Neither half landed, so the user is where they started and can retry.
+		expect(await countSecrets()).toBe(0);
+		expect(localStorage.getItem(LEGACY_SLOT)).toBe("sk-ant-old");
 	});
 
 	it("erases a settled slot once the browser starts allowing it", async () => {

--- a/src/lib/adapters/browser-keychain-adapter.test.ts
+++ b/src/lib/adapters/browser-keychain-adapter.test.ts
@@ -69,6 +69,36 @@ async function openVaultDb(): Promise<IDBDatabase> {
 	});
 }
 
+/**
+ * Empty the wrap-key store immediately after the next read of it, then stop.
+ *
+ * The migration reads the wrapping key twice — once to decide it may proceed, once to
+ * encrypt under — and a loss landing between them is what a caller-side check cannot see.
+ * Firing on the read itself makes that window deterministic instead of hoping a concurrent
+ * write lands inside it. Returns a restore function; it is also self-disarming, so a run
+ * that never reaches the read cannot corrupt a later assertion.
+ */
+function wipeWrapKeyAfterRead(): () => void {
+	const original = IDBObjectStore.prototype.get;
+	let armed = true;
+	IDBObjectStore.prototype.get = function patched(this: IDBObjectStore, query: IDBValidKey) {
+		const request = original.call(this, query);
+		if (armed && this.name === "wrap-key") {
+			armed = false;
+			const db = this.transaction.db;
+			request.addEventListener("success", () => {
+				// Opened on the same connection and from inside the handler, so it is created
+				// before any transaction the caller opens next and therefore commits first.
+				db.transaction("wrap-key", "readwrite").objectStore("wrap-key").clear();
+			});
+		}
+		return request;
+	} as typeof IDBObjectStore.prototype.get;
+	return () => {
+		IDBObjectStore.prototype.get = original;
+	};
+}
+
 /** Replace the contents of the wrap-key store, simulating a damaged vault. */
 async function writeWrapKeyStore(entries: [unknown, string][]): Promise<void> {
 	const db = await openVaultDb();
@@ -503,6 +533,84 @@ describe("recovering from an unreadable record", () => {
 		// The record must survive, so restoring the profile's storage restores the key.
 		expect(await countSecrets()).toBe(1);
 	});
+
+	it("drops a stored value too malformed to read back as a record", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		const db = await openVaultDb();
+		await new Promise<void>((resolve, reject) => {
+			const tx = db.transaction("secrets", "readwrite");
+			tx.objectStore("secrets").put({ iv: "not-bytes", ciphertext: "nope" }, "anthropic");
+			tx.oncomplete = () => resolve();
+			tx.onerror = () => reject(tx.error);
+		});
+		db.close();
+
+		// Nothing here can be compared byte for byte, but the record still has to go. Left in
+		// place it is counted forever: the panel shows the provider as configured while every
+		// request fails for want of a key, and no path removes it.
+		expect(await adapter.getKey("anthropic")).toBeNull();
+		expect(await adapter.hasKey("anthropic")).toBe(false);
+		expect(await countSecrets()).toBe(0);
+	});
+
+	it("erases a clear-text slot the user already revoked even while the vault is damaged", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		await adapter.setKey("openai", "sk-openai-stored");
+		await adapter.deleteKey("anthropic");
+		await writeWrapKeyStore([]);
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-revoked-cleartext");
+
+		// The marker says the user revoked this credential, and reading a marker needs no
+		// wrapping key — so this answers even though the vault cannot decrypt anything, and the
+		// stale clear-text copy does not outlive the damage. Refusing here instead would leave
+		// a revoked key sitting in `localStorage` until the profile was repaired.
+		expect(await adapter.getKey("anthropic")).toBeNull();
+		expect(localStorage.getItem(LEGACY_SLOT)).toBeNull();
+		// The other provider's record is untouched: nothing was minted to strand it.
+		expect(await countSecrets()).toBe(1);
+		expect(await countWrapKeys()).toBe(0);
+	});
+
+	it("lets the user store a new key after the wrapping key is lost", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		await adapter.setKey("openai", "sk-openai-stored");
+		await writeWrapKeyStore([]);
+
+		// Migration refuses to mint over surviving records, but this is the user handing over a
+		// fresh credential. Refusing here too would leave the vault permanently unusable with no
+		// in-app way out, so storing has to be able to start the vault over.
+		await expect(adapter.setKey("anthropic", "sk-ant-reentered")).resolves.toBeUndefined();
+		expect(await adapter.getKey("anthropic")).toBe("sk-ant-reentered");
+		// The record that predates the new key cannot be read under it. Recovery does not
+		// resurrect it — it is dropped on the next read, so the panel stops claiming a key the
+		// user cannot use.
+		expect(await adapter.getKey("openai")).toBeNull();
+		expect(await adapter.hasKey("openai")).toBe(false);
+	});
+
+	it("refuses to mint over surviving records when the key disappears mid-migration", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		localStorage.setItem("tf-api-key-openai", "sk-openai-cleartext");
+
+		// The migration reads the wrapping key to decide it may proceed, then reads it again to
+		// encrypt under. Wiping the store between those two reads is the window a caller-side
+		// check cannot close, and the only way to reach the install path's own refusal.
+		const restore = wipeWrapKeyAfterRead();
+
+		const error = await adapter.getKey("openai").catch((caught: unknown) => caught);
+
+		expect((error as KeyVaultError).reason).toBe("vault-corrupt");
+		// A key installed here could not read the `anthropic` record, so installing one would
+		// destroy it silently. Refusing keeps both the record and the clear-text slot.
+		expect(await countWrapKeys()).toBe(0);
+		expect(await countSecrets()).toBe(1);
+		expect(localStorage.getItem("tf-api-key-openai")).toBe("sk-openai-cleartext");
+		restore();
+	});
 });
 
 describe("storage that never responds", () => {
@@ -850,8 +958,9 @@ describe("two tabs acting on the same provider", () => {
 			});
 			return parked;
 		});
-		// A test that builds a park and never awaits `reached` would otherwise surface the miss
-		// as an unhandled rejection instead of a failure.
+		// Every park must be awaited through `reached` — that await is what turns a missed park
+		// into a failure. This only keeps a test that aborts before reaching its await from
+		// emitting a late rejection that would be attributed to whichever test ran next.
 		void reached.catch(() => undefined);
 		return { reached, release };
 	}
@@ -887,24 +996,31 @@ describe("two tabs acting on the same provider", () => {
 		expect(localStorage.getItem(LEGACY_SLOT)).toBeNull();
 	});
 
-	it("drops a stored value too malformed to read back as a record", async () => {
-		const adapter = new BrowserKeychainAdapter();
-		await adapter.setKey("anthropic", SECRET);
-		const db = await openVaultDb();
+	it("does not discard a key re-entered elsewhere while an unparseable one is dropped", async () => {
+		const tabA = new BrowserKeychainAdapter();
+		await tabA.setKey("anthropic", SECRET);
+		const seed = await openVaultDb();
 		await new Promise<void>((resolve, reject) => {
-			const tx = db.transaction("secrets", "readwrite");
+			const tx = seed.transaction("secrets", "readwrite");
 			tx.objectStore("secrets").put({ iv: "not-bytes", ciphertext: "nope" }, "anthropic");
 			tx.oncomplete = () => resolve();
 			tx.onerror = () => reject(tx.error);
 		});
-		db.close();
+		seed.close();
+		const tabB = await openSecondTab();
 
-		// Nothing here can be compared byte for byte, but the record still has to go. Left in
-		// place it is counted forever: the panel shows the provider as configured while every
-		// request fails for want of a key, and no path removes it.
-		expect(await adapter.getKey("anthropic")).toBeNull();
-		expect(await adapter.hasKey("anthropic")).toBe(false);
-		expect(await countSecrets()).toBe(0);
+		// The same gap as the damaged-record case, but for a value with no bytes to compare.
+		// "Unreadable" is all that identifies it, so the drop has to re-establish that and not
+		// fall back to deleting by id.
+		const suspended = parkVaultOpen(2);
+		const read = tabA.getKey("anthropic");
+		await suspended.reached;
+		await tabB.setKey("anthropic", "sk-ant-reentered");
+		suspended.release();
+
+		await expect(read).resolves.toBeNull();
+		expect(await tabB.getKey("anthropic")).toBe("sk-ant-reentered");
+		expect(await tabA.getKey("anthropic")).toBe("sk-ant-reentered");
 	});
 
 	it("does not discard a key re-entered elsewhere while a damaged one is dropped", async () => {

--- a/src/lib/adapters/browser-keychain-adapter.test.ts
+++ b/src/lib/adapters/browser-keychain-adapter.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } fr
 import "fake-indexeddb/auto";
 import { KEY_VAULT_DB_NAME, KEY_VAULT_DB_VERSION, KeyVaultError } from "./browser-key-vault";
 import { BrowserKeychainAdapter } from "./browser-keychain-adapter";
+import { LEGACY_RETAINED } from "./keychain-adapter";
 import { yieldHostTask } from "./test-fixtures/host-task";
 import { resetKeyVault } from "./test-fixtures/key-vault";
 
@@ -110,6 +111,20 @@ async function writeMetaValue(key: string, value: unknown): Promise<void> {
 		tx.onerror = () => reject(tx.error);
 	});
 	db.close();
+}
+
+/** Read a raw value back out of the vault's meta store. */
+async function readMetaValue(key: string): Promise<unknown> {
+	const db = await openVaultDb();
+	try {
+		return await new Promise<unknown>((resolve, reject) => {
+			const request = db.transaction("meta", "readonly").objectStore("meta").get(key);
+			request.onsuccess = () => resolve(request.result);
+			request.onerror = () => reject(request.error);
+		});
+	} finally {
+		db.close();
+	}
 }
 
 /** Replace the contents of the wrap-key store, simulating a damaged vault. */
@@ -850,7 +865,7 @@ describe("a clear-text slot that will not erase", () => {
 		const error = await adapter.deleteKey("anthropic").catch((caught: unknown) => caught);
 
 		expect(error).toBeInstanceOf(KeyVaultError);
-		expect((error as KeyVaultError).reason).toBe("legacy-retained");
+		expect((error as KeyVaultError).reason).toBe(LEGACY_RETAINED);
 		// The encrypted copy is still removed; only the claim of completeness is withheld.
 		expect(localStorage.getItem(LEGACY_SLOT)).toBe("sk-ant-old-cleartext");
 	});
@@ -887,7 +902,7 @@ describe("a clear-text slot that will not erase", () => {
 		const error = await adapter.deleteKey("anthropic").catch((caught: unknown) => caught);
 
 		expect(error).toBeInstanceOf(KeyVaultError);
-		expect((error as KeyVaultError).reason).toBe("legacy-retained");
+		expect((error as KeyVaultError).reason).toBe(LEGACY_RETAINED);
 		// Asserted here as well as on the retained branch, so collapsing the two messages onto
 		// either wording is caught. Only the message distinguishes "a copy is definitely still
 		// there" from "a copy could not be checked", and they call for different advice.
@@ -960,6 +975,51 @@ describe("a clear-text slot that will not erase", () => {
 		// Neither half landed, so the user is where they started and can retry.
 		expect(await countSecrets()).toBe(0);
 		expect(localStorage.getItem(LEGACY_SLOT)).toBe("sk-ant-old");
+	});
+
+	it("does not let a dropped record weaken a revocation already recorded", async () => {
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-compromised");
+		const refusal = refuseLegacyRemoval();
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		await expect(adapter.deleteKey("anthropic")).rejects.toBeInstanceOf(KeyVaultError);
+
+		// A save after a revocation re-creates a record while the revocation still stands, so
+		// this provider can reach the drop path with a marker already recorded. Re-labelling it
+		// there would lower the only reason answered on a vault that cannot decrypt anything.
+		await adapter.setKey("anthropic", "sk-ant-replacement");
+		await corruptStoredRecord("anthropic");
+		expect(await adapter.getKey("anthropic")).toBeNull();
+
+		await adapter.setKey("openai", "sk-openai-stored");
+		await writeWrapKeyStore([]);
+		refusal.mockRestore();
+
+		const settled = await adapter.getKey("anthropic").catch((caught: unknown) => caught);
+
+		// The revocation is answered before the wrap-key guard, so the read settles the slot and
+		// returns instead of reporting damage. Lowered to a drop, it would stop at that guard —
+		// leaving the revoked credential readable in clear text with no path left to erase it.
+		expect(settled).toBeNull();
+		expect(localStorage.getItem(LEGACY_SLOT)).toBeNull();
+	});
+
+	it("keeps the reason a slot was first settled for", async () => {
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-old");
+		refuseLegacyRemoval();
+		const adapter = new BrowserKeychainAdapter();
+		// Migration writes no marker, so this is the one way a provider reaches the drop path
+		// with its slot still unsettled.
+		expect(await adapter.getKey("anthropic")).toBe("sk-ant-old");
+		await corruptStoredRecord("anthropic");
+		expect(await adapter.getKey("anthropic")).toBeNull();
+
+		await adapter.setKey("anthropic", "sk-ant-replacement");
+
+		// The reasons behave alike, so nothing else would catch this: the marker is the only
+		// record of why a slot stopped being importable, and re-labelling a record this vault
+		// gave up on as a key the user replaced answers a support question wrongly.
+		expect(await readMetaValue("legacy-retired:anthropic")).toBe("dropped");
 	});
 
 	it("erases a settled slot once the browser starts allowing it", async () => {

--- a/src/lib/adapters/browser-keychain-adapter.test.ts
+++ b/src/lib/adapters/browser-keychain-adapter.test.ts
@@ -61,6 +61,43 @@ function describeStoredValue(value: unknown): string {
 	return Object.values(value).map(describeStoredValue).join(",");
 }
 
+/** Open the vault database directly, to inspect or damage it the way a test needs. */
+async function openVaultDb(): Promise<IDBDatabase> {
+	return new Promise<IDBDatabase>((resolve, reject) => {
+		const request = globalThis.indexedDB.open(KEY_VAULT_DB_NAME);
+		request.onsuccess = () => resolve(request.result);
+		request.onerror = () => reject(request.error);
+	});
+}
+
+/** Replace the contents of the wrap-key store, simulating a damaged vault. */
+async function writeWrapKeyStore(entries: [unknown, string][]): Promise<void> {
+	const db = await openVaultDb();
+	await new Promise<void>((resolve, reject) => {
+		const tx = db.transaction("wrap-key", "readwrite");
+		const store = tx.objectStore("wrap-key");
+		store.clear();
+		for (const [value, key] of entries) store.put(value, key);
+		tx.oncomplete = () => resolve();
+		tx.onerror = () => reject(tx.error);
+		tx.onabort = () => reject(tx.error);
+	});
+	db.close();
+}
+
+async function countWrapKeys(): Promise<number> {
+	const db = await openVaultDb();
+	try {
+		return await new Promise<number>((resolve, reject) => {
+			const request = db.transaction("wrap-key", "readonly").objectStore("wrap-key").count();
+			request.onsuccess = () => resolve(request.result);
+			request.onerror = () => reject(request.error);
+		});
+	} finally {
+		db.close();
+	}
+}
+
 beforeEach(() => {
 	globalThis.indexedDB = new IDBFactory();
 	localStorage.clear();
@@ -284,6 +321,28 @@ describe("failing closed when encrypted storage is unavailable", () => {
 		expect((error as KeyVaultError).message).not.toContain("/var/db/foo");
 		expect((error as KeyVaultError).message).not.toContain("IDBFactory");
 	});
+
+	it("redacts a failure raised after the database is open", async () => {
+		// `open()` succeeding is not the only way in. A vault database that already exists at
+		// the expected version but has no stores opens cleanly and then raises a real
+		// `NotFoundError` from `transaction()`, which would otherwise reach the settings panel
+		// verbatim. No mock: this is the genuine exception the platform throws.
+		await new Promise<void>((resolve, reject) => {
+			const request = globalThis.indexedDB.open(KEY_VAULT_DB_NAME, 1);
+			request.onsuccess = () => {
+				request.result.close();
+				resolve();
+			};
+			request.onerror = () => reject(request.error);
+		});
+		const adapter = new BrowserKeychainAdapter();
+
+		const error = await adapter.setKey("anthropic", SECRET).catch((caught: unknown) => caught);
+
+		expect(error).toBeInstanceOf(KeyVaultError);
+		expect((error as KeyVaultError).reason).toBe("unavailable");
+		expect((error as KeyVaultError).message).not.toContain("objectStore");
+	});
 });
 
 describe("recovering from an unreadable record", () => {
@@ -292,11 +351,7 @@ describe("recovering from an unreadable record", () => {
 		await adapter.setKey("anthropic", SECRET);
 
 		// Truncate the ciphertext so AES-GCM authentication fails on read.
-		const db = await new Promise<IDBDatabase>((resolve, reject) => {
-			const request = globalThis.indexedDB.open(KEY_VAULT_DB_NAME);
-			request.onsuccess = () => resolve(request.result);
-			request.onerror = () => reject(request.error);
-		});
+		const db = await openVaultDb();
 		await new Promise<void>((resolve, reject) => {
 			const store = db.transaction("secrets", "readwrite").objectStore("secrets");
 			const read = store.get("anthropic");
@@ -315,7 +370,95 @@ describe("recovering from an unreadable record", () => {
 
 		// The user sees the ordinary "no key configured" path and can simply re-enter it.
 		expect(await adapter.getKey("anthropic")).toBeNull();
+		// ...and the two predicates agree, so the settings panel cannot show the provider as
+		// configured while every request fails for want of a key.
+		expect(await adapter.hasKey("anthropic")).toBe(false);
+
 		await adapter.setKey("anthropic", "sk-ant-reentered");
 		expect(await adapter.getKey("anthropic")).toBe("sk-ant-reentered");
+	});
+
+	it("surfaces a damaged wrapping key instead of reporting no key configured", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+
+		// A wrapping key that is not a usable key makes every record undecryptable. Reporting
+		// that as "no key configured" would send the user into re-entry, which fails the same
+		// way, so the fault has to reach them instead.
+		await writeWrapKeyStore([["not-a-crypto-key", "aes-gcm-256-v1"]]);
+
+		const error = await adapter.getKey("anthropic").catch((caught: unknown) => caught);
+		expect(error).toBeInstanceOf(KeyVaultError);
+		expect((error as KeyVaultError).reason).toBe("vault-corrupt");
+	});
+
+	it("never creates key material on the read path", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		await writeWrapKeyStore([]);
+
+		const error = await adapter.getKey("anthropic").catch((caught: unknown) => caught);
+
+		expect((error as KeyVaultError).reason).toBe("vault-corrupt");
+		// Minting a wrapping key here would convert a diagnosable "the key is gone" state into
+		// records that are silently undecryptable under a brand-new key.
+		expect(await countWrapKeys()).toBe(0);
+	});
+});
+
+describe("durability and ordering", () => {
+	it("resolves a write only after its transaction has committed", async () => {
+		const order: string[] = [];
+		const realTransaction = IDBDatabase.prototype.transaction;
+		vi.spyOn(IDBDatabase.prototype, "transaction").mockImplementation(function (
+			this: IDBDatabase,
+			...args: Parameters<IDBDatabase["transaction"]>
+		) {
+			const tx = realTransaction.apply(this, args);
+			// Track the secret write specifically: the wrapping key is written in a separate
+			// transaction, and its commit must not be mistaken for this one's.
+			if (args[0] === "secrets" && args[1] === "readwrite") {
+				tx.addEventListener("complete", () => order.push("committed"));
+			}
+			return tx;
+		});
+
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		order.push("resolved");
+
+		// A request succeeding does not mean the transaction committed; it can still abort at
+		// commit time. The legacy migration erases the user's only clear-text copy on the
+		// strength of this resolution, so resolving early would risk destroying the key.
+		expect(order).toEqual(["committed", "resolved"]);
+	});
+
+	it("does not resurrect a key when a read races a delete", async () => {
+		localStorage.setItem(LEGACY_SLOT, SECRET);
+		const adapter = new BrowserKeychainAdapter();
+
+		// A migrating read and a delete issued together: whichever order they run in, the
+		// user pressed "remove", so the key must not survive.
+		await Promise.all([adapter.getKey("anthropic"), adapter.deleteKey("anthropic")]);
+
+		expect(await adapter.hasKey("anthropic")).toBe(false);
+		expect(await adapter.getKey("anthropic")).toBeNull();
+		expect(localStorage.getItem(LEGACY_SLOT)).toBeNull();
+	});
+
+	it("converges on one wrapping key when two providers initialize the vault at once", async () => {
+		const adapter = new BrowserKeychainAdapter();
+
+		// Separate providers run concurrently, each opening its own connection, which is the
+		// same race two tabs run on first use.
+		await Promise.all([
+			adapter.setKey("anthropic", SECRET),
+			adapter.setKey("openai", "sk-openai-concurrent"),
+		]);
+
+		// A second wrapping key would have orphaned whichever secret was written under the first.
+		expect(await countWrapKeys()).toBe(1);
+		expect(await adapter.getKey("anthropic")).toBe(SECRET);
+		expect(await adapter.getKey("openai")).toBe("sk-openai-concurrent");
 	});
 });

--- a/src/lib/adapters/browser-keychain-adapter.test.ts
+++ b/src/lib/adapters/browser-keychain-adapter.test.ts
@@ -85,10 +85,19 @@ async function writeWrapKeyStore(entries: [unknown, string][]): Promise<void> {
 }
 
 async function countWrapKeys(): Promise<number> {
+	return countStore("wrap-key");
+}
+
+/** Count the stored secret records. */
+async function countSecrets(): Promise<number> {
+	return countStore("secrets");
+}
+
+async function countStore(store: string): Promise<number> {
 	const db = await openVaultDb();
 	try {
 		return await new Promise<number>((resolve, reject) => {
-			const request = db.transaction("wrap-key", "readonly").objectStore("wrap-key").count();
+			const request = db.transaction(store, "readonly").objectStore(store).count();
 			request.onsuccess = () => resolve(request.result);
 			request.onerror = () => reject(request.error);
 		});
@@ -440,6 +449,24 @@ describe("recovering from an unreadable record", () => {
 		// records that are silently undecryptable under a brand-new key.
 		expect(await countWrapKeys()).toBe(0);
 	});
+
+	it("does not create key material while a clear-text slot is waiting to migrate", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		await writeWrapKeyStore([]);
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-old-cleartext");
+
+		const error = await adapter.getKey("anthropic").catch((caught: unknown) => caught);
+
+		// The migration declines — a secret is already stored — but deciding that must not
+		// involve encrypting, because encrypting mints a wrapping key. Minting one here would
+		// re-key the vault behind the user's back, and the stored record, still encrypted under
+		// the lost key, would go from diagnosably unreadable to silently undecryptable.
+		expect((error as KeyVaultError).reason).toBe("vault-corrupt");
+		expect(await countWrapKeys()).toBe(0);
+		// The record must survive, so restoring the profile's storage restores the key.
+		expect(await countSecrets()).toBe(1);
+	});
 });
 
 describe("storage that never responds", () => {
@@ -573,9 +600,9 @@ describe("a clear-text slot that will not erase", () => {
 		const adapter = new BrowserKeychainAdapter();
 		await adapter.setKey("anthropic", SECRET);
 
-		// The marker is what stops the clear-text slot being re-imported. If it is written
-		// after the record is deleted, a failure here leaves no stored secret to outrank the
-		// slot and no marker to stop it — and the revoked key returns on the next read.
+		// The marker is what stops the clear-text slot being re-imported. Were it a separate
+		// operation from the delete, a failure here would leave no stored secret to outrank the
+		// slot and no marker to stop it — and the revoked key would return on the next read.
 		const metaFailure = failMetaStore();
 
 		const failure = await adapter.deleteKey("anthropic").catch((caught: unknown) => caught);
@@ -728,15 +755,19 @@ describe("two tabs acting on the same provider", () => {
 	}
 
 	/**
-	 * Hold the `nth` vault connection open request until released, and report when it is hit.
+	 * Hold the `nth` vault connection opened from now on, and report when it is reached.
 	 *
-	 * A migration is a check followed by an act, and the window that matters is the one
-	 * between them — where a tab has decided the slot is safe to import but has not yet
-	 * written it. Each vault operation opens its own connection, so suspending an open parks
-	 * the tab in that gap. Real IndexedDB and real Web Crypto still do the work; only the
-	 * delivery of one connection is deferred, which is what a scheduler does to a backgrounded
-	 * tab. Starting both tabs together instead samples whichever interleaving the event loop
-	 * happens to pick, and passes against code that has the race.
+	 * Every vault operation opens its own connection, so suspending one parks a tab between
+	 * two of its operations — the gap a check-then-act spans, and the gap a backgrounded tab
+	 * sits in when the scheduler deprioritizes it. Real IndexedDB and real Web Crypto still do
+	 * the work; only the delivery of one connection is deferred. Starting two tabs together
+	 * instead samples whichever interleaving the event loop happens to pick, and passes
+	 * against code that has the race.
+	 *
+	 * `nth` counts connections rather than naming an operation, so it moves if the operations
+	 * under test change how many they open. `reached` therefore rejects instead of leaving the
+	 * test to time out silently on a park that is never hit — a park landing somewhere
+	 * harmless would let these tests pass vacuously.
 	 */
 	function parkVaultOpen(nth: number): { reached: Promise<void>; release: () => void } {
 		let release = () => {};
@@ -744,11 +775,17 @@ describe("two tabs acting on the same provider", () => {
 			release = resolve;
 		});
 		let signalReached = () => {};
-		const reached = new Promise<void>((resolve) => {
+		let signalMissed = (_reason: Error) => {};
+		const reached = new Promise<void>((resolve, reject) => {
 			signalReached = resolve;
+			signalMissed = reject;
 		});
 		const realOpen = globalThis.indexedDB.open.bind(globalThis.indexedDB);
 		let seen = 0;
+		const missed = setTimeout(
+			() => signalMissed(new Error(`park never reached: wanted vault open #${nth}, saw ${seen}`)),
+			1_000,
+		);
 		vi.spyOn(globalThis.indexedDB, "open").mockImplementation((name, version) => {
 			seen += 1;
 			if (seen !== nth) return realOpen(name, version);
@@ -759,6 +796,7 @@ describe("two tabs acting on the same provider", () => {
 				onblocked: null,
 				result: undefined,
 			} as unknown as IDBOpenDBRequest;
+			clearTimeout(missed);
 			signalReached();
 			void gate.then(() => {
 				const real = realOpen(name, version);
@@ -788,9 +826,13 @@ describe("two tabs acting on the same provider", () => {
 		// Tab B starts migrating the clear-text slot and stalls part-way through. No fault is
 		// injected into storage and both tabs' operations succeed on their own terms; the only
 		// thing arranged is the order, which a backgrounded tab produces by itself.
+		// #1 is the migration's own connection; #2 is the read that follows it.
 		const suspended = parkVaultOpen(2);
 		const read = tabB.getKey("anthropic");
 		await suspended.reached;
+		// Parked before the delete, so the race really is being sampled: the vault still holds
+		// the key tab A is about to remove.
+		expect(await countSecrets()).toBe(1);
 
 		// The user revokes the key in the foreground tab, and is told it worked.
 		await expect(tabA.deleteKey("anthropic")).resolves.toBeUndefined();
@@ -806,18 +848,28 @@ describe("two tabs acting on the same provider", () => {
 		expect(localStorage.getItem(LEGACY_SLOT)).toBeNull();
 	});
 
-	it("keeps a delete final when the other tab migrates afterwards", async () => {
+	it("does not discard a key re-entered elsewhere while a damaged one is dropped", async () => {
 		const tabA = new BrowserKeychainAdapter();
 		await tabA.setKey("anthropic", SECRET);
-		await tabA.deleteKey("anthropic");
-		localStorage.setItem(LEGACY_SLOT, "sk-ant-revoked");
-
-		// The marker outlives the tab that wrote it, so a tab opened later — or one that was
-		// idle through the delete — still discards the slot instead of importing it.
+		await corruptStoredRecord("anthropic");
 		const tabB = await openSecondTab();
 
-		expect(await tabB.getKey("anthropic")).toBeNull();
-		expect(localStorage.getItem(LEGACY_SLOT)).toBeNull();
+		// Tab A reads a damaged record and decides to drop it. Suspending the connection that
+		// drop opens puts the decision and the deletion either side of a real gap — which is
+		// where the user goes when a key stops working: to another tab, to re-enter it.
+		// #1 is the read that finds the damage; #2 is the drop it decides on.
+		const suspended = parkVaultOpen(2);
+		const read = tabA.getKey("anthropic");
+		await suspended.reached;
+		await tabB.setKey("anthropic", "sk-ant-reentered");
+		suspended.release();
+
+		await expect(read).resolves.toBeNull();
+		// The drop must apply to the record it was decided for, not to whatever is stored by
+		// the time it runs. Otherwise the key the user just re-entered disappears with no error
+		// anywhere, and a retirement marker is left behind that nothing can clear.
+		expect(await tabB.getKey("anthropic")).toBe("sk-ant-reentered");
+		expect(await tabA.getKey("anthropic")).toBe("sk-ant-reentered");
 	});
 });
 

--- a/src/lib/adapters/browser-keychain-adapter.test.ts
+++ b/src/lib/adapters/browser-keychain-adapter.test.ts
@@ -339,28 +339,32 @@ describe("failing closed when encrypted storage is unavailable", () => {
 	});
 });
 
-describe("recovering from an unreadable record", () => {
-	it("reports a corrupted record as no key rather than throwing at the caller", async () => {
-		const adapter = new BrowserKeychainAdapter();
-		await adapter.setKey("anthropic", SECRET);
-
-		// Truncate the ciphertext so AES-GCM authentication fails on read.
-		const db = await openVaultDb();
+/** Truncate a stored record's ciphertext so AES-GCM authentication fails on read. */
+async function corruptStoredRecord(id: string): Promise<void> {
+	const db = await openVaultDb();
+	try {
 		await new Promise<void>((resolve, reject) => {
 			const store = db.transaction("secrets", "readwrite").objectStore("secrets");
-			const read = store.get("anthropic");
+			const read = store.get(id);
 			read.onsuccess = () => {
 				const record = read.result as { iv: Uint8Array; ciphertext: Uint8Array };
-				const write = store.put(
-					{ iv: record.iv, ciphertext: record.ciphertext.slice(0, 4) },
-					"anthropic",
-				);
+				const write = store.put({ iv: record.iv, ciphertext: record.ciphertext.slice(0, 4) }, id);
 				write.onsuccess = () => resolve();
 				write.onerror = () => reject(write.error);
 			};
 			read.onerror = () => reject(read.error);
 		});
+	} finally {
 		db.close();
+	}
+}
+
+describe("recovering from an unreadable record", () => {
+	it("reports a corrupted record as no key rather than throwing at the caller", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+
+		await corruptStoredRecord("anthropic");
 
 		// The user sees the ordinary "no key configured" path and can simply re-enter it.
 		expect(await adapter.getKey("anthropic")).toBeNull();
@@ -370,6 +374,25 @@ describe("recovering from an unreadable record", () => {
 
 		await adapter.setKey("anthropic", "sk-ant-reentered");
 		expect(await adapter.getKey("anthropic")).toBe("sk-ant-reentered");
+	});
+
+	it("does not reinstate a replaced clear-text key when the record is dropped", async () => {
+		// A browser that refuses to erase the slot, and a user who replaced a compromised key
+		// rather than deleting it: the clear-text copy still holds the value they retired.
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-replaced-and-compromised");
+		vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => undefined);
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+
+		await corruptStoredRecord("anthropic");
+
+		// Dropping the damaged record removes the only thing outranking that slot, so the drop
+		// has to settle the slot too. Otherwise a truncated ciphertext is enough to silently
+		// restore the retired credential, and the panel reports the provider as configured
+		// while every request is signed with a key the user thought they had replaced.
+		expect(await adapter.getKey("anthropic")).toBeNull();
+		expect(await adapter.getKey("anthropic")).toBeNull();
+		expect(await adapter.hasKey("anthropic")).toBe(false);
 	});
 
 	it("surfaces a damaged wrapping key instead of reporting no key configured", async () => {
@@ -457,13 +480,22 @@ describe("a clear-text slot that will not erase", () => {
 		return vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => undefined);
 	}
 
-	/** Make the vault's marker store unusable, leaving every other store working. */
-	async function failMetaStore(): Promise<MockInstance<IDBDatabase["transaction"]>> {
-		const db = await openVaultDb();
-		const transaction = db.transaction.bind(db);
-		return vi.spyOn(IDBDatabase.prototype, "transaction").mockImplementation((stores, mode) => {
-			if (stores === "meta") throw new DOMException("no meta store", "NotFoundError");
-			return transaction(stores, mode);
+	/**
+	 * Make any transaction touching the vault's marker store fail, leaving the rest working.
+	 *
+	 * Applied to the prototype and dispatched on `this`, so production keeps using its own
+	 * connection: routing its transactions through a second connection opened here would hide
+	 * a real connection-lifecycle bug.
+	 */
+	function failMetaStore(): MockInstance<IDBDatabase["transaction"]> {
+		const realTransaction = IDBDatabase.prototype.transaction;
+		return vi.spyOn(IDBDatabase.prototype, "transaction").mockImplementation(function (
+			this: IDBDatabase,
+			...args
+		) {
+			const stores = typeof args[0] === "string" ? [args[0]] : Array.from(args[0]);
+			if (stores.includes("meta")) throw new DOMException("no meta store", "NotFoundError");
+			return realTransaction.apply(this, args);
 		});
 	}
 
@@ -529,6 +561,10 @@ describe("a clear-text slot that will not erase", () => {
 
 		expect(error).toBeInstanceOf(KeyVaultError);
 		expect((error as KeyVaultError).reason).toBe("legacy-retained");
+		// Asserted here as well as on the retained branch, so collapsing the two messages onto
+		// either wording is caught. Only the message distinguishes "a copy is definitely still
+		// there" from "a copy could not be checked", and they call for different advice.
+		expect((error as KeyVaultError).message).toContain("blocked the check");
 	});
 
 	it("keeps the stored key when the tombstone cannot be written", async () => {
@@ -540,9 +576,12 @@ describe("a clear-text slot that will not erase", () => {
 		// The marker is what stops the clear-text slot being re-imported. If it is written
 		// after the record is deleted, a failure here leaves no stored secret to outrank the
 		// slot and no marker to stop it — and the revoked key returns on the next read.
-		const metaFailure = await failMetaStore();
+		const metaFailure = failMetaStore();
 
-		await expect(adapter.deleteKey("anthropic")).rejects.toBeInstanceOf(KeyVaultError);
+		const failure = await adapter.deleteKey("anthropic").catch((caught: unknown) => caught);
+		// Pinned to the marker write this test is named for, rather than accepting the
+		// `legacy-retained` rejection the refused erase would also produce.
+		expect((failure as KeyVaultError).reason).toBe("unavailable");
 
 		metaFailure.mockRestore();
 		// Nothing was destroyed, so once storage recovers the user still has the key they were
@@ -623,9 +662,10 @@ describe("a wrapping key of the wrong shape", () => {
 
 describe("upgrading a database written by an earlier schema", () => {
 	it("keeps an existing key readable when the marker store is added", async () => {
-		// A version-1 vault: wrapping key and ciphertext, no `meta` store. Built through the
-		// adapter so the record really is what this code writes, then reopened at version 1
-		// to strip the store the current schema adds.
+		// A version-1 vault: wrapping key and ciphertext, no `meta` store. The records are built
+		// through the adapter so they really are what this code writes, then replayed into a
+		// fresh version-1 database — IndexedDB cannot reopen an existing database at a lower
+		// version, so there is no way to strip the store from the one just written.
 		const adapter = new BrowserKeychainAdapter();
 		await adapter.setKey("anthropic", SECRET);
 		const seeded = await openVaultDb();
@@ -670,6 +710,114 @@ describe("upgrading a database written by an earlier schema", () => {
 		expect(Array.from(upgraded.objectStoreNames).sort()).toEqual(["meta", "secrets", "wrap-key"]);
 		expect(upgraded.version).toBe(KEY_VAULT_DB_VERSION);
 		upgraded.close();
+	});
+});
+
+describe("two tabs acting on the same provider", () => {
+	/**
+	 * A second tab, as a second module instance.
+	 *
+	 * The per-provider lock is a module-scoped `Map`, so it orders one tab's calls and nothing
+	 * else. Re-importing gives a genuinely independent lock and vault connection over the same
+	 * `fake-indexeddb` and `localStorage` backing stores, which is what two tabs are.
+	 */
+	async function openSecondTab(): Promise<BrowserKeychainAdapter> {
+		vi.resetModules();
+		const module = await import("./browser-keychain-adapter");
+		return new module.BrowserKeychainAdapter();
+	}
+
+	/**
+	 * Hold the `nth` vault connection open request until released, and report when it is hit.
+	 *
+	 * A migration is a check followed by an act, and the window that matters is the one
+	 * between them — where a tab has decided the slot is safe to import but has not yet
+	 * written it. Each vault operation opens its own connection, so suspending an open parks
+	 * the tab in that gap. Real IndexedDB and real Web Crypto still do the work; only the
+	 * delivery of one connection is deferred, which is what a scheduler does to a backgrounded
+	 * tab. Starting both tabs together instead samples whichever interleaving the event loop
+	 * happens to pick, and passes against code that has the race.
+	 */
+	function parkVaultOpen(nth: number): { reached: Promise<void>; release: () => void } {
+		let release = () => {};
+		const gate = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		let signalReached = () => {};
+		const reached = new Promise<void>((resolve) => {
+			signalReached = resolve;
+		});
+		const realOpen = globalThis.indexedDB.open.bind(globalThis.indexedDB);
+		let seen = 0;
+		vi.spyOn(globalThis.indexedDB, "open").mockImplementation((name, version) => {
+			seen += 1;
+			if (seen !== nth) return realOpen(name, version);
+			const parked = {
+				onupgradeneeded: null,
+				onsuccess: null,
+				onerror: null,
+				onblocked: null,
+				result: undefined,
+			} as unknown as IDBOpenDBRequest;
+			signalReached();
+			void gate.then(() => {
+				const real = realOpen(name, version);
+				const forward = (handler: keyof IDBOpenDBRequest) => (event: Event) => {
+					Object.defineProperty(parked, "result", { value: real.result, configurable: true });
+					(parked[handler] as ((this: IDBRequest, event: Event) => void) | null)?.call(
+						parked,
+						event,
+					);
+				};
+				real.onupgradeneeded = forward("onupgradeneeded");
+				real.onsuccess = forward("onsuccess");
+				real.onerror = forward("onerror");
+				real.onblocked = forward("onblocked");
+			});
+			return parked;
+		});
+		return { reached, release };
+	}
+
+	it("does not resurrect a revoked key when a read races the delete", async () => {
+		const tabA = new BrowserKeychainAdapter();
+		await tabA.setKey("anthropic", SECRET);
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-revoked");
+		const tabB = await openSecondTab();
+
+		// Tab B starts migrating the clear-text slot and stalls part-way through. No fault is
+		// injected into storage and both tabs' operations succeed on their own terms; the only
+		// thing arranged is the order, which a backgrounded tab produces by itself.
+		const suspended = parkVaultOpen(2);
+		const read = tabB.getKey("anthropic");
+		await suspended.reached;
+
+		// The user revokes the key in the foreground tab, and is told it worked.
+		await expect(tabA.deleteKey("anthropic")).resolves.toBeUndefined();
+
+		suspended.release();
+		// Tab B now resumes against a vault the delete has already changed. With the guard read
+		// and the write in separate transactions, tab B still believes nothing is stored and
+		// writes the clear-text value it captured — and nothing anywhere reports a problem.
+		await expect(read).resolves.not.toBe("sk-ant-revoked");
+
+		expect(await tabA.getKey("anthropic")).toBeNull();
+		expect(await tabB.getKey("anthropic")).toBeNull();
+		expect(localStorage.getItem(LEGACY_SLOT)).toBeNull();
+	});
+
+	it("keeps a delete final when the other tab migrates afterwards", async () => {
+		const tabA = new BrowserKeychainAdapter();
+		await tabA.setKey("anthropic", SECRET);
+		await tabA.deleteKey("anthropic");
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-revoked");
+
+		// The marker outlives the tab that wrote it, so a tab opened later — or one that was
+		// idle through the delete — still discards the slot instead of importing it.
+		const tabB = await openSecondTab();
+
+		expect(await tabB.getKey("anthropic")).toBeNull();
+		expect(localStorage.getItem(LEGACY_SLOT)).toBeNull();
 	});
 });
 

--- a/src/lib/adapters/browser-keychain-adapter.test.ts
+++ b/src/lib/adapters/browser-keychain-adapter.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
 import "fake-indexeddb/auto";
 import { KEY_VAULT_DB_NAME, KEY_VAULT_DB_VERSION, KeyVaultError } from "./browser-key-vault";
 import { BrowserKeychainAdapter } from "./browser-keychain-adapter";
@@ -453,8 +453,18 @@ describe("storage that never responds", () => {
 
 describe("a clear-text slot that will not erase", () => {
 	/** Make `localStorage.removeItem` a no-op, as a browser refusing the removal would. */
-	function refuseLegacyRemoval(): void {
-		vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => undefined);
+	function refuseLegacyRemoval(): MockInstance<Storage["removeItem"]> {
+		return vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => undefined);
+	}
+
+	/** Make the vault's marker store unusable, leaving every other store working. */
+	async function failMetaStore(): Promise<MockInstance<IDBDatabase["transaction"]>> {
+		const db = await openVaultDb();
+		const transaction = db.transaction.bind(db);
+		return vi.spyOn(IDBDatabase.prototype, "transaction").mockImplementation((stores, mode) => {
+			if (stores === "meta") throw new DOMException("no meta store", "NotFoundError");
+			return transaction(stores, mode);
+		});
 	}
 
 	it("does not let the stale slot overwrite a newly saved key", async () => {
@@ -520,6 +530,56 @@ describe("a clear-text slot that will not erase", () => {
 		expect(error).toBeInstanceOf(KeyVaultError);
 		expect((error as KeyVaultError).reason).toBe("legacy-retained");
 	});
+
+	it("keeps the stored key when the tombstone cannot be written", async () => {
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-compromised");
+		refuseLegacyRemoval();
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+
+		// The marker is what stops the clear-text slot being re-imported. If it is written
+		// after the record is deleted, a failure here leaves no stored secret to outrank the
+		// slot and no marker to stop it — and the revoked key returns on the next read.
+		const metaFailure = await failMetaStore();
+
+		await expect(adapter.deleteKey("anthropic")).rejects.toBeInstanceOf(KeyVaultError);
+
+		metaFailure.mockRestore();
+		// Nothing was destroyed, so once storage recovers the user still has the key they were
+		// trying to remove, and can retry — rather than the revoked clear-text value coming
+		// back in its place.
+		expect(await adapter.getKey("anthropic")).toBe(SECRET);
+	});
+
+	it("erases a settled slot once the browser starts allowing it", async () => {
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-compromised");
+		const refusal = refuseLegacyRemoval();
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		await expect(adapter.deleteKey("anthropic")).rejects.toBeInstanceOf(KeyVaultError);
+
+		// The refusal lifts — the user changed a site-data setting, or removed an extension.
+		// A user who revoked a key and then left this provider alone runs no other path, so
+		// without this the revoked credential stays readable in clear text indefinitely.
+		refusal.mockRestore();
+
+		expect(await adapter.hasKey("anthropic")).toBe(false);
+		expect(localStorage.getItem(LEGACY_SLOT)).toBeNull();
+	});
+
+	it("distinguishes a slot known to survive from one it could not check", async () => {
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-old-cleartext");
+		refuseLegacyRemoval();
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+
+		const retained = await adapter.deleteKey("anthropic").catch((caught: unknown) => caught);
+
+		// Both cases share a reason code, so only the message tells the user which situation
+		// they are in — and only one of them justifies asserting a copy exists.
+		expect((retained as KeyVaultError).message).toContain("would not delete");
+		expect((retained as KeyVaultError).message).not.toContain("blocked the check");
+	});
 });
 
 describe("a wrapping key of the wrong shape", () => {
@@ -558,6 +618,58 @@ describe("a wrapping key of the wrong shape", () => {
 		await expect(adapter.setKey("anthropic", "sk-ant-second")).rejects.toBeInstanceOf(
 			KeyVaultError,
 		);
+	});
+});
+
+describe("upgrading a database written by an earlier schema", () => {
+	it("keeps an existing key readable when the marker store is added", async () => {
+		// A version-1 vault: wrapping key and ciphertext, no `meta` store. Built through the
+		// adapter so the record really is what this code writes, then reopened at version 1
+		// to strip the store the current schema adds.
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		const seeded = await openVaultDb();
+		const wrapKeys = await new Promise<unknown[]>((resolve, reject) => {
+			const request = seeded.transaction("wrap-key", "readonly").objectStore("wrap-key").getAll();
+			request.onsuccess = () => resolve(request.result);
+			request.onerror = () => reject(request.error);
+		});
+		const secrets = await new Promise<unknown[]>((resolve, reject) => {
+			const request = seeded.transaction("secrets", "readonly").objectStore("secrets").getAll();
+			request.onsuccess = () => resolve(request.result);
+			request.onerror = () => reject(request.error);
+		});
+		seeded.close();
+		resetKeyVault();
+		await new Promise<void>((resolve, reject) => {
+			const request = globalThis.indexedDB.open(KEY_VAULT_DB_NAME, 1);
+			request.onupgradeneeded = () => {
+				const db = request.result;
+				db.createObjectStore("wrap-key");
+				db.createObjectStore("secrets");
+			};
+			request.onsuccess = () => {
+				const db = request.result;
+				const tx = db.transaction(["wrap-key", "secrets"], "readwrite");
+				tx.objectStore("wrap-key").put(wrapKeys[0], "aes-gcm-256-v1");
+				tx.objectStore("secrets").put(secrets[0], "anthropic");
+				tx.oncomplete = () => {
+					db.close();
+					resolve();
+				};
+				tx.onerror = () => reject(tx.error);
+			};
+			request.onerror = () => reject(request.error);
+		});
+
+		// The upgrade must add a store, not reset the database: a user whose key silently
+		// vanished on upgrade would have no way to tell that from the app losing it.
+		expect(await new BrowserKeychainAdapter().getKey("anthropic")).toBe(SECRET);
+
+		const upgraded = await openVaultDb();
+		expect(Array.from(upgraded.objectStoreNames).sort()).toEqual(["meta", "secrets", "wrap-key"]);
+		expect(upgraded.version).toBe(KEY_VAULT_DB_VERSION);
+		upgraded.close();
 	});
 });
 

--- a/src/lib/adapters/browser-keychain-adapter.test.ts
+++ b/src/lib/adapters/browser-keychain-adapter.test.ts
@@ -1262,10 +1262,6 @@ describe("two tabs acting on the same provider", () => {
 			});
 			return parked;
 		});
-		// Every park must be awaited through `reached` — that await is what turns a missed park
-		// into a failure. This only keeps a test that aborts before reaching its await from
-		// emitting a late rejection that would be attributed to whichever test ran next.
-		void reached.catch(() => undefined);
 		return { reached, release };
 	}
 
@@ -1289,11 +1285,16 @@ describe("two tabs acting on the same provider", () => {
 			() => `park never reached: nothing encrypted ${plaintext}, saw [${seen.join(", ")}]`,
 		);
 		const realEncrypt = globalThis.crypto.subtle.encrypt.bind(globalThis.crypto.subtle);
+		// Only the first match parks. Without this, a test whose other tab encrypts the same
+		// string would park that call too, on a gate the test releases once — a timeout with
+		// nothing pointing at the park as its cause.
+		let armed = true;
 		vi.spyOn(globalThis.crypto.subtle, "encrypt").mockImplementation(async (...args) => {
 			const [, , data] = args;
-			const encoded = new TextDecoder().decode(data as BufferSource);
+			const encoded = new TextDecoder().decode(data);
 			seen.push(encoded);
-			if (encoded !== plaintext) return realEncrypt(...args);
+			if (!armed || encoded !== plaintext) return realEncrypt(...args);
+			armed = false;
 			await arrive();
 			return realEncrypt(...args);
 		});
@@ -1434,6 +1435,9 @@ describe("two tabs acting on the same provider", () => {
 	});
 });
 
+// Tests here install storage faults that outlive the call under test. Where a post-condition
+// reads the vault back, `vi.restoreAllMocks()` runs first, so what it asserts is the real
+// stored state and not another trip through the fault.
 describe("durability and ordering", () => {
 	it("resolves a write only after its transaction has committed", async () => {
 		const order: string[] = [];
@@ -1462,15 +1466,29 @@ describe("durability and ordering", () => {
 	});
 
 	/**
-	 * Abort the transaction of the next write to `store`, after its request has succeeded.
+	 * Abort the transaction of every write to `store`, once its request has succeeded.
 	 *
 	 * This is the failure `awaitWrite` exists for and the one no other fault helper reaches:
 	 * `failMetaStore` throws from `transaction()` before any handler is attached, and a
 	 * rejected request never reaches commit. A transaction that aborts after its requests
-	 * succeeded is what a commit-time quota or I/O failure looks like, and the only signal is
-	 * `onabort`. Resolving there instead of rejecting turns every writer into a silent
-	 * success — worst of all the migration, which erases the user's only clear-text copy on
-	 * the strength of that resolution.
+	 * succeeded is what a commit-time quota or I/O failure looks like. Resolving instead of
+	 * rejecting turns a writer into a silent success — worst of all the migration, which
+	 * erases the user's only clear-text copy on the strength of that resolution.
+	 *
+	 * Which store to name matters. The spy stays armed and aborts every write to that store,
+	 * from the first matching request's `success`. Abort a store whose write is followed by
+	 * another request in the same transaction and that request fails with `AbortError`, so
+	 * `onerror` rejects before `onabort` ever runs — the test then passes while the handler it
+	 * is named for stays unwitnessed. Name the store written last, so `onabort` is the only
+	 * signal left; name a store written first to reach `onerror` deliberately.
+	 *
+	 * Two handlers stay out of reach this way: `installWrapKey` and `importLegacySecret` issue
+	 * their last request with nothing else in flight, so an abort can only ever surface as
+	 * `onabort` and their `onerror` has no witness. The remaining route is a request that
+	 * fails on its own, which `fake-indexeddb` will not produce for a well-formed write, and a
+	 * synthetic bubbled `error` event aborts the transaction rather than raising `error` on it
+	 * — a test written that way pins `onabort` again while claiming otherwise. Both are one
+	 * line rejecting exactly as their `onabort` twin does; if either is edited, edit both.
 	 */
 	function abortWriteTo(store: string): void {
 		const realPut = IDBObjectStore.prototype.put;
@@ -1495,6 +1513,25 @@ describe("durability and ordering", () => {
 		});
 	}
 
+	it("does not report a save whose wrapping key never committed", async () => {
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-only-copy");
+		const adapter = new BrowserKeychainAdapter();
+		// The wrapping key is minted in its own transaction before the secret is encrypted, so
+		// it has the same contract and its own handlers.
+		abortWriteTo("wrap-key");
+
+		await expect(adapter.setKey("anthropic", "sk-ant-new")).rejects.toMatchObject({
+			reason: "unavailable",
+		});
+
+		// Resolving on the uncommitted wrapping key would store ciphertext nothing can decrypt
+		// and erase the clear-text slot on the strength of it, so every later read fails as a
+		// damaged vault and the original key is gone.
+		vi.restoreAllMocks();
+		expect(localStorage.getItem(LEGACY_SLOT)).toBe("sk-ant-only-copy");
+		expect(await countSecrets()).toBe(0);
+	});
+
 	it("does not report a save whose transaction aborted at commit", async () => {
 		const adapter = new BrowserKeychainAdapter();
 		await adapter.setKey("anthropic", SECRET);
@@ -1504,8 +1541,8 @@ describe("durability and ordering", () => {
 			reason: "unavailable",
 		});
 
-		// Reporting success here would show the settings panel a key the vault does not hold,
-		// and every request would then fail with the old one still silently in place.
+		// Reporting success here would flip the settings panel to "configured" for a key the
+		// vault does not hold, while the previous key stays in place unannounced.
 		vi.restoreAllMocks();
 		expect(await adapter.getKey("anthropic")).toBe(SECRET);
 	});
@@ -1513,7 +1550,9 @@ describe("durability and ordering", () => {
 	it("does not report a save that supersedes a clear-text slot when its transaction aborts", async () => {
 		localStorage.setItem(LEGACY_SLOT, "sk-ant-only-copy");
 		const adapter = new BrowserKeychainAdapter();
-		abortWriteTo("secrets");
+		// The marker is the last request this transaction issues, so aborting on it leaves
+		// nothing pending and `onabort` is the handler under test.
+		abortWriteTo("meta");
 
 		await expect(adapter.setKey("anthropic", "sk-ant-new")).rejects.toMatchObject({
 			reason: "unavailable",
@@ -1529,10 +1568,43 @@ describe("durability and ordering", () => {
 		expect(await countSecrets()).toBe(0);
 	});
 
+	it("does not report a superseding save when a request in its transaction fails", async () => {
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-only-copy");
+		const adapter = new BrowserKeychainAdapter();
+		// Aborting on the ciphertext leaves the marker read in flight, so this transaction ends
+		// through `error` where its sibling above ends through `abort`.
+		abortWriteTo("secrets");
+
+		await expect(adapter.setKey("anthropic", "sk-ant-new")).rejects.toMatchObject({
+			reason: "unavailable",
+		});
+
+		vi.restoreAllMocks();
+		expect(localStorage.getItem(LEGACY_SLOT)).toBe("sk-ant-only-copy");
+		expect(await countSecrets()).toBe(0);
+	});
+
+	it("does not report a drop when a request in its transaction fails", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		await corruptStoredRecord("anthropic");
+		abortWriteTo("secrets");
+
+		await expect(adapter.getKey("anthropic")).rejects.toMatchObject({
+			reason: "unavailable",
+		});
+
+		vi.restoreAllMocks();
+		expect(await countSecrets()).toBe(1);
+	});
+
 	it("does not report a revocation whose transaction aborted at commit", async () => {
 		const adapter = new BrowserKeychainAdapter();
 		await adapter.setKey("anthropic", SECRET);
-		abortWriteTo("secrets");
+		// The marker is issued before the delete here, so the delete is still in flight when
+		// the abort lands and the transaction reports `error` rather than `abort`. That is the
+		// other half of the same contract, and a separate handler.
+		abortWriteTo("meta");
 
 		await expect(adapter.deleteKey("anthropic")).rejects.toMatchObject({
 			reason: "unavailable",
@@ -1566,17 +1638,21 @@ describe("durability and ordering", () => {
 		const adapter = new BrowserKeychainAdapter();
 		await adapter.setKey("anthropic", SECRET);
 		await corruptStoredRecord("anthropic");
-		abortWriteTo("secrets");
+		// As above: the marker settles last, so this pins `onabort` rather than the generic
+		// error path an outstanding request would take.
+		abortWriteTo("meta");
 
-		// The drop is what lets the panel offer a clean re-entry, so reporting it done while
-		// the damaged record survives would leave the user re-entering a key into a vault that
-		// keeps answering with the broken one.
+		// The drop is what stops `hasKey` counting the damaged record. Reporting it done while
+		// the record survives leaves the settings panel showing the provider as configured
+		// while every request fails for want of a key — the disagreement between the two
+		// predicates that the drop exists to resolve.
 		await expect(adapter.getKey("anthropic")).rejects.toMatchObject({
 			reason: "unavailable",
 		});
 
 		vi.restoreAllMocks();
 		expect(await countSecrets()).toBe(1);
+		expect(await adapter.hasKey("anthropic")).toBe(true);
 	});
 
 	it("does not resurrect a key when a read races a delete", async () => {

--- a/src/lib/adapters/browser-keychain-adapter.test.ts
+++ b/src/lib/adapters/browser-keychain-adapter.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "fake-indexeddb/auto";
-import { KEY_VAULT_DB_NAME, KeyVaultError } from "./browser-key-vault";
+import { KEY_VAULT_DB_NAME, KEY_VAULT_DB_VERSION, KeyVaultError } from "./browser-key-vault";
 import { BrowserKeychainAdapter } from "./browser-keychain-adapter";
+import { yieldHostTask } from "./test-fixtures/host-task";
 import { resetKeyVault } from "./test-fixtures/key-vault";
 
 /**
@@ -17,11 +18,7 @@ const LEGACY_SLOT = "tf-api-key-anthropic";
 
 /** Read every value held in the vault database, as one string, for substring scanning. */
 async function dumpVault(): Promise<string> {
-	const db = await new Promise<IDBDatabase>((resolve, reject) => {
-		const request = globalThis.indexedDB.open(KEY_VAULT_DB_NAME);
-		request.onsuccess = () => resolve(request.result);
-		request.onerror = () => reject(request.error);
-	});
+	const db = await openVaultDb();
 	try {
 		const names = Array.from(db.objectStoreNames);
 		const dumps = await Promise.all(
@@ -148,11 +145,7 @@ describe("BrowserKeychainAdapter encrypted storage", () => {
 		const adapter = new BrowserKeychainAdapter();
 		await adapter.setKey("anthropic", SECRET);
 
-		const db = await new Promise<IDBDatabase>((resolve, reject) => {
-			const request = globalThis.indexedDB.open(KEY_VAULT_DB_NAME);
-			request.onsuccess = () => resolve(request.result);
-			request.onerror = () => reject(request.error);
-		});
+		const db = await openVaultDb();
 		const wrapKey = await new Promise<unknown>((resolve, reject) => {
 			const request = db.transaction("wrap-key", "readonly").objectStore("wrap-key").getAll();
 			request.onsuccess = () => resolve(request.result[0]);
@@ -163,7 +156,7 @@ describe("BrowserKeychainAdapter encrypted storage", () => {
 		expect(wrapKey).toBeInstanceOf(CryptoKey);
 		expect((wrapKey as CryptoKey).extractable).toBe(false);
 		// The property that makes `extractable: false` meaningful: the material cannot be
-		// read back out even by code running on this origin.
+		// read back out through the Web Crypto API, even by code running on this origin.
 		await expect(globalThis.crypto.subtle.exportKey("raw", wrapKey as CryptoKey)).rejects.toThrow();
 	});
 
@@ -189,11 +182,7 @@ describe("BrowserKeychainAdapter encrypted storage", () => {
 		await adapter.setKey("anthropic", SECRET);
 		await adapter.setKey("openai", SECRET);
 
-		const db = await new Promise<IDBDatabase>((resolve, reject) => {
-			const request = globalThis.indexedDB.open(KEY_VAULT_DB_NAME);
-			request.onsuccess = () => resolve(request.result);
-			request.onerror = () => reject(request.error);
-		});
+		const db = await openVaultDb();
 		const records = await new Promise<{ iv: Uint8Array; ciphertext: Uint8Array }[]>(
 			(resolve, reject) => {
 				const request = db.transaction("secrets", "readonly").objectStore("secrets").getAll();
@@ -333,7 +322,7 @@ describe("failing closed when encrypted storage is unavailable", () => {
 		// `NotFoundError` from `transaction()`, which would otherwise reach the settings panel
 		// verbatim. No mock: this is the genuine exception the platform throws.
 		await new Promise<void>((resolve, reject) => {
-			const request = globalThis.indexedDB.open(KEY_VAULT_DB_NAME, 1);
+			const request = globalThis.indexedDB.open(KEY_VAULT_DB_NAME, KEY_VAULT_DB_VERSION);
 			request.onsuccess = () => {
 				request.result.close();
 				resolve();
@@ -431,23 +420,12 @@ describe("recovering from an unreadable record", () => {
 });
 
 describe("storage that never responds", () => {
-	/** Yield one real host task. `MessageChannel` is used because `setTimeout` is faked here. */
-	function yieldRealTask(): Promise<void> {
-		return new Promise((resolve) => {
-			const channel = new MessageChannel();
-			channel.port1.onmessage = () => {
-				channel.port1.close();
-				resolve();
-			};
-			channel.port2.postMessage(null);
-		});
-	}
-
 	it("gives up on a wedged open rather than hanging the caller forever", async () => {
 		vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
-		// Safari and Firefox private mode are both known to accept `open()` and then fire no
-		// event at all. An unbounded wait leaves the settings panel spinning forever, and
-		// because adapter calls are serialized per provider, wedges every later call too.
+		// A stalled storage layer can accept `open()` and then fire no event at all — the
+		// case reported against WebKit, and the shape any wedged implementation produces. An
+		// unbounded wait leaves the settings panel spinning forever, and because adapter calls
+		// are serialized per provider, wedges every later call too.
 		const open = vi.spyOn(globalThis.indexedDB, "open").mockReturnValue({
 			onsuccess: null,
 			onerror: null,
@@ -460,7 +438,7 @@ describe("storage that never responds", () => {
 		await vi.advanceTimersByTimeAsync(10_000);
 		// Raced rather than awaited directly: nothing but the vault's own bound can settle
 		// this call, so an unbounded implementation would hang the suite instead of failing it.
-		const error = await Promise.race([pending, yieldRealTask().then(() => "still pending")]);
+		const error = await Promise.race([pending, yieldHostTask().then(() => "still pending")]);
 
 		expect(error).toBeInstanceOf(KeyVaultError);
 		expect((error as KeyVaultError).reason).toBe("unavailable");
@@ -506,6 +484,41 @@ describe("a clear-text slot that will not erase", () => {
 		expect((error as KeyVaultError).reason).toBe("legacy-retained");
 		// The encrypted copy is still removed; only the claim of completeness is withheld.
 		expect(localStorage.getItem(LEGACY_SLOT)).toBe("sk-ant-old-cleartext");
+	});
+	it("does not let a dismissed clear-text slot come back after a delete", async () => {
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-compromised");
+		refuseLegacyRemoval();
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+
+		await expect(adapter.deleteKey("anthropic")).rejects.toBeInstanceOf(KeyVaultError);
+
+		// The user removed a key they believe is compromised. The clear-text copy survived and
+		// they were told so — but the vault must not re-import it, or the app silently resumes
+		// signing provider requests with the credential they just revoked.
+		expect(await adapter.hasKey("anthropic")).toBe(false);
+		expect(await adapter.getKey("anthropic")).toBeNull();
+	});
+
+	it("does not report a key as removed when it cannot read the slot back", async () => {
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-old-cleartext");
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-old-cleartext");
+		// A browser that blocks site data throws on both removal and read-back. An absent
+		// value and an unreadable one are not the same fact, and treating them alike reports
+		// a clear-text credential as erased when it was never touched.
+		vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+			throw new DOMException("blocked", "SecurityError");
+		});
+		vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+			throw new DOMException("blocked", "SecurityError");
+		});
+
+		const error = await adapter.deleteKey("anthropic").catch((caught: unknown) => caught);
+
+		expect(error).toBeInstanceOf(KeyVaultError);
+		expect((error as KeyVaultError).reason).toBe("legacy-retained");
 	});
 });
 

--- a/src/lib/adapters/browser-keychain-adapter.test.ts
+++ b/src/lib/adapters/browser-keychain-adapter.test.ts
@@ -75,13 +75,17 @@ async function openVaultDb(): Promise<IDBDatabase> {
  * The migration reads the wrapping key twice — once to decide it may proceed, once to
  * encrypt under — and a loss landing between them is what a caller-side check cannot see.
  * Firing on the read itself makes that window deterministic instead of hoping a concurrent
- * write lands inside it. Returns a restore function; it is also self-disarming, so a run
- * that never reaches the read cannot corrupt a later assertion.
+ * write lands inside it. It fires at most once, so later assertions in the same test are not
+ * wiped a second time; `vi.restoreAllMocks()` in `afterEach` is what stops it leaking into
+ * the next test when an assertion fails before the read.
  */
-function wipeWrapKeyAfterRead(): () => void {
+function wipeWrapKeyAfterRead(): void {
 	const original = IDBObjectStore.prototype.get;
 	let armed = true;
-	IDBObjectStore.prototype.get = function patched(this: IDBObjectStore, query: IDBValidKey) {
+	vi.spyOn(IDBObjectStore.prototype, "get").mockImplementation(function patched(
+		this: IDBObjectStore,
+		query: IDBValidKey | IDBKeyRange,
+	) {
 		const request = original.call(this, query);
 		if (armed && this.name === "wrap-key") {
 			armed = false;
@@ -93,10 +97,7 @@ function wipeWrapKeyAfterRead(): () => void {
 			});
 		}
 		return request;
-	} as typeof IDBObjectStore.prototype.get;
-	return () => {
-		IDBObjectStore.prototype.get = original;
-	};
+	});
 }
 
 /** Replace the contents of the wrap-key store, simulating a damaged vault. */
@@ -591,6 +592,41 @@ describe("recovering from an unreadable record", () => {
 		expect(await adapter.hasKey("openai")).toBe(false);
 	});
 
+	it("recovers a clear-text copy left behind when the vault is started over", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		await adapter.setKey("openai", "sk-openai-stored");
+		await writeWrapKeyStore([]);
+		localStorage.setItem("tf-api-key-openai", "sk-openai-cleartext");
+
+		await adapter.setKey("anthropic", "sk-ant-reentered");
+
+		// Re-entry mints a key that cannot read the `openai` record. Leaving that record in
+		// place would let the next read find it broken, drop it, and settle `openai` — erasing
+		// the clear-text copy that is still perfectly good. Discarding it with the old key
+		// instead leaves the slot importable, so the credential comes back.
+		expect(await adapter.getKey("openai")).toBe("sk-openai-cleartext");
+		expect(await adapter.getKey("anthropic")).toBe("sk-ant-reentered");
+	});
+
+	it("keeps a clear-text copy the user never revoked when the vault is damaged", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		await adapter.setKey("openai", "sk-openai-stored");
+		await corruptStoredRecord("anthropic");
+		// The vault discards the unreadable record. The user asked for none of this.
+		expect(await adapter.getKey("anthropic")).toBeNull();
+		await writeWrapKeyStore([]);
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-still-good");
+
+		const error = await adapter.getKey("anthropic").catch((caught: unknown) => caught);
+
+		// A dropped record settles the provider, but it is not a revocation, so it must not
+		// license erasing the clear-text copy while the vault cannot offer a replacement.
+		expect((error as KeyVaultError).reason).toBe("vault-corrupt");
+		expect(localStorage.getItem(LEGACY_SLOT)).toBe("sk-ant-still-good");
+	});
+
 	it("refuses to mint over surviving records when the key disappears mid-migration", async () => {
 		const adapter = new BrowserKeychainAdapter();
 		await adapter.setKey("anthropic", SECRET);
@@ -599,7 +635,7 @@ describe("recovering from an unreadable record", () => {
 		// The migration reads the wrapping key to decide it may proceed, then reads it again to
 		// encrypt under. Wiping the store between those two reads is the window a caller-side
 		// check cannot close, and the only way to reach the install path's own refusal.
-		const restore = wipeWrapKeyAfterRead();
+		wipeWrapKeyAfterRead();
 
 		const error = await adapter.getKey("openai").catch((caught: unknown) => caught);
 
@@ -609,7 +645,6 @@ describe("recovering from an unreadable record", () => {
 		expect(await countWrapKeys()).toBe(0);
 		expect(await countSecrets()).toBe(1);
 		expect(localStorage.getItem("tf-api-key-openai")).toBe("sk-openai-cleartext");
-		restore();
 	});
 });
 

--- a/src/lib/adapters/browser-keychain-adapter.test.ts
+++ b/src/lib/adapters/browser-keychain-adapter.test.ts
@@ -450,6 +450,42 @@ describe("recovering from an unreadable record", () => {
 		expect(await countWrapKeys()).toBe(0);
 	});
 
+	it("keeps the clear-text slot when the wrapping key is unusable", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		await writeWrapKeyStore([["not-a-crypto-key", "aes-gcm-256-v1"]]);
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-only-readable-copy");
+
+		const error = await adapter.getKey("anthropic").catch((caught: unknown) => caught);
+
+		expect((error as KeyVaultError).reason).toBe("vault-corrupt");
+		// The stored record cannot be decrypted, so the clear-text slot is the only usable
+		// credential left. Deciding the migration has nothing to do — a record is already
+		// stored — and erasing the slot on that basis destroys it, while the message shown
+		// tells the user to clear their browser data.
+		expect(localStorage.getItem(LEGACY_SLOT)).toBe("sk-ant-only-readable-copy");
+	});
+
+	it("does not create key material for one provider while another's record is stranded", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		await writeWrapKeyStore([]);
+		localStorage.setItem("tf-api-key-openai", "sk-openai-old-cleartext");
+
+		const error = await adapter.getKey("openai").catch((caught: unknown) => caught);
+
+		// The wrapping key is shared, so minting one to migrate openai would strand the
+		// anthropic record under a key that no longer exists — and the next anthropic read
+		// would then read as an ordinary corrupt record and drop it. Nothing about openai
+		// makes that acceptable, so the vault has to fail for every provider at once.
+		expect((error as KeyVaultError).reason).toBe("vault-corrupt");
+		expect(await countWrapKeys()).toBe(0);
+		expect(await countSecrets()).toBe(1);
+		// The clear-text slot must survive too: erasing it on the strength of an import that
+		// never happened would destroy the only copy of that key.
+		expect(localStorage.getItem("tf-api-key-openai")).toBe("sk-openai-old-cleartext");
+	});
+
 	it("does not create key material while a clear-text slot is waiting to migrate", async () => {
 		const adapter = new BrowserKeychainAdapter();
 		await adapter.setKey("anthropic", SECRET);
@@ -784,7 +820,7 @@ describe("two tabs acting on the same provider", () => {
 		let seen = 0;
 		const missed = setTimeout(
 			() => signalMissed(new Error(`park never reached: wanted vault open #${nth}, saw ${seen}`)),
-			1_000,
+			3_000,
 		);
 		vi.spyOn(globalThis.indexedDB, "open").mockImplementation((name, version) => {
 			seen += 1;
@@ -814,6 +850,9 @@ describe("two tabs acting on the same provider", () => {
 			});
 			return parked;
 		});
+		// A test that builds a park and never awaits `reached` would otherwise surface the miss
+		// as an unhandled rejection instead of a failure.
+		void reached.catch(() => undefined);
 		return { reached, release };
 	}
 
@@ -846,6 +885,26 @@ describe("two tabs acting on the same provider", () => {
 		expect(await tabA.getKey("anthropic")).toBeNull();
 		expect(await tabB.getKey("anthropic")).toBeNull();
 		expect(localStorage.getItem(LEGACY_SLOT)).toBeNull();
+	});
+
+	it("drops a stored value too malformed to read back as a record", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		const db = await openVaultDb();
+		await new Promise<void>((resolve, reject) => {
+			const tx = db.transaction("secrets", "readwrite");
+			tx.objectStore("secrets").put({ iv: "not-bytes", ciphertext: "nope" }, "anthropic");
+			tx.oncomplete = () => resolve();
+			tx.onerror = () => reject(tx.error);
+		});
+		db.close();
+
+		// Nothing here can be compared byte for byte, but the record still has to go. Left in
+		// place it is counted forever: the panel shows the provider as configured while every
+		// request fails for want of a key, and no path removes it.
+		expect(await adapter.getKey("anthropic")).toBeNull();
+		expect(await adapter.hasKey("anthropic")).toBe(false);
+		expect(await countSecrets()).toBe(0);
 	});
 
 	it("does not discard a key re-entered elsewhere while a damaged one is dropped", async () => {

--- a/src/lib/adapters/browser-keychain-adapter.test.ts
+++ b/src/lib/adapters/browser-keychain-adapter.test.ts
@@ -1,0 +1,321 @@
+import { IDBFactory } from "fake-indexeddb";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "fake-indexeddb/auto";
+import { KEY_VAULT_DB_NAME, KeyVaultError } from "./browser-key-vault";
+import { BrowserKeychainAdapter } from "./browser-keychain-adapter";
+
+/**
+ * #133: browser BYOK keys are encrypted at rest under a non-extractable wrapping key.
+ *
+ * These tests assert the property that matters — a stored key is never recoverable as clear
+ * text from web storage — against the real IndexedDB and Web Crypto implementations rather
+ * than against a mock of them, so they would fail if the adapter reverted to `localStorage`.
+ */
+
+const SECRET = "sk-ant-test-0123456789abcdef";
+const LEGACY_SLOT = "tf-api-key-anthropic";
+
+/** Read every value held in the vault database, as one string, for substring scanning. */
+async function dumpVault(): Promise<string> {
+	const db = await new Promise<IDBDatabase>((resolve, reject) => {
+		const request = globalThis.indexedDB.open(KEY_VAULT_DB_NAME);
+		request.onsuccess = () => resolve(request.result);
+		request.onerror = () => reject(request.error);
+	});
+	try {
+		const names = Array.from(db.objectStoreNames);
+		const dumps = await Promise.all(
+			names.map(
+				(name) =>
+					new Promise<unknown[]>((resolve, reject) => {
+						const request = db.transaction(name, "readonly").objectStore(name).getAll();
+						request.onsuccess = () => resolve(request.result);
+						request.onerror = () => reject(request.error);
+					}),
+			),
+		);
+		// `CryptoKey` and byte views do not survive `JSON.stringify`, so build a
+		// representation that decodes raw bytes — otherwise a plaintext key sitting in the
+		// store could pass a substring check simply by being unreadable.
+		return dumps
+			.flat()
+			.map((record) => describeStoredValue(record))
+			.join("|");
+	} finally {
+		db.close();
+	}
+}
+
+/**
+ * Render one stored value as scannable text. Structured clone returns cross-realm objects,
+ * so this brands byte views with `ArrayBuffer.isView` rather than `instanceof`.
+ */
+function describeStoredValue(value: unknown): string {
+	if (ArrayBuffer.isView(value)) {
+		return new TextDecoder().decode(
+			new Uint8Array(value.buffer, value.byteOffset, value.byteLength),
+		);
+	}
+	if (typeof value !== "object" || value === null) return String(value);
+	if (value.constructor?.name === "CryptoKey") return "CryptoKey";
+	return Object.values(value).map(describeStoredValue).join(",");
+}
+
+beforeEach(() => {
+	globalThis.indexedDB = new IDBFactory();
+	localStorage.clear();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("BrowserKeychainAdapter encrypted storage", () => {
+	it("round-trips a stored key", async () => {
+		const adapter = new BrowserKeychainAdapter();
+
+		expect(await adapter.hasKey("anthropic")).toBe(false);
+		expect(await adapter.getKey("anthropic")).toBeNull();
+
+		await adapter.setKey("anthropic", SECRET);
+
+		expect(await adapter.hasKey("anthropic")).toBe(true);
+		expect(await adapter.getKey("anthropic")).toBe(SECRET);
+	});
+
+	it("never writes the key to localStorage", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+
+		const values = Object.keys(localStorage).map((key) => localStorage.getItem(key) ?? "");
+		expect(values.some((value) => value.includes(SECRET))).toBe(false);
+		expect(localStorage.getItem(LEGACY_SLOT)).toBeNull();
+	});
+
+	it("persists ciphertext rather than the key itself", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+
+		const dump = await dumpVault();
+		expect(dump).not.toContain(SECRET);
+		// The vault is not merely empty: a wrapping key and a record are both present.
+		expect(dump).toContain("CryptoKey");
+	});
+
+	it("stores the wrapping key as non-extractable", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+
+		const db = await new Promise<IDBDatabase>((resolve, reject) => {
+			const request = globalThis.indexedDB.open(KEY_VAULT_DB_NAME);
+			request.onsuccess = () => resolve(request.result);
+			request.onerror = () => reject(request.error);
+		});
+		const wrapKey = await new Promise<unknown>((resolve, reject) => {
+			const request = db.transaction("wrap-key", "readonly").objectStore("wrap-key").getAll();
+			request.onsuccess = () => resolve(request.result[0]);
+			request.onerror = () => reject(request.error);
+		});
+		db.close();
+
+		expect(wrapKey).toBeInstanceOf(CryptoKey);
+		expect((wrapKey as CryptoKey).extractable).toBe(false);
+		// The property that makes `extractable: false` meaningful: the material cannot be
+		// read back out even by code running on this origin.
+		await expect(globalThis.crypto.subtle.exportKey("raw", wrapKey as CryptoKey)).rejects.toThrow();
+	});
+
+	it("keeps providers isolated from each other", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		await adapter.setKey("openai", "sk-openai-different-value");
+
+		expect(await adapter.getKey("anthropic")).toBe(SECRET);
+		expect(await adapter.getKey("openai")).toBe("sk-openai-different-value");
+	});
+
+	it("overwrites a previously stored key", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		await adapter.setKey("anthropic", "sk-ant-replacement");
+
+		expect(await adapter.getKey("anthropic")).toBe("sk-ant-replacement");
+	});
+
+	it("uses a fresh nonce per encryption so identical keys differ on disk", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		await adapter.setKey("openai", SECRET);
+
+		const db = await new Promise<IDBDatabase>((resolve, reject) => {
+			const request = globalThis.indexedDB.open(KEY_VAULT_DB_NAME);
+			request.onsuccess = () => resolve(request.result);
+			request.onerror = () => reject(request.error);
+		});
+		const records = await new Promise<{ iv: Uint8Array; ciphertext: Uint8Array }[]>(
+			(resolve, reject) => {
+				const request = db.transaction("secrets", "readonly").objectStore("secrets").getAll();
+				request.onsuccess = () => resolve(request.result);
+				request.onerror = () => reject(request.error);
+			},
+		);
+		db.close();
+
+		expect(records).toHaveLength(2);
+		const [first, second] = records;
+		expect(Array.from(first.iv)).not.toEqual(Array.from(second.iv));
+		expect(Array.from(first.ciphertext)).not.toEqual(Array.from(second.ciphertext));
+	});
+
+	it("removes a deleted key", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		await adapter.deleteKey("anthropic");
+
+		expect(await adapter.hasKey("anthropic")).toBe(false);
+		expect(await adapter.getKey("anthropic")).toBeNull();
+		expect(await dumpVault()).not.toContain(SECRET);
+	});
+
+	it("leaves other providers usable after one is deleted", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		await adapter.setKey("openai", "sk-openai-survivor");
+
+		await adapter.deleteKey("anthropic");
+
+		// Deleting one provider must not drop the shared wrapping key and orphan the rest.
+		expect(await adapter.getKey("openai")).toBe("sk-openai-survivor");
+	});
+});
+
+describe("migration from the pre-#133 clear-text slot", () => {
+	it("moves an existing clear-text key into the vault and erases the slot", async () => {
+		localStorage.setItem(LEGACY_SLOT, SECRET);
+		const adapter = new BrowserKeychainAdapter();
+
+		expect(await adapter.getKey("anthropic")).toBe(SECRET);
+
+		expect(localStorage.getItem(LEGACY_SLOT)).toBeNull();
+		expect(await dumpVault()).not.toContain(SECRET);
+		// The key is still usable after the clear-text copy is gone.
+		expect(await adapter.getKey("anthropic")).toBe(SECRET);
+	});
+
+	it("migrates on a status check as well as on a read", async () => {
+		localStorage.setItem(LEGACY_SLOT, SECRET);
+		const adapter = new BrowserKeychainAdapter();
+
+		expect(await adapter.hasKey("anthropic")).toBe(true);
+		expect(localStorage.getItem(LEGACY_SLOT)).toBeNull();
+	});
+
+	it("erases the clear-text slot when a new key is saved over it", async () => {
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-old-clear-text");
+		const adapter = new BrowserKeychainAdapter();
+
+		await adapter.setKey("anthropic", SECRET);
+
+		expect(localStorage.getItem(LEGACY_SLOT)).toBeNull();
+		expect(await adapter.getKey("anthropic")).toBe(SECRET);
+	});
+
+	it("erases the clear-text slot on delete", async () => {
+		localStorage.setItem(LEGACY_SLOT, SECRET);
+		const adapter = new BrowserKeychainAdapter();
+
+		await adapter.deleteKey("anthropic");
+
+		expect(localStorage.getItem(LEGACY_SLOT)).toBeNull();
+		expect(await adapter.hasKey("anthropic")).toBe(false);
+	});
+
+	it("keeps the clear-text key when the encrypted write fails", async () => {
+		localStorage.setItem(LEGACY_SLOT, SECRET);
+		// The vault cannot be opened, so the migration cannot complete.
+		vi.spyOn(globalThis.indexedDB, "open").mockImplementation(() => {
+			throw new DOMException("blocked", "SecurityError");
+		});
+		const adapter = new BrowserKeychainAdapter();
+
+		await expect(adapter.getKey("anthropic")).rejects.toBeInstanceOf(KeyVaultError);
+
+		// Erasing before the encrypted copy exists would destroy the user's only key.
+		expect(localStorage.getItem(LEGACY_SLOT)).toBe(SECRET);
+	});
+});
+
+describe("failing closed when encrypted storage is unavailable", () => {
+	it("refuses to store a key when IndexedDB is blocked", async () => {
+		vi.spyOn(globalThis.indexedDB, "open").mockImplementation(() => {
+			throw new DOMException("blocked", "SecurityError");
+		});
+		const adapter = new BrowserKeychainAdapter();
+
+		await expect(adapter.setKey("anthropic", SECRET)).rejects.toBeInstanceOf(KeyVaultError);
+
+		// The whole point of failing closed: no clear-text consolation copy is written.
+		const values = Object.keys(localStorage).map((key) => localStorage.getItem(key) ?? "");
+		expect(values.some((value) => value.includes(SECRET))).toBe(false);
+	});
+
+	it("refuses to store a key when Web Crypto is unavailable", async () => {
+		vi.spyOn(globalThis.crypto, "subtle", "get").mockReturnValue(
+			undefined as unknown as SubtleCrypto,
+		);
+		const adapter = new BrowserKeychainAdapter();
+
+		await expect(adapter.setKey("anthropic", SECRET)).rejects.toBeInstanceOf(KeyVaultError);
+
+		const values = Object.keys(localStorage).map((key) => localStorage.getItem(key) ?? "");
+		expect(values.some((value) => value.includes(SECRET))).toBe(false);
+	});
+
+	it("surfaces a user-safe message that carries no internal detail", async () => {
+		vi.spyOn(globalThis.indexedDB, "open").mockImplementation(() => {
+			throw new DOMException("IDBFactory internal failure at /var/db/foo", "SecurityError");
+		});
+		const adapter = new BrowserKeychainAdapter();
+
+		const error = await adapter.setKey("anthropic", SECRET).catch((caught: unknown) => caught);
+
+		expect(error).toBeInstanceOf(KeyVaultError);
+		expect((error as KeyVaultError).reason).toBe("unavailable");
+		expect((error as KeyVaultError).message).not.toContain("/var/db/foo");
+		expect((error as KeyVaultError).message).not.toContain("IDBFactory");
+	});
+});
+
+describe("recovering from an unreadable record", () => {
+	it("reports a corrupted record as no key rather than throwing at the caller", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+
+		// Truncate the ciphertext so AES-GCM authentication fails on read.
+		const db = await new Promise<IDBDatabase>((resolve, reject) => {
+			const request = globalThis.indexedDB.open(KEY_VAULT_DB_NAME);
+			request.onsuccess = () => resolve(request.result);
+			request.onerror = () => reject(request.error);
+		});
+		await new Promise<void>((resolve, reject) => {
+			const store = db.transaction("secrets", "readwrite").objectStore("secrets");
+			const read = store.get("anthropic");
+			read.onsuccess = () => {
+				const record = read.result as { iv: Uint8Array; ciphertext: Uint8Array };
+				const write = store.put(
+					{ iv: record.iv, ciphertext: record.ciphertext.slice(0, 4) },
+					"anthropic",
+				);
+				write.onsuccess = () => resolve();
+				write.onerror = () => reject(write.error);
+			};
+			read.onerror = () => reject(read.error);
+		});
+		db.close();
+
+		// The user sees the ordinary "no key configured" path and can simply re-enter it.
+		expect(await adapter.getKey("anthropic")).toBeNull();
+		await adapter.setKey("anthropic", "sk-ant-reentered");
+		expect(await adapter.getKey("anthropic")).toBe("sk-ant-reentered");
+	});
+});

--- a/src/lib/adapters/browser-keychain-adapter.test.ts
+++ b/src/lib/adapters/browser-keychain-adapter.test.ts
@@ -113,20 +113,6 @@ async function writeMetaValue(key: string, value: unknown): Promise<void> {
 	db.close();
 }
 
-/** Read a raw value back out of the vault's meta store. */
-async function readMetaValue(key: string): Promise<unknown> {
-	const db = await openVaultDb();
-	try {
-		return await new Promise<unknown>((resolve, reject) => {
-			const request = db.transaction("meta", "readonly").objectStore("meta").get(key);
-			request.onsuccess = () => resolve(request.result);
-			request.onerror = () => reject(request.error);
-		});
-	} finally {
-		db.close();
-	}
-}
-
 /** Replace the contents of the wrap-key store, simulating a damaged vault. */
 async function writeWrapKeyStore(entries: [unknown, string][]): Promise<void> {
 	const db = await openVaultDb();
@@ -1002,24 +988,6 @@ describe("a clear-text slot that will not erase", () => {
 		// leaving the revoked credential readable in clear text with no path left to erase it.
 		expect(settled).toBeNull();
 		expect(localStorage.getItem(LEGACY_SLOT)).toBeNull();
-	});
-
-	it("keeps the reason a slot was first settled for", async () => {
-		localStorage.setItem(LEGACY_SLOT, "sk-ant-old");
-		refuseLegacyRemoval();
-		const adapter = new BrowserKeychainAdapter();
-		// Migration writes no marker, so this is the one way a provider reaches the drop path
-		// with its slot still unsettled.
-		expect(await adapter.getKey("anthropic")).toBe("sk-ant-old");
-		await corruptStoredRecord("anthropic");
-		expect(await adapter.getKey("anthropic")).toBeNull();
-
-		await adapter.setKey("anthropic", "sk-ant-replacement");
-
-		// The reasons behave alike, so nothing else would catch this: the marker is the only
-		// record of why a slot stopped being importable, and re-labelling a record this vault
-		// gave up on as a key the user replaced answers a support question wrongly.
-		expect(await readMetaValue("legacy-retired:anthropic")).toBe("dropped");
 	});
 
 	it("erases a settled slot once the browser starts allowing it", async () => {

--- a/src/lib/adapters/browser-keychain-adapter.test.ts
+++ b/src/lib/adapters/browser-keychain-adapter.test.ts
@@ -101,6 +101,20 @@ function wipeWrapKeyAfterRead(): void {
 	});
 }
 
+/** Read a raw value back out of the vault's meta store. */
+async function readMetaValue(key: string): Promise<unknown> {
+	const db = await openVaultDb();
+	try {
+		return await new Promise<unknown>((resolve, reject) => {
+			const request = db.transaction("meta", "readonly").objectStore("meta").get(key);
+			request.onsuccess = () => resolve(request.result);
+			request.onerror = () => reject(request.error);
+		});
+	} finally {
+		db.close();
+	}
+}
+
 /** Write a raw value into the vault's meta store, standing in for another build. */
 async function writeMetaValue(key: string, value: unknown): Promise<void> {
 	const db = await openVaultDb();
@@ -652,6 +666,23 @@ describe("recovering from an unreadable record", () => {
 		expect(await countWrapKeys()).toBe(0);
 	});
 
+	it("does not overwrite a marker it cannot recognise", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		await adapter.deleteKey("anthropic");
+		const foreign = { reason: "revoked-by-policy", v: 3 };
+		await writeMetaValue("legacy-retired:anthropic", foreign);
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-settled");
+
+		await adapter.setKey("anthropic", "sk-ant-new");
+
+		// Reading an unrecognised marker fails closed, so writing over one has to be refused
+		// for the same reason: this build cannot tell whether it is weaker than what it would
+		// replace. Downgrading a stronger marker from a later build to `settled` would strip
+		// the authority to erase a revoked clear-text slot on a vault that cannot decrypt.
+		expect(await readMetaValue("legacy-retired:anthropic")).toEqual(foreign);
+	});
+
 	it("treats a marker it cannot recognise as a marker", async () => {
 		const adapter = new BrowserKeychainAdapter();
 		await adapter.setKey("anthropic", SECRET);
@@ -1194,6 +1225,94 @@ describe("two tabs acting on the same provider", () => {
 		return { reached, release };
 	}
 
+	/**
+	 * Hold the migration between its pre-check and the transaction that decides.
+	 *
+	 * `importLegacySecret` reads the marker and the record count once before encrypting, then
+	 * re-reads both inside the write transaction. Parking a connection cannot sample the gap
+	 * between those two reads, because it stalls the tab before the pre-check rather than
+	 * after it. Encryption is the only await that sits in the middle, so gating the first
+	 * `subtle.encrypt` call is what puts another tab inside the window the in-transaction
+	 * guards exist to close.
+	 */
+	function parkMigrationEncrypt(): { reached: Promise<void>; release: () => void } {
+		let release = () => {};
+		const gate = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		let signalReached = () => {};
+		let signalMissed = (_reason: Error) => {};
+		const reached = new Promise<void>((resolve, reject) => {
+			signalReached = resolve;
+			signalMissed = reject;
+		});
+		const missed = setTimeout(
+			() => signalMissed(new Error("migration never reached encrypt")),
+			3_000,
+		);
+		const realEncrypt = globalThis.crypto.subtle.encrypt.bind(globalThis.crypto.subtle);
+		let seen = 0;
+		vi.spyOn(globalThis.crypto.subtle, "encrypt").mockImplementation(async (...args) => {
+			seen += 1;
+			if (seen > 1) return realEncrypt(...args);
+			clearTimeout(missed);
+			signalReached();
+			await gate;
+			return realEncrypt(...args);
+		});
+		void reached.catch(() => undefined);
+		return { reached, release };
+	}
+
+	it("does not import a clear-text slot revoked while the migration was encrypting", async () => {
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-revoked");
+		const tabB = await openSecondTab();
+		const tabA = new BrowserKeychainAdapter();
+
+		// Tab B has read an unsettled slot and an empty vault, and is now encrypting what it
+		// captured. Both reads were true when it made them.
+		const suspended = parkMigrationEncrypt();
+		const migrating = tabB.getKey("anthropic");
+		await suspended.reached;
+
+		// The user revokes the provider in the foreground tab and is told it worked.
+		await expect(tabA.deleteKey("anthropic")).resolves.toBeUndefined();
+		expect(localStorage.getItem(LEGACY_SLOT)).toBeNull();
+
+		suspended.release();
+		// Tab B resumes holding a credential the user has since thrown away. Its pre-check is
+		// stale, so only the marker re-read inside the write transaction can stop it storing
+		// the value — and a resurrection here is silent, since the migration reports the key
+		// it captured either way.
+		await migrating;
+
+		expect(await tabA.hasKey("anthropic")).toBe(false);
+		expect(await countSecrets()).toBe(0);
+	});
+
+	it("does not import a clear-text slot replaced while the migration was encrypting", async () => {
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-old");
+		const tabB = await openSecondTab();
+		const tabA = new BrowserKeychainAdapter();
+
+		const suspended = parkMigrationEncrypt();
+		const migrating = tabB.getKey("anthropic");
+		await suspended.reached;
+
+		// The user types a new key in the foreground tab. That save writes a marker too, so the
+		// count re-read is only load-bearing for the window where a record exists without one:
+		// a save whose slot was already absent takes the `leave-slot` path.
+		localStorage.removeItem(LEGACY_SLOT);
+		await tabA.setKey("anthropic", "sk-ant-replacement");
+
+		suspended.release();
+		await migrating;
+
+		// Reverting to the old key would be indistinguishable from the save silently failing.
+		expect(await tabA.getKey("anthropic")).toBe("sk-ant-replacement");
+		expect(await countSecrets()).toBe(1);
+	});
+
 	it("does not resurrect a revoked key when a read races the delete", async () => {
 		const tabA = new BrowserKeychainAdapter();
 		await tabA.setKey("anthropic", SECRET);
@@ -1215,9 +1334,11 @@ describe("two tabs acting on the same provider", () => {
 		await expect(tabA.deleteKey("anthropic")).resolves.toBeUndefined();
 
 		suspended.release();
-		// Tab B now resumes against a vault the delete has already changed. With the guard read
-		// and the write in separate transactions, tab B still believes nothing is stored and
-		// writes the clear-text value it captured — and nothing anywhere reports a problem.
+		// Tab B now resumes against a vault the delete has already changed. Parking the
+		// connection stalls it before its pre-check rather than inside the window between that
+		// check and the write, so what this samples is the coarser ordering: a tab that opens
+		// its migration connection before the delete must still not hand back the revoked
+		// value. The narrower gap is covered by the two encrypt-parked tests above.
 		await expect(read).resolves.not.toBe("sk-ant-revoked");
 
 		expect(await tabA.getKey("anthropic")).toBeNull();

--- a/src/lib/adapters/browser-keychain-adapter.ts
+++ b/src/lib/adapters/browser-keychain-adapter.ts
@@ -1,5 +1,6 @@
 import type { AiProvider } from "@/stores/chat-store";
 import {
+	dropUnreadableSecret,
 	getSecret,
 	hasSecret,
 	importLegacySecret,
@@ -83,18 +84,27 @@ function removeLegacyKey(provider: AiProvider): LegacyErasure {
  * a credential the user revoked cannot come back on the next read. A settled slot is still
  * erased on sight — the browser that refused the removal may since have started allowing it,
  * and this is the only path a user who revoked a key and then left the provider alone will
- * ever run again. Discarding rather than importing is the right reading of the marker,
- * because a user delete is the only thing that sets it.
+ * ever run again. Discarding rather than importing is the right reading of the marker: it
+ * means this vault destroyed the record that outranked the slot, whether because the user
+ * deleted it or because it was damaged beyond reading, and in both cases the slot holds a
+ * value the vault has already superseded.
  *
  * Both guards are evaluated inside {@link importLegacySecret}'s own transaction rather than
  * here, because a check in this function and a write in another transaction can straddle a
  * concurrent delete in a second tab.
  *
- * The erase happens only after the encrypted write has committed — {@link importLegacySecret}
- * resolves at transaction commit, not at request success — so a failure part-way through
- * leaves the user's key intact rather than destroying it. If the vault is unavailable the
- * error propagates: callers must not fall back to reading clear text, because that would
- * quietly re-establish the storage posture #133 removed.
+ * The erase happens only after {@link importLegacySecret} has committed — it resolves at
+ * transaction commit, not at request success — so a failure part-way through leaves the
+ * user's key intact rather than destroying it. If the vault is unavailable the error
+ * propagates: callers must not fall back to reading clear text, because that would quietly
+ * re-establish the storage posture #133 removed.
+ *
+ * When the import declines because a secret is already stored, the slot is erased without
+ * that secret having been read. A stored record that turns out to be undecryptable therefore
+ * costs the user their clear-text copy too. Reaching that needs a damaged record and a slot
+ * that survived an earlier erase — which means a browser that was refusing removal and has
+ * since stopped — so it is left as a known narrow window rather than paying a decrypt on
+ * every migration.
  *
  * A slot that refuses to be erased here is not reported. Only `deleteKey` makes a claim about
  * a credential being gone, so only it must fail when one survives; a read reporting an error
@@ -183,7 +193,9 @@ export class BrowserKeychainAdapter implements KeychainAdapter {
 					// Marked as well as deleted: this destroys the record that outranks the
 					// clear-text slot, so without the marker a slot the browser refused to erase
 					// would be re-imported on the next read — reinstating a key the user replaced.
-					await retireAndDeleteSecret(provider);
+					// Applies only if the damaged record is still the stored one, so a key saved
+					// from another tab in the meantime is not collateral.
+					await dropUnreadableSecret(provider, error);
 					return null;
 				}
 				// A `vault-corrupt` or `unavailable` fault affects every provider and re-entering

--- a/src/lib/adapters/browser-keychain-adapter.ts
+++ b/src/lib/adapters/browser-keychain-adapter.ts
@@ -1,37 +1,91 @@
 import type { AiProvider } from "@/stores/chat-store";
+import { deleteSecret, getSecret, hasSecret, KeyVaultError, putSecret } from "./browser-key-vault";
 import type { KeychainAdapter } from "./keychain-adapter";
 
-const KEY_PREFIX = "tf-api-key-";
+/**
+ * Prefix of the clear-text `localStorage` slot this adapter used before #133. Retained only
+ * so an existing key can be migrated into the encrypted vault and then erased; nothing is
+ * ever written back under it.
+ */
+const LEGACY_KEY_PREFIX = "tf-api-key-";
 
-function storageKey(provider: AiProvider): string {
-	return `${KEY_PREFIX}${provider}`;
+function legacyStorageKey(provider: AiProvider): string {
+	return `${LEGACY_KEY_PREFIX}${provider}`;
+}
+
+/** Read the pre-#133 clear-text slot, tolerating a browser that blocks `localStorage`. */
+function readLegacyKey(provider: AiProvider): string | null {
+	try {
+		return localStorage.getItem(legacyStorageKey(provider));
+	} catch {
+		return null;
+	}
+}
+
+function removeLegacyKey(provider: AiProvider): void {
+	try {
+		localStorage.removeItem(legacyStorageKey(provider));
+	} catch {
+		// A browser that refuses the removal leaves the stale slot behind. The vault is
+		// already authoritative at this point, so this cannot resurrect the old value.
+	}
 }
 
 /**
- * Browser keychain adapter using localStorage.
- * Less secure than encrypted storage — noted in the UI when running in browser.
+ * Move a pre-#133 clear-text key into the encrypted vault, then erase the clear-text slot.
  *
- * {@link BrowserKeychainAdapter.getKey} is deliberately not part of
- * `KeychainAdapter`: in the browser there is no process that can hold the key on
- * the user's behalf, so the transport has to read it back to build the request
- * headers, and that capability must not be reachable through the shared
- * interface a desktop caller also sees.
+ * The erase happens only after the encrypted write resolves, so a failure part-way through
+ * leaves the user's key intact rather than destroying it. If the vault is unavailable the
+ * error propagates: callers must not fall back to reading clear text, because that would
+ * quietly re-establish the storage posture #133 removed.
+ */
+async function migrateLegacyKey(provider: AiProvider): Promise<void> {
+	const legacy = readLegacyKey(provider);
+	if (legacy === null) return;
+	await putSecret(provider, legacy);
+	removeLegacyKey(provider);
+}
+
+/**
+ * Browser keychain adapter backed by the encrypted {@link ./browser-key-vault | key vault}.
+ *
+ * Keys are stored as AES-GCM ciphertext under a non-extractable wrapping key held in
+ * IndexedDB, never as clear text. When the vault cannot be opened the adapter fails closed
+ * and surfaces a {@link KeyVaultError}; it never degrades to plain `localStorage`.
+ *
+ * {@link BrowserKeychainAdapter.getKey} is deliberately not part of `KeychainAdapter`: in
+ * the browser there is no process that can hold the key on the user's behalf, so the
+ * transport has to read it back to build the request headers, and that capability must not
+ * be reachable through the shared interface a desktop caller also sees.
  */
 export class BrowserKeychainAdapter implements KeychainAdapter {
 	async setKey(provider: AiProvider, key: string): Promise<void> {
-		localStorage.setItem(storageKey(provider), key);
+		await putSecret(provider, key);
+		// A stored key supersedes any pre-#133 clear-text value for the same provider.
+		removeLegacyKey(provider);
 	}
 
 	async hasKey(provider: AiProvider): Promise<boolean> {
-		return localStorage.getItem(storageKey(provider)) !== null;
+		await migrateLegacyKey(provider);
+		return hasSecret(provider);
 	}
 
 	/** Browser-only: read a stored key back so the transport can sign a request. */
 	async getKey(provider: AiProvider): Promise<string | null> {
-		return localStorage.getItem(storageKey(provider));
+		await migrateLegacyKey(provider);
+		try {
+			return await getSecret(provider);
+		} catch (error) {
+			// An undecryptable record is reported as "no key configured" so the caller shows
+			// the normal unconfigured path and the user can simply re-enter the key. Any other
+			// failure is a real fault and must not be swallowed.
+			if (error instanceof KeyVaultError && error.reason === "corrupt") return null;
+			throw error;
+		}
 	}
 
 	async deleteKey(provider: AiProvider): Promise<void> {
-		localStorage.removeItem(storageKey(provider));
+		removeLegacyKey(provider);
+		await deleteSecret(provider);
 	}
 }

--- a/src/lib/adapters/browser-keychain-adapter.ts
+++ b/src/lib/adapters/browser-keychain-adapter.ts
@@ -5,6 +5,7 @@ import {
 	hasSecret,
 	importLegacySecret,
 	KeyVaultError,
+	markSupersededSlot,
 	putSecret,
 	retireAndDeleteSecret,
 } from "./browser-key-vault";
@@ -84,9 +85,14 @@ function removeLegacyKey(provider: AiProvider): LegacyErasure {
  * a credential the user revoked cannot come back on the next read. A settled slot is still
  * erased on sight — the browser that refused the removal may since have started allowing it,
  * and this is the only path a user who revoked a key and then left the provider alone will
- * ever run again. Discarding rather than importing is the right reading of the marker: it is
- * set when the user deletes a credential and when a damaged record is dropped, and in both
- * cases the slot holds a value this vault has already settled.
+ * ever run again.
+ *
+ * A marker is set for three different reasons and they are not interchangeable. Only a
+ * revocation is the user throwing a credential away, so only a revocation is answered while
+ * the vault is too damaged to decrypt anything; a slot superseded by a later save, or settled
+ * because a record could not be read, waits for a readable vault instead of being erased on
+ * the strength of a copy that may be the last one. On a healthy vault all three discard the
+ * slot rather than importing it.
  *
  * Both guards are evaluated inside {@link importLegacySecret}'s own transaction rather than
  * here, because a check in this function and a write in another transaction can straddle a
@@ -166,7 +172,13 @@ export class BrowserKeychainAdapter implements KeychainAdapter {
 			// succeeded, and reporting an error would tell the user the opposite. It can no
 			// longer override the vault, and `deleteKey` is where a surviving clear-text
 			// credential becomes a claim that must not be made.
-			removeLegacyKey(provider);
+			if (removeLegacyKey(provider) === "erased") return;
+			// The slot survived, so the stored record is the only thing outranking it — and
+			// that record does not survive the vault being restarted after its wrapping key is
+			// lost. Settling the slot now keeps the replaced credential from coming back once
+			// the record is gone. Best effort: the save has already committed, and failing it
+			// here would report the opposite of what happened.
+			await markSupersededSlot(provider).catch(() => undefined);
 		});
 	}
 

--- a/src/lib/adapters/browser-keychain-adapter.ts
+++ b/src/lib/adapters/browser-keychain-adapter.ts
@@ -86,12 +86,11 @@ function removeLegacyKey(provider: AiProvider): LegacyErasure {
  * and this is the only path a user who revoked a key and then left the provider alone will
  * ever run again.
  *
- * A marker records why the slot was settled, and one reason is not like the others. Only a
+ * A marker records that the slot was settled, and one reason is not like the others. Only a
  * revocation is the user throwing a credential away, so only a revocation is answered while
  * the vault is too damaged to decrypt anything; a slot superseded by a later save, or settled
  * because a record could not be read, waits for a readable vault instead of being erased on
- * the strength of a copy that may be the last one. Those two are recorded apart for
- * diagnosis and take the same path as each other. On a healthy vault every reason discards
+ * the strength of a copy that may be the last one. On a healthy vault either reason discards
  * the slot rather than importing it.
  *
  * Both guards are evaluated inside {@link importLegacySecret}'s own transaction rather than

--- a/src/lib/adapters/browser-keychain-adapter.ts
+++ b/src/lib/adapters/browser-keychain-adapter.ts
@@ -34,16 +34,37 @@ function removeLegacyKey(provider: AiProvider): void {
 /**
  * Move a pre-#133 clear-text key into the encrypted vault, then erase the clear-text slot.
  *
- * The erase happens only after the encrypted write resolves, so a failure part-way through
- * leaves the user's key intact rather than destroying it. If the vault is unavailable the
- * error propagates: callers must not fall back to reading clear text, because that would
- * quietly re-establish the storage posture #133 removed.
+ * The erase happens only after the encrypted write has committed — {@link putSecret} resolves
+ * at transaction commit, not at request success — so a failure part-way through leaves the
+ * user's key intact rather than destroying it. If the vault is unavailable the error
+ * propagates: callers must not fall back to reading clear text, because that would quietly
+ * re-establish the storage posture #133 removed.
  */
 async function migrateLegacyKey(provider: AiProvider): Promise<void> {
 	const legacy = readLegacyKey(provider);
 	if (legacy === null) return;
 	await putSecret(provider, legacy);
 	removeLegacyKey(provider);
+}
+
+/**
+ * Per-provider operation chains, so this tab's keychain calls never interleave.
+ *
+ * Every public method is a read-modify-write across two stores, so an unordered `getKey` and
+ * `deleteKey` can interleave such that the migration re-inserts the key the user just
+ * deleted. Serializing per provider removes that window. Cross-tab races are out of scope
+ * here; IndexedDB's own transaction serialization is what keeps the vault itself consistent.
+ */
+const providerOperations = new Map<AiProvider, Promise<unknown>>();
+
+function withProviderLock<T>(provider: AiProvider, operation: () => Promise<T>): Promise<T> {
+	const pending = (providerOperations.get(provider) ?? Promise.resolve()).then(operation);
+	// The stored link never rejects, so one failed operation cannot poison the queue.
+	providerOperations.set(
+		provider,
+		pending.catch(() => undefined),
+	);
+	return pending;
 }
 
 /**
@@ -60,32 +81,46 @@ async function migrateLegacyKey(provider: AiProvider): Promise<void> {
  */
 export class BrowserKeychainAdapter implements KeychainAdapter {
 	async setKey(provider: AiProvider, key: string): Promise<void> {
-		await putSecret(provider, key);
-		// A stored key supersedes any pre-#133 clear-text value for the same provider.
-		removeLegacyKey(provider);
+		await withProviderLock(provider, async () => {
+			await putSecret(provider, key);
+			// A stored key supersedes any pre-#133 clear-text value for the same provider.
+			removeLegacyKey(provider);
+		});
 	}
 
 	async hasKey(provider: AiProvider): Promise<boolean> {
-		await migrateLegacyKey(provider);
-		return hasSecret(provider);
+		return withProviderLock(provider, async () => {
+			await migrateLegacyKey(provider);
+			return hasSecret(provider);
+		});
 	}
 
 	/** Browser-only: read a stored key back so the transport can sign a request. */
 	async getKey(provider: AiProvider): Promise<string | null> {
-		await migrateLegacyKey(provider);
-		try {
-			return await getSecret(provider);
-		} catch (error) {
-			// An undecryptable record is reported as "no key configured" so the caller shows
-			// the normal unconfigured path and the user can simply re-enter the key. Any other
-			// failure is a real fault and must not be swallowed.
-			if (error instanceof KeyVaultError && error.reason === "corrupt") return null;
-			throw error;
-		}
+		return withProviderLock(provider, async () => {
+			await migrateLegacyKey(provider);
+			try {
+				return await getSecret(provider);
+			} catch (error) {
+				if (error instanceof KeyVaultError && error.reason === "corrupt") {
+					// This provider's record is unreadable, so it is worth nothing: drop it and
+					// report the provider as unconfigured. Without the delete, `hasKey` would keep
+					// counting the record and the settings panel would show the provider as
+					// configured while every request failed for want of a key.
+					await deleteSecret(provider);
+					return null;
+				}
+				// A `vault-corrupt` or `unavailable` fault affects every provider and re-entering
+				// a key cannot fix it, so it must reach the user instead of reading as "no key".
+				throw error;
+			}
+		});
 	}
 
 	async deleteKey(provider: AiProvider): Promise<void> {
-		removeLegacyKey(provider);
-		await deleteSecret(provider);
+		await withProviderLock(provider, async () => {
+			removeLegacyKey(provider);
+			await deleteSecret(provider);
+		});
 	}
 }

--- a/src/lib/adapters/browser-keychain-adapter.ts
+++ b/src/lib/adapters/browser-keychain-adapter.ts
@@ -1,5 +1,13 @@
 import type { AiProvider } from "@/stores/chat-store";
-import { deleteSecret, getSecret, hasSecret, KeyVaultError, putSecret } from "./browser-key-vault";
+import {
+	deleteSecret,
+	getSecret,
+	hasSecret,
+	isLegacySlotRetired,
+	KeyVaultError,
+	putSecret,
+	retireLegacySlot,
+} from "./browser-key-vault";
 import type { KeychainAdapter } from "./keychain-adapter";
 
 /**
@@ -13,38 +21,67 @@ function legacyStorageKey(provider: AiProvider): string {
 	return `${LEGACY_KEY_PREFIX}${provider}`;
 }
 
-/** Read the pre-#133 clear-text slot, tolerating a browser that blocks `localStorage`. */
-function readLegacyKey(provider: AiProvider): string | null {
+/**
+ * What the pre-#133 clear-text slot currently holds.
+ *
+ * `absent` and `unreadable` are kept apart deliberately. A browser that blocks site data
+ * throws on read while the value stays on disk, so collapsing the two — as this did before —
+ * lets the adapter report a live clear-text credential as erased.
+ */
+type LegacySlot =
+	| { readonly state: "present"; readonly value: string }
+	| { readonly state: "absent" }
+	| { readonly state: "unreadable" };
+
+function readLegacySlot(provider: AiProvider): LegacySlot {
 	try {
-		return localStorage.getItem(legacyStorageKey(provider));
+		const value = localStorage.getItem(legacyStorageKey(provider));
+		return value === null ? { state: "absent" } : { state: "present", value };
 	} catch {
-		return null;
+		return { state: "unreadable" };
 	}
 }
+
+/** The outcome of trying to erase the clear-text slot, as far as it can be established. */
+type LegacyErasure =
+	/** Confirmed gone. */
+	| "erased"
+	/** Still readable after the attempt: a live credential. */
+	| "retained"
+	/** Storage would not answer, so absence cannot be claimed either way. */
+	| "unverified";
 
 /**
  * Erase the pre-#133 clear-text slot, reporting whether it is actually gone.
  *
  * A browser can refuse the removal (storage policy, an extension shim, partitioned storage
  * quirks) while still serving reads, so the caller has to know: a surviving clear-text slot
- * is a live credential, and the migration below will read it again.
+ * is a live credential. The read-back, not the `removeItem` call, is what decides the answer.
  */
-function removeLegacyKey(provider: AiProvider): boolean {
+function removeLegacyKey(provider: AiProvider): LegacyErasure {
+	if (readLegacySlot(provider).state === "absent") return "erased";
 	try {
 		localStorage.removeItem(legacyStorageKey(provider));
 	} catch {
 		// Fall through to the read-back, which is what actually decides the outcome.
 	}
-	return readLegacyKey(provider) === null;
+	const after = readLegacySlot(provider);
+	if (after.state === "absent") return "erased";
+	return after.state === "present" ? "retained" : "unverified";
 }
 
 /**
  * Move a pre-#133 clear-text key into the encrypted vault, then erase the clear-text slot.
  *
  * The vault outranks the legacy slot. Migrating unconditionally would let a slot that could
- * not be erased overwrite the vault on every subsequent read — silently reverting a key the
- * user had just replaced, and resurrecting one they had just deleted — so a provider that
- * already has a stored secret is never re-migrated, only cleaned up.
+ * not be erased overwrite the vault on every subsequent read, silently reverting a key the
+ * user had just replaced, so a provider that already has a stored secret is never
+ * re-migrated, only cleaned up.
+ *
+ * That guard alone does not cover deletion, because after a delete there is no stored secret
+ * to outrank the slot. {@link retireLegacySlot} closes that: once the slot has been settled —
+ * erased during migration, or dismissed by {@link BrowserKeychainAdapter.deleteKey} — it is
+ * never imported again, so a credential the user revoked cannot come back on the next read.
  *
  * The erase happens only after the encrypted write has committed — {@link putSecret} resolves
  * at transaction commit, not at request success — so a failure part-way through leaves the
@@ -53,12 +90,17 @@ function removeLegacyKey(provider: AiProvider): boolean {
  * re-establish the storage posture #133 removed.
  */
 async function migrateLegacyKey(provider: AiProvider): Promise<void> {
-	const legacy = readLegacyKey(provider);
-	if (legacy === null) return;
+	const slot = readLegacySlot(provider);
+	// Checked before the vault is consulted, so the common case — no legacy slot, which is
+	// every profile created after #133 — costs no extra transaction.
+	if (slot.state !== "present") return;
+	if (await isLegacySlotRetired(provider)) return;
 	if (!(await hasSecret(provider))) {
-		await putSecret(provider, legacy);
+		await putSecret(provider, slot.value);
 	}
-	removeLegacyKey(provider);
+	if (removeLegacyKey(provider) === "erased") {
+		await retireLegacySlot(provider);
+	}
 }
 
 /**
@@ -102,7 +144,9 @@ export class BrowserKeychainAdapter implements KeychainAdapter {
 			// succeeded, and reporting an error would tell the user the opposite. It can no
 			// longer override the vault, and `deleteKey` is where a surviving clear-text
 			// credential becomes a claim that must not be made.
-			removeLegacyKey(provider);
+			if (removeLegacyKey(provider) === "erased") {
+				await retireLegacySlot(provider);
+			}
 		});
 	}
 
@@ -137,15 +181,22 @@ export class BrowserKeychainAdapter implements KeychainAdapter {
 
 	async deleteKey(provider: AiProvider): Promise<void> {
 		await withProviderLock(provider, async () => {
-			const legacyErased = removeLegacyKey(provider);
+			const erasure = removeLegacyKey(provider);
 			await deleteSecret(provider);
-			if (!legacyErased) {
-				// The encrypted copy is gone but a clear-text one survived, so the credential
-				// is still usable from this browser. Reporting success here would tell a user
-				// who is removing a possibly-compromised key that it is gone when it is not.
+			// The user asked for this credential to be gone. Even when the clear-text slot
+			// survives, it must never be imported again — otherwise the next read would
+			// re-encrypt the revoked key into the vault and the app would quietly resume
+			// signing provider requests with it.
+			await retireLegacySlot(provider);
+			if (erasure !== "erased") {
+				// The encrypted copy is gone but a clear-text one may still be readable from
+				// this browser. Reporting success would tell a user who is removing a
+				// possibly-compromised key that it is gone when it is not.
 				throw new KeyVaultError(
 					"legacy-retained",
-					"The API key was removed from encrypted storage, but this browser would not delete an older clear-text copy. Clear this site's browser data to remove it.",
+					erasure === "retained"
+						? "The API key was removed from encrypted storage, but this browser would not delete an older clear-text copy. Clear this site's browser data to remove it."
+						: "The API key was removed from encrypted storage, but this browser blocked the check for an older clear-text copy. Clear this site's browser data to be sure it is gone.",
 				);
 			}
 		});

--- a/src/lib/adapters/browser-keychain-adapter.ts
+++ b/src/lib/adapters/browser-keychain-adapter.ts
@@ -1,12 +1,11 @@
 import type { AiProvider } from "@/stores/chat-store";
 import {
-	deleteSecret,
 	getSecret,
 	hasSecret,
-	isLegacySlotRetired,
+	importLegacySecret,
 	KeyVaultError,
 	putSecret,
-	retireLegacySlot,
+	retireAndDeleteSecret,
 } from "./browser-key-vault";
 import type { KeychainAdapter } from "./keychain-adapter";
 
@@ -79,7 +78,7 @@ function removeLegacyKey(provider: AiProvider): LegacyErasure {
  * re-migrated, only cleaned up.
  *
  * That guard alone does not cover deletion, because after a delete there is no stored secret
- * to outrank the slot. {@link retireLegacySlot} closes that: once
+ * to outrank the slot. The retirement marker closes that: once
  * {@link BrowserKeychainAdapter.deleteKey} has settled a slot it is never imported again, so
  * a credential the user revoked cannot come back on the next read. A settled slot is still
  * erased on sight — the browser that refused the removal may since have started allowing it,
@@ -87,27 +86,31 @@ function removeLegacyKey(provider: AiProvider): LegacyErasure {
  * ever run again. Discarding rather than importing is the right reading of the marker,
  * because a user delete is the only thing that sets it.
  *
- * The erase happens only after the encrypted write has committed — {@link putSecret} resolves
- * at transaction commit, not at request success — so a failure part-way through leaves the
- * user's key intact rather than destroying it. If the vault is unavailable the error
- * propagates: callers must not fall back to reading clear text, because that would quietly
- * re-establish the storage posture #133 removed.
+ * Both guards are evaluated inside {@link importLegacySecret}'s own transaction rather than
+ * here, because a check in this function and a write in another transaction can straddle a
+ * concurrent delete in a second tab.
+ *
+ * The erase happens only after the encrypted write has committed — {@link importLegacySecret}
+ * resolves at transaction commit, not at request success — so a failure part-way through
+ * leaves the user's key intact rather than destroying it. If the vault is unavailable the
+ * error propagates: callers must not fall back to reading clear text, because that would
+ * quietly re-establish the storage posture #133 removed.
+ *
+ * A slot that refuses to be erased here is not reported. Only `deleteKey` makes a claim about
+ * a credential being gone, so only it must fail when one survives; a read reporting an error
+ * would break every AI request over a residue the user cannot act on from that surface.
+ * Surfacing it persistently in settings is #233.
  */
 async function migrateLegacyKey(provider: AiProvider): Promise<void> {
 	const slot = readLegacySlot(provider);
 	// Checked before the vault is consulted, so the common case — no legacy slot, which is
 	// every profile created after #133 — costs no extra transaction.
 	if (slot.state !== "present") return;
-	if (await isLegacySlotRetired(provider)) {
-		removeLegacyKey(provider);
-		return;
-	}
-	if (!(await hasSecret(provider))) {
-		await putSecret(provider, slot.value);
-	}
+	await importLegacySecret(provider, slot.value);
 	// No marker is written here. Once the slot is erased it reads as `absent` and the guard
-	// above short-circuits before the vault is touched, so a marker would only add a write to
-	// every migration. `deleteKey` is the one caller whose marker is load-bearing.
+	// above short-circuits before the vault is touched; no in-app path re-creates the slot, so
+	// a marker would only add a write to every migration. `deleteKey` is the one caller whose
+	// marker is load-bearing.
 	removeLegacyKey(provider);
 }
 
@@ -116,8 +119,10 @@ async function migrateLegacyKey(provider: AiProvider): Promise<void> {
  *
  * Every public method is a read-modify-write across two stores, so an unordered `getKey` and
  * `deleteKey` can interleave such that the migration re-inserts the key the user just
- * deleted. Serializing per provider removes that window. Cross-tab races are out of scope
- * here; IndexedDB's own transaction serialization is what keeps the vault itself consistent.
+ * deleted. Serializing per provider removes that window for this tab. It cannot order
+ * anything across tabs, because the map is module-scoped — that is why the vault's own
+ * check-and-act operations each run in a single IndexedDB transaction, which the browser does
+ * serialize across connections.
  */
 const providerOperations = new Map<AiProvider, Promise<unknown>>();
 
@@ -175,7 +180,10 @@ export class BrowserKeychainAdapter implements KeychainAdapter {
 					// report the provider as unconfigured. Without the delete, `hasKey` would keep
 					// counting the record and the settings panel would show the provider as
 					// configured while every request failed for want of a key.
-					await deleteSecret(provider);
+					// Marked as well as deleted: this destroys the record that outranks the
+					// clear-text slot, so without the marker a slot the browser refused to erase
+					// would be re-imported on the next read — reinstating a key the user replaced.
+					await retireAndDeleteSecret(provider);
 					return null;
 				}
 				// A `vault-corrupt` or `unavailable` fault affects every provider and re-entering
@@ -188,15 +196,13 @@ export class BrowserKeychainAdapter implements KeychainAdapter {
 	async deleteKey(provider: AiProvider): Promise<void> {
 		await withProviderLock(provider, async () => {
 			const erasure = removeLegacyKey(provider);
-			// Written before the record is deleted, not after. The marker records the user's
-			// intent to be rid of this credential, so establishing it first is what makes the
-			// delete safe: if this write fails, nothing has been destroyed, the stored secret
-			// still outranks the clear-text slot, and the user gets an honest failure. Written
-			// afterwards it would leave a window — a failed write, or another tab reading
-			// between the two steps — in which there is no stored secret to outrank the slot
-			// and no marker to stop it, which is exactly the resurrection this guards against.
-			await retireLegacySlot(provider);
-			await deleteSecret(provider);
+			// Marker and delete commit together or not at all. Applied separately, the moment
+			// between them has no stored secret to outrank the clear-text slot and no marker to
+			// stop it, and the credential the user just revoked comes back on the next read.
+			// If the whole transaction fails, the stored secret survives and the user gets an
+			// honest failure. The clear-text slot has already been erased by then, which is the
+			// safe direction for a delete.
+			await retireAndDeleteSecret(provider);
 			if (erasure !== "erased") {
 				// The encrypted copy is gone but a clear-text one may still be readable from
 				// this browser. Reporting success would tell a user who is removing a

--- a/src/lib/adapters/browser-keychain-adapter.ts
+++ b/src/lib/adapters/browser-keychain-adapter.ts
@@ -8,7 +8,7 @@ import {
 	putSecret,
 	retireAndDeleteSecret,
 } from "./browser-key-vault";
-import type { KeychainAdapter } from "./keychain-adapter";
+import { type KeychainAdapter, LEGACY_RETAINED } from "./keychain-adapter";
 
 /**
  * Prefix of the clear-text `localStorage` slot this adapter used before #133. Retained only
@@ -232,7 +232,7 @@ export class BrowserKeychainAdapter implements KeychainAdapter {
 				// this browser. Reporting success would tell a user who is removing a
 				// possibly-compromised key that it is gone when it is not.
 				throw new KeyVaultError(
-					"legacy-retained",
+					LEGACY_RETAINED,
 					erasure === "retained"
 						? "The API key was removed from encrypted storage, but this browser would not delete an older clear-text copy. Clear this site's browser data to remove it."
 						: "The API key was removed from encrypted storage, but this browser blocked the check for an older clear-text copy. Clear this site's browser data to be sure it is gone.",

--- a/src/lib/adapters/browser-keychain-adapter.ts
+++ b/src/lib/adapters/browser-keychain-adapter.ts
@@ -84,10 +84,9 @@ function removeLegacyKey(provider: AiProvider): LegacyErasure {
  * a credential the user revoked cannot come back on the next read. A settled slot is still
  * erased on sight — the browser that refused the removal may since have started allowing it,
  * and this is the only path a user who revoked a key and then left the provider alone will
- * ever run again. Discarding rather than importing is the right reading of the marker: it
- * means this vault destroyed the record that outranked the slot, whether because the user
- * deleted it or because it was damaged beyond reading, and in both cases the slot holds a
- * value the vault has already superseded.
+ * ever run again. Discarding rather than importing is the right reading of the marker: it is
+ * set when the user deletes a credential and when a damaged record is dropped, and in both
+ * cases the slot holds a value this vault has already settled.
  *
  * Both guards are evaluated inside {@link importLegacySecret}'s own transaction rather than
  * here, because a check in this function and a write in another transaction can straddle a
@@ -103,8 +102,8 @@ function removeLegacyKey(provider: AiProvider): LegacyErasure {
  * that secret having been read. A stored record that turns out to be undecryptable therefore
  * costs the user their clear-text copy too. Reaching that needs a damaged record and a slot
  * that survived an earlier erase — which means a browser that was refusing removal and has
- * since stopped — so it is left as a known narrow window rather than paying a decrypt on
- * every migration.
+ * since stopped — so it is left as a known narrow window. A vault that cannot produce a
+ * wrapping key at all is a different case, and is refused rather than declined.
  *
  * A slot that refuses to be erased here is not reported. Only `deleteKey` makes a claim about
  * a credential being gone, so only it must fail when one survives; a read reporting an error

--- a/src/lib/adapters/browser-keychain-adapter.ts
+++ b/src/lib/adapters/browser-keychain-adapter.ts
@@ -79,9 +79,13 @@ function removeLegacyKey(provider: AiProvider): LegacyErasure {
  * re-migrated, only cleaned up.
  *
  * That guard alone does not cover deletion, because after a delete there is no stored secret
- * to outrank the slot. {@link retireLegacySlot} closes that: once the slot has been settled —
- * erased during migration, or dismissed by {@link BrowserKeychainAdapter.deleteKey} — it is
- * never imported again, so a credential the user revoked cannot come back on the next read.
+ * to outrank the slot. {@link retireLegacySlot} closes that: once
+ * {@link BrowserKeychainAdapter.deleteKey} has settled a slot it is never imported again, so
+ * a credential the user revoked cannot come back on the next read. A settled slot is still
+ * erased on sight — the browser that refused the removal may since have started allowing it,
+ * and this is the only path a user who revoked a key and then left the provider alone will
+ * ever run again. Discarding rather than importing is the right reading of the marker,
+ * because a user delete is the only thing that sets it.
  *
  * The erase happens only after the encrypted write has committed — {@link putSecret} resolves
  * at transaction commit, not at request success — so a failure part-way through leaves the
@@ -94,13 +98,17 @@ async function migrateLegacyKey(provider: AiProvider): Promise<void> {
 	// Checked before the vault is consulted, so the common case — no legacy slot, which is
 	// every profile created after #133 — costs no extra transaction.
 	if (slot.state !== "present") return;
-	if (await isLegacySlotRetired(provider)) return;
+	if (await isLegacySlotRetired(provider)) {
+		removeLegacyKey(provider);
+		return;
+	}
 	if (!(await hasSecret(provider))) {
 		await putSecret(provider, slot.value);
 	}
-	if (removeLegacyKey(provider) === "erased") {
-		await retireLegacySlot(provider);
-	}
+	// No marker is written here. Once the slot is erased it reads as `absent` and the guard
+	// above short-circuits before the vault is touched, so a marker would only add a write to
+	// every migration. `deleteKey` is the one caller whose marker is load-bearing.
+	removeLegacyKey(provider);
 }
 
 /**
@@ -144,9 +152,7 @@ export class BrowserKeychainAdapter implements KeychainAdapter {
 			// succeeded, and reporting an error would tell the user the opposite. It can no
 			// longer override the vault, and `deleteKey` is where a surviving clear-text
 			// credential becomes a claim that must not be made.
-			if (removeLegacyKey(provider) === "erased") {
-				await retireLegacySlot(provider);
-			}
+			removeLegacyKey(provider);
 		});
 	}
 
@@ -182,12 +188,15 @@ export class BrowserKeychainAdapter implements KeychainAdapter {
 	async deleteKey(provider: AiProvider): Promise<void> {
 		await withProviderLock(provider, async () => {
 			const erasure = removeLegacyKey(provider);
-			await deleteSecret(provider);
-			// The user asked for this credential to be gone. Even when the clear-text slot
-			// survives, it must never be imported again — otherwise the next read would
-			// re-encrypt the revoked key into the vault and the app would quietly resume
-			// signing provider requests with it.
+			// Written before the record is deleted, not after. The marker records the user's
+			// intent to be rid of this credential, so establishing it first is what makes the
+			// delete safe: if this write fails, nothing has been destroyed, the stored secret
+			// still outranks the clear-text slot, and the user gets an honest failure. Written
+			// afterwards it would leave a window — a failed write, or another tab reading
+			// between the two steps — in which there is no stored secret to outrank the slot
+			// and no marker to stop it, which is exactly the resurrection this guards against.
 			await retireLegacySlot(provider);
+			await deleteSecret(provider);
 			if (erasure !== "erased") {
 				// The encrypted copy is gone but a clear-text one may still be readable from
 				// this browser. Reporting success would tell a user who is removing a

--- a/src/lib/adapters/browser-keychain-adapter.ts
+++ b/src/lib/adapters/browser-keychain-adapter.ts
@@ -5,7 +5,6 @@ import {
 	hasSecret,
 	importLegacySecret,
 	KeyVaultError,
-	markSupersededSlot,
 	putSecret,
 	retireAndDeleteSecret,
 } from "./browser-key-vault";
@@ -87,12 +86,13 @@ function removeLegacyKey(provider: AiProvider): LegacyErasure {
  * and this is the only path a user who revoked a key and then left the provider alone will
  * ever run again.
  *
- * A marker is set for three different reasons and they are not interchangeable. Only a
+ * A marker records why the slot was settled, and one reason is not like the others. Only a
  * revocation is the user throwing a credential away, so only a revocation is answered while
  * the vault is too damaged to decrypt anything; a slot superseded by a later save, or settled
  * because a record could not be read, waits for a readable vault instead of being erased on
- * the strength of a copy that may be the last one. On a healthy vault all three discard the
- * slot rather than importing it.
+ * the strength of a copy that may be the last one. Those two are recorded apart for
+ * diagnosis and take the same path as each other. On a healthy vault every reason discards
+ * the slot rather than importing it.
  *
  * Both guards are evaluated inside {@link importLegacySecret}'s own transaction rather than
  * here, because a check in this function and a write in another transaction can straddle a
@@ -166,19 +166,20 @@ function withProviderLock<T>(provider: AiProvider, operation: () => Promise<T>):
 export class BrowserKeychainAdapter implements KeychainAdapter {
 	async setKey(provider: AiProvider, key: string): Promise<void> {
 		await withProviderLock(provider, async () => {
-			await putSecret(provider, key);
-			// A stored key supersedes any pre-#133 clear-text value for the same provider.
-			// A slot that refuses to be erased is not failed here: the save genuinely
-			// succeeded, and reporting an error would tell the user the opposite. It can no
-			// longer override the vault, and `deleteKey` is where a surviving clear-text
-			// credential becomes a claim that must not be made.
-			if (removeLegacyKey(provider) === "erased") return;
-			// The slot survived, so the stored record is the only thing outranking it — and
-			// that record does not survive the vault being restarted after its wrapping key is
-			// lost. Settling the slot now keeps the replaced credential from coming back once
-			// the record is gone. Best effort: the save has already committed, and failing it
-			// here would report the opposite of what happened.
-			await markSupersededSlot(provider).catch(() => undefined);
+			// Read before the write, because the save itself has to carry the answer: a stored
+			// key supersedes any pre-#133 clear-text value for the same provider, and the record
+			// that expresses that ranking does not survive the vault being restarted after its
+			// wrapping key is lost. Recording it in the same transaction as the ciphertext is
+			// what keeps the replaced credential from coming back once the record is gone.
+			// `unreadable` is settled too: storage that will not answer may still be holding a
+			// slot, and a marker for a slot that does not exist is inert.
+			const slot = readLegacySlot(provider);
+			await putSecret(provider, key, slot.state === "absent" ? "leave-slot" : "supersede-slot");
+			// Attempted, but not reported. A slot that refuses to be erased does not fail the
+			// save: the save genuinely succeeded, it can no longer override the vault, and
+			// `deleteKey` is where a surviving clear-text credential becomes a claim that must
+			// not be made.
+			removeLegacyKey(provider);
 		});
 	}
 

--- a/src/lib/adapters/browser-keychain-adapter.ts
+++ b/src/lib/adapters/browser-keychain-adapter.ts
@@ -22,17 +22,29 @@ function readLegacyKey(provider: AiProvider): string | null {
 	}
 }
 
-function removeLegacyKey(provider: AiProvider): void {
+/**
+ * Erase the pre-#133 clear-text slot, reporting whether it is actually gone.
+ *
+ * A browser can refuse the removal (storage policy, an extension shim, partitioned storage
+ * quirks) while still serving reads, so the caller has to know: a surviving clear-text slot
+ * is a live credential, and the migration below will read it again.
+ */
+function removeLegacyKey(provider: AiProvider): boolean {
 	try {
 		localStorage.removeItem(legacyStorageKey(provider));
 	} catch {
-		// A browser that refuses the removal leaves the stale slot behind. The vault is
-		// already authoritative at this point, so this cannot resurrect the old value.
+		// Fall through to the read-back, which is what actually decides the outcome.
 	}
+	return readLegacyKey(provider) === null;
 }
 
 /**
  * Move a pre-#133 clear-text key into the encrypted vault, then erase the clear-text slot.
+ *
+ * The vault outranks the legacy slot. Migrating unconditionally would let a slot that could
+ * not be erased overwrite the vault on every subsequent read — silently reverting a key the
+ * user had just replaced, and resurrecting one they had just deleted — so a provider that
+ * already has a stored secret is never re-migrated, only cleaned up.
  *
  * The erase happens only after the encrypted write has committed — {@link putSecret} resolves
  * at transaction commit, not at request success — so a failure part-way through leaves the
@@ -43,7 +55,9 @@ function removeLegacyKey(provider: AiProvider): void {
 async function migrateLegacyKey(provider: AiProvider): Promise<void> {
 	const legacy = readLegacyKey(provider);
 	if (legacy === null) return;
-	await putSecret(provider, legacy);
+	if (!(await hasSecret(provider))) {
+		await putSecret(provider, legacy);
+	}
 	removeLegacyKey(provider);
 }
 
@@ -84,6 +98,10 @@ export class BrowserKeychainAdapter implements KeychainAdapter {
 		await withProviderLock(provider, async () => {
 			await putSecret(provider, key);
 			// A stored key supersedes any pre-#133 clear-text value for the same provider.
+			// A slot that refuses to be erased is not failed here: the save genuinely
+			// succeeded, and reporting an error would tell the user the opposite. It can no
+			// longer override the vault, and `deleteKey` is where a surviving clear-text
+			// credential becomes a claim that must not be made.
 			removeLegacyKey(provider);
 		});
 	}
@@ -119,8 +137,17 @@ export class BrowserKeychainAdapter implements KeychainAdapter {
 
 	async deleteKey(provider: AiProvider): Promise<void> {
 		await withProviderLock(provider, async () => {
-			removeLegacyKey(provider);
+			const legacyErased = removeLegacyKey(provider);
 			await deleteSecret(provider);
+			if (!legacyErased) {
+				// The encrypted copy is gone but a clear-text one survived, so the credential
+				// is still usable from this browser. Reporting success here would tell a user
+				// who is removing a possibly-compromised key that it is gone when it is not.
+				throw new KeyVaultError(
+					"legacy-retained",
+					"The API key was removed from encrypted storage, but this browser would not delete an older clear-text copy. Clear this site's browser data to remove it.",
+				);
+			}
 		});
 	}
 }

--- a/src/lib/adapters/browser-keychain-adapter.ts
+++ b/src/lib/adapters/browser-keychain-adapter.ts
@@ -86,7 +86,7 @@ function removeLegacyKey(provider: AiProvider): LegacyErasure {
  * and this is the only path a user who revoked a key and then left the provider alone will
  * ever run again.
  *
- * A marker records that the slot was settled, and one reason is not like the others. Only a
+ * A marker records that the slot was settled, and one reason is not like the other. Only a
  * revocation is the user throwing a credential away, so only a revocation is answered while
  * the vault is too damaged to decrypt anything; a slot superseded by a later save, or settled
  * because a record could not be read, waits for a readable vault instead of being erased on

--- a/src/lib/adapters/chat-adapter.ts
+++ b/src/lib/adapters/chat-adapter.ts
@@ -112,7 +112,7 @@ export interface ChatTransport {
  * It lives here rather than in either transport because the code is what
  * consumers branch on — a settings prompt is the only useful response, and a
  * retry never is — and the two platforms discover the same condition in
- * different places: the browser reads `localStorage` before fetching, while
+ * different places: the browser reads its encrypted vault before fetching, while
  * desktop learns it from the relay's refusal, since only Rust can see the
  * encrypted store.
  */

--- a/src/lib/adapters/chat-adapter.ts
+++ b/src/lib/adapters/chat-adapter.ts
@@ -80,9 +80,9 @@ export interface TransportCallbacks {
  * protocol — one shared decoder (`src/lib/ai/providers/sse.ts`) and one shared
  * mapper pair decode frames on both platforms. The single intentional difference
  * between them is where the API key lives and who performs the HTTPS request:
- * the browser transport reads the key from `localStorage` and fetches directly,
- * while the desktop transport hands the body to Rust, which holds the key and
- * owns the endpoint and headers.
+ * the browser transport decrypts the key from the local key vault and fetches
+ * directly, while the desktop transport hands the body to Rust, which holds the
+ * key and owns the endpoint and headers.
  */
 export interface ChatTransport {
 	/**

--- a/src/lib/adapters/get-chat-transport.test.ts
+++ b/src/lib/adapters/get-chat-transport.test.ts
@@ -8,7 +8,9 @@
  * `retry.ts`'s tests would not.
  */
 
+import { IDBFactory } from "fake-indexeddb";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "fake-indexeddb/auto";
 import { buildAnthropicRequestBody } from "@/lib/ai/providers/anthropic";
 import { ANTHROPIC_TEXT_STREAM } from "@/lib/ai/providers/test-fixtures/anthropic-fixtures";
 import { fakeErrorResponse, fakeStream } from "@/lib/ai/providers/test-fixtures/fake-stream";
@@ -38,17 +40,27 @@ function recordingCallbacks() {
 	} satisfies TransportCallbacks;
 }
 
+/**
+ * Reset the encrypted key vault. Since #133 browser keys live in IndexedDB, so a fresh
+ * factory — not `localStorage.clear()` — is what leaves no key stored.
+ */
+function resetKeyVault(): void {
+	globalThis.indexedDB = new IDBFactory();
+}
+
 beforeEach(async () => {
 	// The factory memoizes its transport in a module-level binding; reset the module
 	// registry so each test starts from a fresh, unwrapped-then-wrapped factory.
 	vi.resetModules();
 	vi.stubGlobal("fetch", vi.fn());
+	resetKeyVault();
 	await new BrowserKeychainAdapter().setKey("anthropic", "sk-ant-wiring-test");
 });
 
 afterEach(() => {
 	vi.unstubAllGlobals();
 	localStorage.clear();
+	resetKeyVault();
 });
 
 describe("getChatTransport", () => {

--- a/src/lib/adapters/get-chat-transport.test.ts
+++ b/src/lib/adapters/get-chat-transport.test.ts
@@ -8,8 +8,8 @@
  * `retry.ts`'s tests would not.
  */
 
-import { IDBFactory } from "fake-indexeddb";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetKeyVault } from "./test-fixtures/key-vault";
 import "fake-indexeddb/auto";
 import { buildAnthropicRequestBody } from "@/lib/ai/providers/anthropic";
 import { ANTHROPIC_TEXT_STREAM } from "@/lib/ai/providers/test-fixtures/anthropic-fixtures";
@@ -38,14 +38,6 @@ function recordingCallbacks() {
 		onTransportError: vi.fn(),
 		onClose: vi.fn(),
 	} satisfies TransportCallbacks;
-}
-
-/**
- * Reset the encrypted key vault. Since #133 browser keys live in IndexedDB, so a fresh
- * factory — not `localStorage.clear()` — is what leaves no key stored.
- */
-function resetKeyVault(): void {
-	globalThis.indexedDB = new IDBFactory();
 }
 
 beforeEach(async () => {

--- a/src/lib/adapters/keychain-adapter.test.ts
+++ b/src/lib/adapters/keychain-adapter.test.ts
@@ -42,6 +42,23 @@ describe("the shared keychain interface", () => {
 		expect(askForTheKey).toThrowError(TypeError);
 	});
 
+	it("keeps the retained-copy reason a literal type rather than a string", () => {
+		// `LEGACY_RETAINED` is inferred, and the inference is load-bearing: it is what
+		// keeps `KeyVaultErrorReason` a closed union. Annotate the constant `: string`
+		// and the union collapses, `new KeyVaultError("legacy-retaind", …)` compiles,
+		// and the settings panel silently stops recognising a removal that left a live
+		// clear-text key — with no diagnostic anywhere.
+		//
+		// `tsc --noEmit` fails with "unused '@ts-expect-error' directive" the moment
+		// that widening happens, because a `string` would accept this typo.
+		// @ts-expect-error the constant's type is the literal, not `string`.
+		const widened: typeof LEGACY_RETAINED = "legacy-retaind";
+
+		// The runtime half is what keeps `widened` a used binding, so the directive
+		// above stays attached to a real declaration rather than to dead code.
+		expect(widened).not.toBe(LEGACY_RETAINED);
+	});
+
 	it("does not carry a key-reading method anywhere on the desktop adapter", () => {
 		expect("getKey" in new TauriKeychainAdapter()).toBe(false);
 	});
@@ -61,23 +78,6 @@ describe("the browser keychain adapter", () => {
 
 		expect(await browser.getKey("openai")).toBe("sk-browser-test-key");
 		expect(await browser.hasKey("openai")).toBe(true);
-	});
-
-	it("keeps the retained-copy reason a literal type rather than a string", () => {
-		// `LEGACY_RETAINED` is inferred, and the inference is load-bearing: it is what
-		// keeps `KeyVaultErrorReason` a closed union. Annotate the constant `: string`
-		// and the union collapses, `new KeyVaultError("legacy-retaind", …)` compiles,
-		// and the settings panel silently stops recognising a removal that left a live
-		// clear-text key — with no diagnostic anywhere.
-		//
-		// `tsc --noEmit` fails with "unused '@ts-expect-error' directive" the moment
-		// that widening happens, because a `string` would accept this typo.
-		// @ts-expect-error the constant's type is the literal, not `string`.
-		const widened: typeof LEGACY_RETAINED = "legacy-retaind";
-
-		// And the directive is guarding a real value rather than a name that never
-		// resolves, which is what would make the assertion vacuous.
-		expect(widened).not.toBe(LEGACY_RETAINED);
 	});
 
 	it("reports a missing key as null rather than an error", async () => {

--- a/src/lib/adapters/keychain-adapter.test.ts
+++ b/src/lib/adapters/keychain-adapter.test.ts
@@ -10,20 +10,12 @@
  * `null`.
  */
 
-import { IDBFactory } from "fake-indexeddb";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resetKeyVault } from "./test-fixtures/key-vault";
 import "fake-indexeddb/auto";
 import { BrowserKeychainAdapter } from "./browser-keychain-adapter";
 import type { KeychainAdapter } from "./keychain-adapter";
 import { TauriKeychainAdapter } from "./tauri-keychain-adapter";
-
-/**
- * Reset the encrypted key vault. Since #133 browser keys live in IndexedDB, so a fresh
- * factory — not `localStorage.clear()` — is what leaves no key stored.
- */
-function resetKeyVault(): void {
-	globalThis.indexedDB = new IDBFactory();
-}
 
 beforeEach(() => {
 	resetKeyVault();

--- a/src/lib/adapters/keychain-adapter.test.ts
+++ b/src/lib/adapters/keychain-adapter.test.ts
@@ -10,13 +10,28 @@
  * `null`.
  */
 
-import { afterEach, describe, expect, it } from "vitest";
+import { IDBFactory } from "fake-indexeddb";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import "fake-indexeddb/auto";
 import { BrowserKeychainAdapter } from "./browser-keychain-adapter";
 import type { KeychainAdapter } from "./keychain-adapter";
 import { TauriKeychainAdapter } from "./tauri-keychain-adapter";
 
+/**
+ * Reset the encrypted key vault. Since #133 browser keys live in IndexedDB, so a fresh
+ * factory — not `localStorage.clear()` — is what leaves no key stored.
+ */
+function resetKeyVault(): void {
+	globalThis.indexedDB = new IDBFactory();
+}
+
+beforeEach(() => {
+	resetKeyVault();
+});
+
 afterEach(() => {
 	localStorage.clear();
+	resetKeyVault();
 });
 
 describe("the shared keychain interface", () => {

--- a/src/lib/adapters/keychain-adapter.test.ts
+++ b/src/lib/adapters/keychain-adapter.test.ts
@@ -14,7 +14,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { resetKeyVault } from "./test-fixtures/key-vault";
 import "fake-indexeddb/auto";
 import { BrowserKeychainAdapter } from "./browser-keychain-adapter";
-import type { KeychainAdapter } from "./keychain-adapter";
+import { type KeychainAdapter, LEGACY_RETAINED } from "./keychain-adapter";
 import { TauriKeychainAdapter } from "./tauri-keychain-adapter";
 
 beforeEach(() => {
@@ -61,6 +61,23 @@ describe("the browser keychain adapter", () => {
 
 		expect(await browser.getKey("openai")).toBe("sk-browser-test-key");
 		expect(await browser.hasKey("openai")).toBe(true);
+	});
+
+	it("keeps the retained-copy reason a literal type rather than a string", () => {
+		// `LEGACY_RETAINED` is inferred, and the inference is load-bearing: it is what
+		// keeps `KeyVaultErrorReason` a closed union. Annotate the constant `: string`
+		// and the union collapses, `new KeyVaultError("legacy-retaind", …)` compiles,
+		// and the settings panel silently stops recognising a removal that left a live
+		// clear-text key — with no diagnostic anywhere.
+		//
+		// `tsc --noEmit` fails with "unused '@ts-expect-error' directive" the moment
+		// that widening happens, because a `string` would accept this typo.
+		// @ts-expect-error the constant's type is the literal, not `string`.
+		const widened: typeof LEGACY_RETAINED = "legacy-retaind";
+
+		// And the directive is guarding a real value rather than a name that never
+		// resolves, which is what would make the assertion vacuous.
+		expect(widened).not.toBe(LEGACY_RETAINED);
 	});
 
 	it("reports a missing key as null rather than an error", async () => {

--- a/src/lib/adapters/keychain-adapter.ts
+++ b/src/lib/adapters/keychain-adapter.ts
@@ -23,3 +23,12 @@ export interface KeychainAdapter {
 	/** Delete an API key for a provider. */
 	deleteKey(provider: AiProvider): Promise<void>;
 }
+
+/**
+ * Reason code for a removal that succeeded but left a readable clear-text copy behind.
+ *
+ * Declared here rather than beside the browser vault that raises it because callers have to
+ * recognise it without importing IndexedDB code into the desktop bundle. Shared so renaming
+ * it cannot leave a caller silently matching a string nothing throws any more.
+ */
+export const LEGACY_RETAINED = "legacy-retained";

--- a/src/lib/adapters/keychain-adapter.ts
+++ b/src/lib/adapters/keychain-adapter.ts
@@ -27,8 +27,9 @@ export interface KeychainAdapter {
 /**
  * Reason code for a removal that succeeded but left a readable clear-text copy behind.
  *
- * Declared here rather than beside the browser vault that raises it because callers have to
- * recognise it without importing IndexedDB code into the desktop bundle. Shared so renaming
- * it cannot leave a caller silently matching a string nothing throws any more.
+ * Declared here rather than beside the browser keychain adapter that throws it, because
+ * callers have to recognise it without importing IndexedDB code into the desktop bundle.
+ * Shared so renaming it cannot leave a caller silently matching a string nothing throws any
+ * more.
  */
 export const LEGACY_RETAINED = "legacy-retained";

--- a/src/lib/adapters/keychain-adapter.ts
+++ b/src/lib/adapters/keychain-adapter.ts
@@ -4,13 +4,14 @@ import type { AiProvider } from "@/stores/chat-store";
  * Adapter interface for API key storage.
  *
  * Tauri implementation uses AES-256-GCM encrypted file storage via invoke().
- * Browser implementation uses localStorage (less secure, noted in UI).
+ * Browser implementation encrypts the key under a non-extractable Web Crypto key held in
+ * IndexedDB; see `./browser-key-vault.ts` for what that does and does not defend against.
  *
  * Reading a key back is deliberately absent from this interface. On desktop the
  * key never leaves Rust — it is used only inside `auth_headers`
  * (`src-tauri/src/ai/providers.rs`) and there is no `get_api_key` command to
- * fetch it — so `getKey` exists solely on `BrowserKeychainAdapter`, where
- * `localStorage` is the store and the browser transport is the one caller.
+ * fetch it — so `getKey` exists solely on `BrowserKeychainAdapter`, where the
+ * encrypted key vault is the store and the browser transport is the one caller.
  * Declaring it here would make asking for the desktop key compile, which is the
  * property this omission removes; see `./keychain-adapter.test.ts`.
  */

--- a/src/lib/adapters/test-fixtures/host-task.ts
+++ b/src/lib/adapters/test-fixtures/host-task.ts
@@ -1,0 +1,18 @@
+/**
+ * Yield one real host task.
+ *
+ * `MessageChannel` rather than `setTimeout` because the tests that need this have faked the
+ * timer functions, and a faked `setTimeout` never lets IndexedDB or the fetch transport make
+ * progress. `MessageChannel` is not faked by `vi.useFakeTimers`, so it still schedules a
+ * genuine macrotask.
+ */
+export function yieldHostTask(): Promise<void> {
+	return new Promise((resolve) => {
+		const channel = new MessageChannel();
+		channel.port1.onmessage = () => {
+			channel.port1.close();
+			resolve();
+		};
+		channel.port2.postMessage(null);
+	});
+}

--- a/src/lib/adapters/test-fixtures/key-vault.ts
+++ b/src/lib/adapters/test-fixtures/key-vault.ts
@@ -1,0 +1,16 @@
+/**
+ * Test-side control over the encrypted browser key vault (#133).
+ *
+ * Before #133 a browser key was a `localStorage` slot, so `localStorage.clear()` was enough
+ * to leave a test with no key stored. The key now lives in a dedicated IndexedDB database,
+ * which `localStorage.clear()` does not touch — a suite that still relies on it would carry
+ * a key between cases and quietly stop testing the unconfigured path. Replacing the factory
+ * is what actually empties the vault.
+ */
+
+import { IDBFactory } from "fake-indexeddb";
+
+/** Discard every stored key by giving the process a fresh, empty IndexedDB. */
+export function resetKeyVault(): void {
+	globalThis.indexedDB = new IDBFactory();
+}

--- a/src/lib/ai/protocol/client.test.ts
+++ b/src/lib/ai/protocol/client.test.ts
@@ -9,8 +9,8 @@
  * consumer callback never rejects the stream or the transport on either platform.
  */
 
-import { IDBFactory } from "fake-indexeddb";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetKeyVault } from "@/lib/adapters/test-fixtures/key-vault";
 import "fake-indexeddb/auto";
 import { BrowserChatTransport } from "@/lib/adapters/browser-chat-adapter";
 import { BrowserKeychainAdapter } from "@/lib/adapters/browser-keychain-adapter";
@@ -108,14 +108,6 @@ const TEXT_FRAME = `event: content_block_delta\ndata: ${JSON.stringify({
 	index: 0,
 	delta: { type: "text_delta", text: "hi" },
 })}\n\n`;
-
-/**
- * Reset the encrypted key vault. Since #133 browser keys live in IndexedDB, so a fresh
- * factory — not `localStorage.clear()` — is what leaves no key stored.
- */
-function resetKeyVault(): void {
-	globalThis.indexedDB = new IDBFactory();
-}
 
 beforeEach(() => {
 	relay.reset();

--- a/src/lib/ai/protocol/client.test.ts
+++ b/src/lib/ai/protocol/client.test.ts
@@ -9,7 +9,9 @@
  * consumer callback never rejects the stream or the transport on either platform.
  */
 
+import { IDBFactory } from "fake-indexeddb";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "fake-indexeddb/auto";
 import { BrowserChatTransport } from "@/lib/adapters/browser-chat-adapter";
 import { BrowserKeychainAdapter } from "@/lib/adapters/browser-keychain-adapter";
 import type {
@@ -107,14 +109,24 @@ const TEXT_FRAME = `event: content_block_delta\ndata: ${JSON.stringify({
 	delta: { type: "text_delta", text: "hi" },
 })}\n\n`;
 
+/**
+ * Reset the encrypted key vault. Since #133 browser keys live in IndexedDB, so a fresh
+ * factory — not `localStorage.clear()` — is what leaves no key stored.
+ */
+function resetKeyVault(): void {
+	globalThis.indexedDB = new IDBFactory();
+}
+
 beforeEach(() => {
 	relay.reset();
+	resetKeyVault();
 });
 
 afterEach(() => {
 	vi.unstubAllGlobals();
 	vi.useRealTimers();
 	localStorage.clear();
+	resetKeyVault();
 });
 
 describe("streamConversation orchestration", () => {

--- a/src/lib/ai/protocol/contract.test.ts
+++ b/src/lib/ai/protocol/contract.test.ts
@@ -16,7 +16,9 @@
  * this corpus exists to catch.
  */
 
+import { IDBFactory } from "fake-indexeddb";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "fake-indexeddb/auto";
 import { BrowserChatTransport } from "@/lib/adapters/browser-chat-adapter";
 import { BrowserKeychainAdapter } from "@/lib/adapters/browser-keychain-adapter";
 import { TauriChatTransport } from "@/lib/adapters/tauri-chat-adapter";
@@ -220,9 +222,18 @@ const TRANSPORTS: Array<[string, Runner]> = [
 	["desktop", runTauri],
 ];
 
+/**
+ * Reset the encrypted key vault. Since #133 browser keys live in IndexedDB, so a fresh
+ * factory — not `localStorage.clear()` — is what leaves no key stored.
+ */
+function resetKeyVault(): void {
+	globalThis.indexedDB = new IDBFactory();
+}
+
 beforeEach(async () => {
 	relay.reset();
 	vi.stubGlobal("fetch", vi.fn());
+	resetKeyVault();
 	await new BrowserKeychainAdapter().setKey("anthropic", ANTHROPIC_KEY);
 	await new BrowserKeychainAdapter().setKey("openai", OPENAI_KEY);
 });
@@ -231,6 +242,7 @@ afterEach(() => {
 	vi.unstubAllGlobals();
 	vi.useRealTimers();
 	localStorage.clear();
+	resetKeyVault();
 });
 
 describe("provider and transport neutrality", () => {

--- a/src/lib/ai/protocol/contract.test.ts
+++ b/src/lib/ai/protocol/contract.test.ts
@@ -16,8 +16,8 @@
  * this corpus exists to catch.
  */
 
-import { IDBFactory } from "fake-indexeddb";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetKeyVault } from "@/lib/adapters/test-fixtures/key-vault";
 import "fake-indexeddb/auto";
 import { BrowserChatTransport } from "@/lib/adapters/browser-chat-adapter";
 import { BrowserKeychainAdapter } from "@/lib/adapters/browser-keychain-adapter";
@@ -221,14 +221,6 @@ const TRANSPORTS: Array<[string, Runner]> = [
 	["browser", runBrowser],
 	["desktop", runTauri],
 ];
-
-/**
- * Reset the encrypted key vault. Since #133 browser keys live in IndexedDB, so a fresh
- * factory — not `localStorage.clear()` — is what leaves no key stored.
- */
-function resetKeyVault(): void {
-	globalThis.indexedDB = new IDBFactory();
-}
 
 beforeEach(async () => {
 	relay.reset();

--- a/src/lib/ai/protocol/errors.ts
+++ b/src/lib/ai/protocol/errors.ts
@@ -18,7 +18,7 @@
 export type ProtocolErrorCode =
 	/** The selected model cannot do what the request asks (for example tool calling). */
 	| "unsupported_capability"
-	/** No BYOK credential is configured for the selected provider. */
+	/** No usable BYOK credential: none is configured, or the stored one cannot be read. */
 	| "no_api_key"
 	/** The provider answered with a non-2xx status that is not rate limiting. */
 	| "http_status"

--- a/src/lib/onboarding/guides.ts
+++ b/src/lib/onboarding/guides.ts
@@ -109,7 +109,7 @@ export const AI_ASSISTANT_GUIDE: OnboardingGuide = {
 			targetSelector: "[data-testid='btn-settings-dialog']",
 			title: "Configure API Key",
 			content:
-				"To use AI features, open Settings and add your API key (OpenAI or Anthropic). Desktop keys are encrypted at rest; browser keys are stored in localStorage.",
+				"To use AI features, open Settings and add your API key (OpenAI or Anthropic). Desktop keys are encrypted at rest; browser keys are encrypted using a key your browser will not export.",
 			placement: "bottom",
 		},
 		{

--- a/src/lib/onboarding/guides.ts
+++ b/src/lib/onboarding/guides.ts
@@ -109,7 +109,7 @@ export const AI_ASSISTANT_GUIDE: OnboardingGuide = {
 			targetSelector: "[data-testid='btn-settings-dialog']",
 			title: "Configure API Key",
 			content:
-				"To use AI features, open Settings and add your API key (OpenAI or Anthropic). Desktop keys are encrypted at rest; browser keys are encrypted using a key your browser will not export.",
+				"To use AI features, open Settings and add your API key (OpenAI or Anthropic). Desktop keys are encrypted at rest; browser keys are encrypted using a key your browser will not export, though anything running on this page can still use them.",
 			placement: "bottom",
 		},
 		{

--- a/src/lib/persistence/no-key-leakage.test.ts
+++ b/src/lib/persistence/no-key-leakage.test.ts
@@ -67,7 +67,7 @@ function modelWithoutSecret(): ThreatModel {
 	};
 }
 
-/** Enumerate every record in every IndexedDB store as one string for substring scanning. */
+/** Enumerate every record in the workspace database's stores as one string for scanning. */
 async function dumpIndexedDb(): Promise<string> {
 	const db = await openWorkspaceDb();
 	try {
@@ -214,7 +214,8 @@ describe("no key material reaches the workspace stores (D6)", () => {
 	});
 
 	it("stores keys in a different database from the workspace", () => {
-		// Two separate databases, so neither store can enumerate the other's records.
+		// A rename-collision guard: if either namespace were ever changed to match the other,
+		// the scan above would stop being a disjointness proof and would silently still pass.
 		expect(KEY_VAULT_DB_NAME).not.toBe(WORKSPACE_STORAGE_NAMESPACE);
 	});
 

--- a/src/lib/persistence/no-key-leakage.test.ts
+++ b/src/lib/persistence/no-key-leakage.test.ts
@@ -3,6 +3,8 @@ import { IDBFactory } from "fake-indexeddb";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "fake-indexeddb/auto";
 import { useWorkspacePersistence } from "@/hooks/use-workspace-persistence";
+import { KEY_VAULT_DB_NAME } from "@/lib/adapters/browser-key-vault";
+import { BrowserKeychainAdapter } from "@/lib/adapters/browser-keychain-adapter";
 import { serializeThreatModelYaml } from "@/lib/thf-yaml";
 import { useDocumentRegistry } from "@/stores/document-registry";
 import { createDocumentStores, setActiveStores } from "@/stores/document-stores";
@@ -17,7 +19,12 @@ import { WORKSPACE_STORAGE_NAMESPACE } from "./types";
 /**
  * D6: the no-key-leakage boundary, proven at runtime rather than asserted. The workspace stores
  * hold only `.thf` text and the id/order/title/preferences manifest; a stored API key must never
- * appear in either, and the keychain's `tf-api-key-` namespace stays disjoint.
+ * appear in either, and the keychain's namespace stays disjoint.
+ *
+ * Since #133 the keychain is its own encrypted IndexedDB database rather than a `localStorage`
+ * slot, so disjointness is now a database-name separation as well as a value separation. The
+ * legacy `tf-api-key-` cases below are retained because that slot still exists on any profile
+ * that predates #133 until the adapter migrates it.
  */
 
 /**
@@ -183,6 +190,32 @@ describe("no key material reaches the workspace stores (D6)", () => {
 			...removeItem.mock.calls,
 		].map((call) => String(call[0]));
 		expect(touchedKeys.some((key) => /^tf-api-key-/.test(key))).toBe(false);
+	});
+
+	it("keeps a key stored through the real keychain out of the workspace stores", async () => {
+		// The strongest form of the proof: the key goes in through the production adapter
+		// rather than a hand-seeded slot, so it covers wherever the keychain actually writes.
+		await new BrowserKeychainAdapter().setKey("anthropic", KEYCHAIN_CANARY);
+
+		const storage = new IndexeddbWorkspaceStorage();
+		await storage.writeDocumentBody(DOC, serializeThreatModelYaml(modelWithoutSecret()));
+		useWorkspaceStore.getState().upsertManifestEntry({
+			id: DOC,
+			title: "Payment Service",
+			filePath: null,
+			order: 0,
+			createdAt: "2026-07-21T00:00:00.000Z",
+			updatedAt: "2026-07-21T00:00:00.000Z",
+		});
+
+		expect(await dumpIndexedDb()).not.toContain(KEYCHAIN_CANARY);
+		const localValues = Object.keys(localStorage).map((key) => localStorage.getItem(key) ?? "");
+		expect(localValues.some((value) => value.includes(KEYCHAIN_CANARY))).toBe(false);
+	});
+
+	it("stores keys in a different database from the workspace", () => {
+		// Two separate databases, so neither store can enumerate the other's records.
+		expect(KEY_VAULT_DB_NAME).not.toBe(WORKSPACE_STORAGE_NAMESPACE);
 	});
 
 	it("has no persistence module that imports a keychain adapter", () => {

--- a/src/lib/persistence/types.ts
+++ b/src/lib/persistence/types.ts
@@ -11,7 +11,8 @@ import type { DocumentId } from "@/types/document";
 
 /**
  * The single namespace shared by both browser stores: the localStorage manifest key and the
- * IndexedDB database name. Kept disjoint from the keychain's `tf-api-key-` namespace.
+ * IndexedDB database name. Kept disjoint from the keychain's own `threatforge-keychain`
+ * database, so document storage and key storage never share a store.
  */
 export const WORKSPACE_STORAGE_NAMESPACE = "threatforge-workspace";
 

--- a/src/pages/privacy-page.tsx
+++ b/src/pages/privacy-page.tsx
@@ -24,9 +24,10 @@ export function PrivacyPage() {
 							Threat Forge uses a Bring Your Own Key (BYOK) model for AI features. When you use
 							AI-powered threat analysis or chat, your API key and prompts are sent directly from
 							your machine to your chosen provider (OpenAI or Anthropic). On the desktop app, your
-							API keys are encrypted at rest using AES-256-GCM; in the web app, they are stored in
-							your browser&apos;s localStorage. In both cases, your keys are never transmitted to
-							Exit Zero Labs.
+							API keys are encrypted at rest using AES-256-GCM; in the web app, they are encrypted
+							in your browser&apos;s storage under a key the browser will not export, though
+							anything running on the page can still use that key. In both cases, your keys are
+							never transmitted to Exit Zero Labs.
 						</p>
 						<p>
 							AI features are entirely optional. The application is fully functional without them.


### PR DESCRIPTION
Closes #133.

Browser BYOK API keys were stored clear-text in `localStorage` under `tf-api-key-<provider>`, readable by any script on the origin, by a browser extension with storage access, and by anyone with the profile directory. This moves them into an IndexedDB vault encrypted with AES-GCM under a **non-extractable** wrap key, and migrates existing keys on first read. There is no UX change — the design the owner selected.

## What changed

| Surface | Change |
|---|---|
| `browser-key-vault.ts` (new) | The vault: wrap-key lifecycle, encrypt/decrypt, retirement markers, and every transaction boundary |
| `browser-keychain-adapter.ts` | Reads/writes through the vault; migrates and then erases the clear-text slot |
| `browser-chat-adapter.ts` | Vault faults re-raise as protocol errors instead of falling back to clear text |
| `ai-settings-content.tsx` | Reports a surviving clear-text copy the user must clear manually |
| `no-key-leakage.test.ts`, `privacy-page.tsx`, `guides.ts` | Doc and assertion surfaces that asserted clear-text storage |

The wrap key is generated with `extractable: false`, so it can be *used* by page script but never *exported*. Ciphertext and wrap key live in separate object stores.

## Threat model — please read before validating

**This defends against storage inspection, not against script on the origin.** Any script running on the ThreatForge origin can call into the vault and decrypt exactly as the app does; a non-extractable key raises the cost of exfiltration (the attacker must stay resident and use the key in place) but does not prevent it. `script-src 'self'` remains the primary defense for key confidentiality — encryption at rest is defense in depth behind it.

The wrap key is also serialized into the same IndexedDB backing store as the ciphertext, so an attacker with the browser profile directory recovers both together. **Only the desktop build keeps key material out of the browser profile.** The honest statement of the win is: clear-text keys no longer sit in a store that is trivially readable, greppable, synced, and visible in devtools at a glance.

`static.cloudflareinsights.com` sits in `script-src` without SRI, so it is trusted equal to `'self'` for key confidentiality. That policy line is **unchanged by this PR** (the `public/_headers` diff here is comment-only) and the residual is tracked as #232.

## Verification

`npm run ci:local` green. 71 tests in `browser-keychain-adapter.test.ts`, 157 across `src/lib/adapters/`.

Beyond the suite, the durability contracts are pinned by mutation testing. Mutating each of the ten transaction handlers one at a time (`awaitWrite`, `installWrapKey`, `putSecret`, `dropUnreadableSecret`, `importLegacySecret` × `onabort`/`onerror`) from reject to resolve kills **8 of 10**, each failing exactly the test named for it. This was reproduced independently by the review lane.

## How this was reviewed

Seventeen convergent audit rounds (security auditor + slop auditor in parallel, fresh context each round). **Rounds 5–14 each found a real defect, most of them regressions introduced by the previous round's fix.** Rounds 15 and 16 found no production defect. Round 17 returned no must-fix from either lane.

The recurring defect class was **check-then-act across IndexedDB transactions**. Contributing facts, each of which cost a round:

- IndexedDB transactions auto-commit as soon as the request queue drains and control returns to the event loop — so a guard read before an `await` does not hold for the write after it. Every check-and-act is now a single transaction, which is what actually orders concurrent tabs; the provider lock is a module-scoped `Map` and orders one tab only.
- `IDBRequest.onsuccess` is not durability. Only `tx.oncomplete` is. The migration erases the user's only clear-text copy on the strength of that resolution.
- `instanceof DOMException` **fails across realms** — reproduced. The equivalent `CryptoKey` brand check is **hardening, not a reproduced fix**, and is labelled as such in the code.

Two of the fifteen defects were docstrings falsified by their own commit's other change; one was a refactor that reversed a rule *and deleted the only test watching it in the same commit*. Both are now covered by tests rather than prose.

## Known limitations — deliberately deferred, not oversights

- **#233** — the settings panel reports a surviving clear-text key only once; the blocked-storage `unverified` case; and a `revoked` marker is permanent, so a post-revocation re-save can cost the user their surviving clear-text copy. Availability, not confidentiality.
- **#234** — `hasKey` reports "configured" for a record the vault cannot decrypt.
- Migration erases the clear-text slot on record **existence**, not readability.
- Retirement markers are written per delete and never cleared: one small record per provider the user has ever deleted a key for.
- A `settled` marker on a healthy vault still erases the last clear-text copy — pre-existing designed behaviour, unchanged here.
- **#235** — the commit-time abort tests inject from a request `success` handler, which can race `fake-indexeddb`'s auto-commit. The security lane observed nondeterminism on Node 24; I ran it 10 times on Node 24, including under load, and could not reproduce it. Both observations are recorded on the issue. CI pins Node 22 and is unaffected.
- **`installWrapKey` and `importLegacySecret`'s `tx.onerror` are knowingly unwitnessed.** Both writers issue their last request with nothing else in flight, so no abort can reach them, and a synthetic bubbled `error` event aborts the transaction instead of raising `error` on it — a test written that way pins `onabort` while claiming otherwise. I removed the tests that did this rather than ship a false rationale. This is documented in `abortWriteTo`'s docstring. **If you run mutation testing, these two are the expected survivors.**

One security finding was **declined**: a success flag on the marker write (round 12 C1), as an unreachable defensive branch. Round 13 confirmed the decline.

## What I could not verify for you

Everything above was verified in `fake-indexeddb` under jsdom. The cross-realm `DOMException` behaviour was reproduced there; **real-browser behaviour under storage pressure, Safari's ITP eviction, and private-browsing quota limits were not exercised.** The failure mode that matters if any of those differ is a write reported as durable before it committed, which the vault is built to reject and which #235 exists to keep honest.

Milestone: `M2 • General Release`.