### PR TITLE
ci: fall back to GitHub-hosted runners while self-hosted runner is down

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,8 @@ permissions:
 jobs:
   lockfile:
     name: Lockfile
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","hostinger"]') || 'ubuntu-latest' }}
+    # Temporarily on GitHub-hosted runners; restore self-hosted via #239.
+    runs-on: ubuntu-latest
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo-home
     steps:
@@ -40,7 +41,8 @@ jobs:
   lint:
     name: Lint
     needs: [lockfile]
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","hostinger"]') || 'ubuntu-latest' }}
+    # Temporarily on GitHub-hosted runners; restore self-hosted via #239.
+    runs-on: ubuntu-latest
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo-home
     steps:
@@ -100,7 +102,8 @@ jobs:
   test:
     name: Test
     needs: [lockfile]
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","hostinger"]') || 'ubuntu-latest' }}
+    # Temporarily on GitHub-hosted runners; restore self-hosted via #239.
+    runs-on: ubuntu-latest
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo-home
     steps:
@@ -149,7 +152,8 @@ jobs:
   e2e:
     name: E2E Tests
     needs: [test]
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","hostinger"]') || 'ubuntu-latest' }}
+    # Temporarily on GitHub-hosted runners; restore self-hosted via #239.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -190,7 +194,8 @@ jobs:
   build:
     name: Build (${{ matrix.platform }})
     needs: [lint, test]
-    runs-on: ${{ matrix.platform == 'ubuntu-latest' && ((github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","hostinger"]') || 'ubuntu-latest') || matrix.platform }}
+    # Temporarily on GitHub-hosted runners; restore self-hosted via #239.
+    runs-on: ${{ matrix.platform }}
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo-home
     strategy:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,7 +10,8 @@ permissions:
 jobs:
   dependency-review:
     name: Dependency Review
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","hostinger"]') || 'ubuntu-latest' }}
+    # Temporarily on GitHub-hosted runners; restore self-hosted via #239.
+    runs-on: ubuntu-latest
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo-home
     steps:


### PR DESCRIPTION
Unblocks CI. The org self-hosted runner `hostinger-vps-01` stopped accepting jobs and there is no repo-side way to restart it.

## Evidence

- `CI` and `Dependency Review` runs queued **29+ minutes** with zero jobs started, on two independent branches (`feat/203-bounded-ai-read-tools`, `chore/e0l-doctrine-v1`).
- Runner's last completed job: `01:56:42Z`. Nothing accepted after that.
- `GET /repos/.../actions/runners` returns an empty list, so the runner is org-scoped; no available token carries `admin:org`, so it cannot be queried or restarted from here.
- githubstatus.com reports all systems operational, so this is not a platform incident.
- Concurrency groups are per-`github.ref`, which rules out cross-branch blocking.

## Change

All five CI jobs move from the `["self-hosted","Linux","X64","hostinger"]` runner expression to GitHub-hosted runners. The `build` matrix returns to plain `matrix.platform`.

The replaced expression already resolved to `ubuntu-latest` for fork PRs, so the hosted path is a configuration CI already supported, not a new and unexercised one.

## Scope discipline

No job logic, step, dependency, or permission is touched. Only the five `runs-on` values change, so restoring self-hosted is a plain `git revert` of this commit rather than a re-derivation.

## Verification

This PR's own CI is the verification: it runs on GitHub-hosted runners, so a green result proves the fallback works end to end. That is also why it is self-unblocking.

## Follow-up

Tracked in #239: root-cause the outage, restore the runner with restart-on-failure, revert this commit, and add queue-stall visibility so a repeat is noticed without manual inspection.

This is a stopgap, not a decision to abandon self-hosted CI.
