### PR TITLE
chore(release): prepare v0.3.0 with honest first-run guidance

### DIFF
--- a/docs/runbooks/releasing-a-version.md
+++ b/docs/runbooks/releasing-a-version.md
@@ -30,18 +30,22 @@ OIDC before enabling signed releases.
 
 ### Recorded waivers
 
-**v0.3.0 — unsigned macOS builds and no updater.** The owner accepted shipping v0.3.0 with rows
-#51 and #49 open, to get 98 commits of work into users' hands rather than hold it behind signing
-provisioning. What this costs users:
+**v0.3.0 — unsigned macOS builds, unverified Windows signing, and no updater.** The owner
+accepted shipping v0.3.0 with rows #51, #50, and #49 open, to get 98 commits of work into users'
+hands rather than hold it behind signing provisioning. What this costs users:
 
-- macOS reports the app as damaged on first launch and they must clear the quarantine flag by
-  hand. The `/support` page carries the instructions and `/downloads` links to them ([#245]).
-- There is no in-app update. Users return to the downloads page for the next version.
-- Windows installers are signed through Azure Trusted Signing, but SmartScreen reputation is
-  still accumulating, so a warning is expected there too.
+- **#51, macOS.** No Developer ID signature or notarization, so macOS reports the app as damaged
+  on first launch and users must clear the quarantine flag by hand. The `/support` page carries
+  the instructions and `/downloads` links to them ([#245]).
+- **#50, Windows.** Azure Trusted Signing is wired into the build, but it has never been verified
+  on a published artifact — that is the open half of the row. Treat "the installer is signed" as
+  unconfirmed until step 8 checks the signature on the real v0.3.0 artifact. SmartScreen
+  reputation is still accumulating either way, so a warning is expected.
+- **#49, updater.** There is no in-app update. Users return to the downloads page for the next
+  version.
 
-Revisit at the next release: if #51 and #49 are still open then, that is a signal to stop
-shipping past them rather than to re-waive.
+Revisit at the next release: if these rows are still open then, that is a signal to stop shipping
+past them rather than to re-waive.
 
 [#245]: https://github.com/exit-zero-labs/threat-forge/issues/245
 
@@ -140,9 +144,10 @@ Monitor the workflow at: `Actions > Release > vX.Y.Z`.
 ### 8. Verify the Release
 
 1. Check GitHub Releases page for the draft release
-2. Confirm the draft carries an artifact for every matrix target. A missing Windows artifact
-   means Azure signing failed — `scripts/sign-windows.ps1` exits non-zero rather than shipping an
-   unsigned installer, and `fail-fast: false` lets the other platforms finish around it.
+2. Confirm the draft carries an artifact for every matrix target. A missing artifact means that
+   platform's build or signing step failed; `fail-fast: false` lets the others finish around it.
+   For Windows specifically, `scripts/sign-windows.ps1` exits non-zero rather than shipping an
+   unsigned installer, so a missing installer may mean signing rather than the build.
 3. Download binaries for each platform and smoke test:
    - Verify the Windows installer signature and publisher identity
    - On macOS, confirm the documented first-run recovery actually works on a machine that has
@@ -179,8 +184,8 @@ git commit -m "fix: critical bug description"
 # Merge to main, then tag a patch release
 git checkout main
 git merge fix/critical-bug
-git tag vX.Y.Z+1
-git push origin main vX.Y.Z+1
+git tag vX.Y.Z            # the next patch version
+git push origin main vX.Y.Z
 ```
 
 ## Troubleshooting

--- a/docs/runbooks/releasing-a-version.md
+++ b/docs/runbooks/releasing-a-version.md
@@ -40,7 +40,9 @@ hands rather than hold it behind signing provisioning. What this costs users:
 - **#50, Windows.** Azure Trusted Signing is wired into the build, but it has never been verified
   on a published artifact — that is the open half of the row. Treat "the installer is signed" as
   unconfirmed until step 8 checks the signature on the real v0.3.0 artifact. SmartScreen
-  reputation is still accumulating either way, so a warning is expected.
+  reputation is still accumulating either way, so a warning is expected. Owner-facing: the
+  Azure credentials stay repository-scoped rather than `Production`-scoped for this release, so
+  other workflows can reference them until the OIDC migration in #50 lands.
 - **#49, updater.** There is no in-app update. Users return to the downloads page for the next
   version.
 
@@ -73,9 +75,10 @@ cargo test --manifest-path src-tauri/Cargo.toml --frozen
 
 ### 2. Bump Version Numbers
 
-The version appears in four files that must agree. `scripts/check-lockfile-registry.mjs`
-rejects a `package-lock.json` whose root version has drifted from `package.json`, so the
-lockfile is not optional.
+The version appears in five files that must agree — the four below plus `src-tauri/Cargo.lock`,
+regenerated in step 4. Neither lockfile is optional: `scripts/check-lockfile-registry.mjs`
+rejects a `package-lock.json` whose root version has drifted from `package.json`, and the
+release workflow runs `cargo fetch --locked`, which fails on a stale `Cargo.lock`.
 
 ```bash
 # 1. Cargo.toml
@@ -95,15 +98,20 @@ npm install --package-lock-only --ignore-scripts
 ```
 
 `__APP_VERSION__` is compiled from `package.json`, so the in-app version badge, settings
-dialog, site footer, and the version the What's New overlay announces all follow this bump with
-no further edits.
+dialog, and site footer follow this bump with no further edits. The What's New overlay does not
+— see the next step.
 
 ### 3. Add the What's New Entry
 
-The overlay's `CHANGELOG` in `src/lib/whats-new.ts` is hand-maintained and does **not** follow
-the version bump. Add an entry at the top of the list — newest first — describing what changed in
-terms of what a user can now do. `src/lib/whats-new.test.ts` fails if the newest entry does not
-match the running version, so a skipped entry stops CI rather than shipping a silent upgrade.
+The overlay renders `entry.version` from the hand-maintained `CHANGELOG` in
+`src/lib/whats-new.ts`, so it does **not** follow the version bump. Add an entry at the top of
+the list — newest first — describing what changed in terms of what a user can now do, and scope
+any bullet that only applies to one surface (`(desktop app)`, `Browser …`).
+`src/lib/whats-new.test.ts` fails if the newest entry does not match the running version, so a
+skipped entry stops CI rather than shipping a silent upgrade.
+
+Use the intended publish date in UTC, not today's — the tag waits on a second owner's
+`Production` approval, so authoring and publishing can fall on different days.
 
 ### 4. Update Cargo.lock
 

--- a/docs/runbooks/releasing-a-version.md
+++ b/docs/runbooks/releasing-a-version.md
@@ -7,13 +7,14 @@ Step-by-step guide for creating a new release of ThreatForge.
 - One of the repository owners (`Shreyasdbz` or `exitzerolabs-admin`) creates the release
 - All CI checks passing on `main`
 - A second repository owner is available to approve the protected `Production` deployment
-- Code signing and updater signing are configured and verified (see
-  [Release Readiness](#release-readiness) and
-  [Configuring release signing](configuring-release-signing.md))
+- The [Release Readiness](#release-readiness) rows are complete, or the owner has recorded a
+  waiver for the ones that are not (see [Configuring release signing](configuring-release-signing.md))
 
 ## Release Readiness
 
-Do not publish a production release until every row is complete.
+Every row here should be complete before a release goes out. A row that is not complete is a
+promise the release breaks, so it takes an explicit, recorded owner waiver rather than silence —
+and the waiver has to say what users experience because of it.
 
 | Control | Current state | Tracking |
 |---------|---------------|----------|
@@ -26,6 +27,23 @@ The `Production` environment gates all platform build jobs after validation. The
 values are repository-scoped, so other workflows could reference them without this environment
 approval. Move provider credentials into `Production` and replace the Azure client secret with
 OIDC before enabling signed releases.
+
+### Recorded waivers
+
+**v0.3.0 — unsigned macOS builds and no updater.** The owner accepted shipping v0.3.0 with rows
+#51 and #49 open, to get 98 commits of work into users' hands rather than hold it behind signing
+provisioning. What this costs users:
+
+- macOS reports the app as damaged on first launch and they must clear the quarantine flag by
+  hand. The `/support` page carries the instructions and `/downloads` links to them ([#245]).
+- There is no in-app update. Users return to the downloads page for the next version.
+- Windows installers are signed through Azure Trusted Signing, but SmartScreen reputation is
+  still accumulating, so a warning is expected there too.
+
+Revisit at the next release: if #51 and #49 are still open then, that is a signal to stop
+shipping past them rather than to re-waive.
+
+[#245]: https://github.com/exit-zero-labs/threat-forge/issues/245
 
 Use [Configuring release signing](configuring-release-signing.md) for the portable owner and
 implementation procedure. Project 2 and issues #49 through #52 remain the live status source.
@@ -57,15 +75,15 @@ lockfile is not optional.
 
 ```bash
 # 1. Cargo.toml
-# version = "0.3.0"
+# version = "X.Y.Z"
 vim src-tauri/Cargo.toml
 
 # 2. tauri.conf.json
-# "version": "0.3.0"
+# "version": "X.Y.Z"
 vim src-tauri/tauri.conf.json
 
 # 3. package.json
-# "version": "0.3.0"
+# "version": "X.Y.Z"
 vim package.json
 
 # 4. package-lock.json — regenerate rather than hand-edit
@@ -73,33 +91,42 @@ npm install --package-lock-only --ignore-scripts
 ```
 
 `__APP_VERSION__` is compiled from `package.json`, so the in-app version badge, settings
-dialog, site footer, and What's New overlay follow this bump with no further edits.
+dialog, site footer, and the version the What's New overlay announces all follow this bump with
+no further edits.
 
-### 3. Update Cargo.lock
+### 3. Add the What's New Entry
+
+The overlay's `CHANGELOG` in `src/lib/whats-new.ts` is hand-maintained and does **not** follow
+the version bump. Add an entry at the top of the list — newest first — describing what changed in
+terms of what a user can now do. `src/lib/whats-new.test.ts` fails if the newest entry does not
+match the running version, so a skipped entry stops CI rather than shipping a silent upgrade.
+
+### 4. Update Cargo.lock
 
 ```bash
 cargo check --manifest-path src-tauri/Cargo.toml
 ```
 
-### 4. Commit the Version Bump
+### 5. Commit the Version Bump
 
 ```bash
-git add src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json package.json package-lock.json
-git commit -m "chore: bump version to 0.3.0"
+git add src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json \
+        package.json package-lock.json src/lib/whats-new.ts
+git commit -m "chore: bump version to X.Y.Z"
 ```
 
-### 5. Create and Push the Tag
+### 6. Create and Push the Tag
 
 Only the two repository owners can update `main`. The owner who pushes the tag cannot approve
 their own `Production` deployment, so coordinate with the other owner before tagging.
 
 ```bash
-git tag -a v0.2.0 -m "Release v0.2.0"
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
 git push origin main
-git push origin v0.2.0
+git push origin vX.Y.Z
 ```
 
-### 6. Trigger Release Build
+### 7. Trigger Release Build
 
 The `release.yml` workflow triggers on `v*` tags and builds binaries for:
 - Ubuntu (x86_64)
@@ -108,24 +135,33 @@ The `release.yml` workflow triggers on `v*` tags and builds binaries for:
 
 The workflow validates the release first, then pauses at the protected `Production`
 environment. The owner who did not initiate the release reviews and approves the deployment.
-Monitor the workflow at: `Actions > Release > v0.2.0`.
+Monitor the workflow at: `Actions > Release > vX.Y.Z`.
 
-### 7. Verify the Release
+### 8. Verify the Release
 
 1. Check GitHub Releases page for the draft release
-2. Download binaries for each platform and smoke test:
+2. Confirm the draft carries an artifact for every matrix target. A missing Windows artifact
+   means Azure signing failed — `scripts/sign-windows.ps1` exits non-zero rather than shipping an
+   unsigned installer, and `fail-fast: false` lets the other platforms finish around it.
+3. Download binaries for each platform and smoke test:
    - Verify the Windows installer signature and publisher identity
-   - Verify the macOS app is signed, notarized, and accepted by Gatekeeper
+   - On macOS, confirm the documented first-run recovery actually works on a machine that has
+     not run the app before: the quarantine flag is set, and the `xattr -dr` command on
+     `/support` clears it. Unsigned builds are covered by a recorded waiver, so this replaces
+     the notarization check rather than being skipped alongside it.
    - App launches without errors
    - Can create, save, and reopen a `.thf` file
    - Import a `.tm7` file (File > Import) — elements, flows, boundaries, and threats appear on canvas
    - AI chat works (with valid API key): model selector, chat sessions, stop generating, markdown rendering
    - STRIDE analysis runs
-3. Verify release checksums, signing evidence, workflow logs, and updater artifacts are retained
-   with the draft release
-4. Publish the draft release (click "Publish release" on GitHub)
+4. Verify release checksums, signing evidence, and workflow logs are retained with the draft
+   release. Updater artifacts are absent until #49 lands; releasing without them requires a
+   recorded waiver in [Release Readiness](#release-readiness).
+5. Write the release notes and publish the draft release (click "Publish release" on GitHub)
+6. Deploy the website so `/downloads` resolves the new release — see
+   [Deploying the website](deploying-the-website.md)
 
-### 8. Post-Release
+### 9. Post-Release
 
 - Verify auto-updater manifest was generated by the release workflow (when code signing is enabled)
 - Announce on relevant channels
@@ -136,15 +172,15 @@ Monitor the workflow at: `Actions > Release > v0.2.0`.
 For critical bugs in a released version:
 
 ```bash
-git checkout v0.2.0            # Check out the release tag
+git checkout vX.Y.Z            # Check out the release tag
 git checkout -b fix/critical-bug
 # ... fix the bug ...
 git commit -m "fix: critical bug description"
 # Merge to main, then tag a patch release
 git checkout main
 git merge fix/critical-bug
-git tag v0.2.1
-git push origin main v0.2.1
+git tag vX.Y.Z+1
+git push origin main vX.Y.Z+1
 ```
 
 ## Troubleshooting
@@ -154,6 +190,7 @@ git push origin main v0.2.1
 | Production deployment is waiting | The owner who did not push the tag must approve the protected environment |
 | macOS build fails signing | Check the Apple Developer secrets and certificate validity tracked in issue #51 |
 | Windows build fails signing | Check Azure credentials, Artifact Signing metadata, and issue #50 |
-| Updater artifacts are absent | Do not publish; complete the updater signing controls tracked in issue #49 |
+| Updater artifacts are absent | Expected until #49 lands. Publishing without them needs a recorded waiver |
+| A platform's artifact is missing from the draft | That platform's build or signing step failed. Read its job log; do not publish a partial release without saying so in the notes |
 | Release workflow doesn't trigger | Ensure tag matches `v*` pattern |
 | Binary too large | Check that `profile.release` settings are applied (LTO, strip, opt-level) |

--- a/docs/runbooks/releasing-a-version.md
+++ b/docs/runbooks/releasing-a-version.md
@@ -51,20 +51,29 @@ cargo test --manifest-path src-tauri/Cargo.toml --frozen
 
 ### 2. Bump Version Numbers
 
-Update version in three places:
+The version appears in four files that must agree. `scripts/check-lockfile-registry.mjs`
+rejects a `package-lock.json` whose root version has drifted from `package.json`, so the
+lockfile is not optional.
 
 ```bash
 # 1. Cargo.toml
-# version = "0.2.0"
+# version = "0.3.0"
 vim src-tauri/Cargo.toml
 
 # 2. tauri.conf.json
-# "version": "0.2.0"
+# "version": "0.3.0"
 vim src-tauri/tauri.conf.json
 
-# 3. package.json (if applicable)
+# 3. package.json
+# "version": "0.3.0"
 vim package.json
+
+# 4. package-lock.json — regenerate rather than hand-edit
+npm install --package-lock-only --ignore-scripts
 ```
+
+`__APP_VERSION__` is compiled from `package.json`, so the in-app version badge, settings
+dialog, site footer, and What's New overlay follow this bump with no further edits.
 
 ### 3. Update Cargo.lock
 
@@ -75,8 +84,8 @@ cargo check --manifest-path src-tauri/Cargo.toml
 ### 4. Commit the Version Bump
 
 ```bash
-git add src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json package.json
-git commit -m "chore: bump version to 0.2.0"
+git add src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/tauri.conf.json package.json package-lock.json
+git commit -m "chore: bump version to 0.3.0"
 ```
 
 ### 5. Create and Push the Tag

--- a/docs/runbooks/releasing-a-version.md
+++ b/docs/runbooks/releasing-a-version.md
@@ -77,9 +77,9 @@ cargo test --manifest-path src-tauri/Cargo.toml --frozen
 
 The version appears in five files that must agree — the four below plus `src-tauri/Cargo.lock`,
 regenerated in step 4 — and step 3 adds a sixth place it must match. Neither lockfile is
-optional: `scripts/check-lockfile-registry.mjs`
-rejects a `package-lock.json` whose root version has drifted from `package.json`, and the
-release workflow runs `cargo fetch --locked`, which fails on a stale `Cargo.lock`.
+optional: `scripts/check-lockfile-registry.mjs` rejects a `package-lock.json` whose root version
+has drifted from `package.json`, and the release workflow runs `cargo fetch --locked`, which
+fails on a stale `Cargo.lock`.
 
 ```bash
 # 1. Cargo.toml
@@ -195,15 +195,11 @@ git checkout main
 git merge fix/critical-bug
 ```
 
-Then run steps 2 through 5 for `vX.Y.(Z+1)` before tagging — a hotfix is a release, and
-skipping the bump ships a build whose `__APP_VERSION__` still names the previous version,
-which is the defect [#246](https://github.com/exit-zero-labs/threat-forge/issues/246) exists to
-close.
-
-```bash
-git tag vX.Y.(Z+1)
-git push origin main vX.Y.(Z+1)
-```
+Then run [Release Steps](#release-steps) 1 through 9 as for any release, using the next patch
+version. A hotfix is a release: it tags a commit, it fires `release.yml`, and it still needs the
+`Production` approval from the owner who did not push the tag. Skipping the version bump ships a
+build that reports the previous version everywhere and announces no What's New entry for the fix
+users are being asked to install.
 
 ## Troubleshooting
 

--- a/docs/runbooks/releasing-a-version.md
+++ b/docs/runbooks/releasing-a-version.md
@@ -76,7 +76,8 @@ cargo test --manifest-path src-tauri/Cargo.toml --frozen
 ### 2. Bump Version Numbers
 
 The version appears in five files that must agree — the four below plus `src-tauri/Cargo.lock`,
-regenerated in step 4. Neither lockfile is optional: `scripts/check-lockfile-registry.mjs`
+regenerated in step 4 — and step 3 adds a sixth place it must match. Neither lockfile is
+optional: `scripts/check-lockfile-registry.mjs`
 rejects a `package-lock.json` whose root version has drifted from `package.json`, and the
 release workflow runs `cargo fetch --locked`, which fails on a stale `Cargo.lock`.
 
@@ -110,8 +111,9 @@ any bullet that only applies to one surface (`(desktop app)`, `Browser …`).
 `src/lib/whats-new.test.ts` fails if the newest entry does not match the running version, so a
 skipped entry stops CI rather than shipping a silent upgrade.
 
-Use the intended publish date in UTC, not today's — the tag waits on a second owner's
-`Production` approval, so authoring and publishing can fall on different days.
+Date the entry for the day you expect it to publish rather than the day you write it — the tag
+waits on a second owner's `Production` approval, so the two can differ. The date is rendered
+verbatim; only its shape is checked.
 
 ### 4. Update Cargo.lock
 
@@ -185,15 +187,22 @@ Monitor the workflow at: `Actions > Release > vX.Y.Z`.
 For critical bugs in a released version:
 
 ```bash
-git checkout vX.Y.Z            # Check out the release tag
+git checkout vX.Y.Z            # the released tag being fixed
 git checkout -b fix/critical-bug
 # ... fix the bug ...
 git commit -m "fix: critical bug description"
-# Merge to main, then tag a patch release
 git checkout main
 git merge fix/critical-bug
-git tag vX.Y.Z            # the next patch version
-git push origin main vX.Y.Z
+```
+
+Then run steps 2 through 5 for `vX.Y.(Z+1)` before tagging — a hotfix is a release, and
+skipping the bump ships a build whose `__APP_VERSION__` still names the previous version,
+which is the defect [#246](https://github.com/exit-zero-labs/threat-forge/issues/246) exists to
+close.
+
+```bash
+git tag vX.Y.(Z+1)
+git push origin main vX.Y.(Z+1)
 ```
 
 ## Troubleshooting

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,4 +1,5 @@
 import type { Page } from "@playwright/test";
+import { APP_VERSION } from "./support/app-version";
 import { failureAwareTest as base, expect } from "./support/base";
 
 /** Platform-aware modifier key: Meta on macOS, Control elsewhere */
@@ -89,13 +90,16 @@ const AUTO_START_GUIDE_IDS = ["welcome", "dfd-basics"];
  * is not suppressed away.
  */
 export async function suppressFirstRunOverlays(page: Page) {
-	await page.addInitScript((guideIds: string[]) => {
-		localStorage.setItem("threatforge-last-seen-version", "1.0.0");
-		localStorage.setItem(
-			"threatforge-onboarding",
-			JSON.stringify({ completedGuideIds: [], dismissedGuideIds: guideIds }),
-		);
-	}, AUTO_START_GUIDE_IDS);
+	await page.addInitScript(
+		({ guideIds, version }: { guideIds: string[]; version: string }) => {
+			localStorage.setItem("threatforge-last-seen-version", version);
+			localStorage.setItem(
+				"threatforge-onboarding",
+				JSON.stringify({ completedGuideIds: [], dismissedGuideIds: guideIds }),
+			);
+		},
+		{ guideIds: AUTO_START_GUIDE_IDS, version: APP_VERSION },
+	);
 }
 
 /**

--- a/e2e/onboarding-auto-start.spec.ts
+++ b/e2e/onboarding-auto-start.spec.ts
@@ -1,10 +1,7 @@
 import type { Page } from "@playwright/test";
 import { createModel, dismissWhatsNew } from "./fixtures";
+import { APP_VERSION } from "./support/app-version";
 import { expect, failureAwareTest as test } from "./support/base";
-
-// The shared fixture suppresses both guides for deterministic workflow specs. These tests use
-// plain Playwright contexts and seed only what each first-run contract requires.
-const CURRENT_VERSION = "1.0.0";
 
 async function readOnboardingState(page: Page): Promise<unknown> {
 	return page.evaluate<unknown>(() => {
@@ -14,13 +11,15 @@ async function readOnboardingState(page: Page): Promise<unknown> {
 }
 
 test.describe("Onboarding guide auto-start (real browser, #141)", () => {
+	// The shared fixture suppresses both guides for deterministic workflow specs. These tests
+	// use plain Playwright contexts and seed only what each first-run contract requires.
 	test("welcome guide auto-starts when eligible under StrictMode and can be dismissed", async ({
 		page,
 	}) => {
 		// Suppressing What's New makes welcome eligible; onboarding itself stays unseeded.
 		await page.addInitScript((version: string) => {
 			localStorage.setItem("threatforge-last-seen-version", version);
-		}, CURRENT_VERSION);
+		}, APP_VERSION);
 
 		await page.goto("/app");
 

--- a/e2e/support/app-version.ts
+++ b/e2e/support/app-version.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/**
+ * The version the app under test reports, read from the same `package.json` that
+ * `vite.config.ts` compiles into `__APP_VERSION__`.
+ *
+ * The What's New overlay suppresses itself only when `threatforge-last-seen-version`
+ * matches that build define exactly, so a hard-coded literal here would silently stop
+ * suppressing the overlay on the next version bump and block every spec behind a modal.
+ */
+export const APP_VERSION: string = (
+	JSON.parse(
+		readFileSync(fileURLToPath(new URL("../../package.json", import.meta.url)), "utf-8"),
+	) as { version: string }
+).version;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "threat-forge",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "threat-forge",
-			"version": "0.2.0",
+			"version": "0.3.0",
 			"dependencies": {
 				"@tauri-apps/api": "2.11.1",
 				"@tauri-apps/plugin-clipboard-manager": "2.3.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "threat-forge",
 	"private": true,
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4958,7 +4958,7 @@ dependencies = [
 
 [[package]]
 name = "threat-forge"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aes-gcm",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "threat-forge"
-version = "0.2.0"
+version = "0.3.0"
 description = "AI-enhanced threat modeling desktop application"
 authors = ["Exit Zero Labs <admin@exitzerolabs.com>"]
 license = "Apache-2.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Threat Forge",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"identifier": "com.exitzerolabs.threatforge",
 	"build": {
 		"beforeDevCommand": "npm run dev",

--- a/src/components/onboarding/whats-new-overlay.test.tsx
+++ b/src/components/onboarding/whats-new-overlay.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { WhatsNewOverlay } from "./whats-new-overlay";
+
+const STORAGE_KEY = "threatforge-last-seen-version";
+
+function seenVersions(): string[] {
+	return screen
+		.queryAllByText(/^v\d+\.\d+\.\d+$/)
+		.map((node) => node.textContent ?? "")
+		.map((text) => text.slice(1));
+}
+
+describe("WhatsNewOverlay", () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
+	afterEach(() => {
+		localStorage.clear();
+	});
+
+	it("shows only the newest entry on first launch", () => {
+		render(<WhatsNewOverlay />);
+
+		expect(screen.getByTestId("whats-new-overlay")).toBeInTheDocument();
+		expect(seenVersions()).toEqual([__APP_VERSION__]);
+	});
+
+	it("announces the version the rest of the app reports", () => {
+		render(<WhatsNewOverlay />);
+
+		// The regression in #246: the overlay claimed 1.0.0 while every other version
+		// surface read __APP_VERSION__.
+		expect(seenVersions()).not.toContain("1.0.0");
+		expect(screen.getByText(`v${__APP_VERSION__}`)).toBeInTheDocument();
+	});
+
+	it("stays hidden once the current version has been dismissed", () => {
+		localStorage.setItem(STORAGE_KEY, __APP_VERSION__);
+
+		render(<WhatsNewOverlay />);
+
+		expect(screen.queryByTestId("whats-new-overlay")).not.toBeInTheDocument();
+	});
+
+	it("records the current version when dismissed", () => {
+		render(<WhatsNewOverlay />);
+
+		fireEvent.click(screen.getByRole("button", { name: "Got it" }));
+
+		expect(localStorage.getItem(STORAGE_KEY)).toBe(__APP_VERSION__);
+		expect(screen.queryByTestId("whats-new-overlay")).not.toBeInTheDocument();
+	});
+
+	it("shows every entry newer than the version the user last saw", () => {
+		localStorage.setItem(STORAGE_KEY, "0.1.0");
+
+		render(<WhatsNewOverlay />);
+
+		const shown = seenVersions();
+		expect(shown).toContain("0.2.0");
+		expect(shown).toContain(__APP_VERSION__);
+		expect(shown).not.toContain("0.1.0");
+	});
+
+	it("shows one entry when the user is a single version behind", () => {
+		localStorage.setItem(STORAGE_KEY, "0.2.0");
+
+		render(<WhatsNewOverlay />);
+
+		expect(seenVersions()).toEqual([__APP_VERSION__]);
+	});
+
+	it("recovers when a prior build stored a version that was never released", () => {
+		// Builds up to 0.2.0 wrote a hard-coded "1.0.0" here. Treating that as "already
+		// seen" would suppress the overlay until the app really reached 1.0.0.
+		localStorage.setItem(STORAGE_KEY, "1.0.0");
+
+		render(<WhatsNewOverlay />);
+
+		expect(screen.getByTestId("whats-new-overlay")).toBeInTheDocument();
+		expect(seenVersions()).toEqual([__APP_VERSION__]);
+	});
+
+	it("recovers when the stored value is not a version at all", () => {
+		localStorage.setItem(STORAGE_KEY, "not-a-version");
+
+		render(<WhatsNewOverlay />);
+
+		expect(screen.getByTestId("whats-new-overlay")).toBeInTheDocument();
+		expect(seenVersions()).toEqual([__APP_VERSION__]);
+	});
+});

--- a/src/components/onboarding/whats-new-overlay.test.tsx
+++ b/src/components/onboarding/whats-new-overlay.test.tsx
@@ -65,9 +65,9 @@ describe("WhatsNewOverlay", () => {
 	it("shows one entry when the user is a single version behind", () => {
 		// Derived, not a literal: seeding "0.2.0" made the premise expire at the next
 		// version bump, so a routine release would go red for nothing.
-		const previous = CHANGELOG[1]?.version;
+		const previous = CHANGELOG[1].version;
 		expect(previous).toBeDefined();
-		localStorage.setItem(STORAGE_KEY, previous as string);
+		localStorage.setItem(STORAGE_KEY, previous);
 
 		render(<WhatsNewOverlay />);
 

--- a/src/components/onboarding/whats-new-overlay.test.tsx
+++ b/src/components/onboarding/whats-new-overlay.test.tsx
@@ -66,7 +66,6 @@ describe("WhatsNewOverlay", () => {
 		// Derived, not a literal: seeding "0.2.0" made the premise expire at the next
 		// version bump, so a routine release would go red for nothing.
 		const previous = CHANGELOG[1].version;
-		expect(previous).toBeDefined();
 		localStorage.setItem(STORAGE_KEY, previous);
 
 		render(<WhatsNewOverlay />);

--- a/src/components/onboarding/whats-new-overlay.test.tsx
+++ b/src/components/onboarding/whats-new-overlay.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { WHATS_NEW_STORAGE_KEY as STORAGE_KEY } from "@/lib/whats-new";
+import { CHANGELOG, WHATS_NEW_STORAGE_KEY as STORAGE_KEY } from "@/lib/whats-new";
 import { WhatsNewOverlay } from "./whats-new-overlay";
 
 function seenVersions(): string[] {
@@ -54,18 +54,20 @@ describe("WhatsNewOverlay", () => {
 	});
 
 	it("shows every entry newer than the version the user last saw", () => {
-		localStorage.setItem(STORAGE_KEY, "0.1.0");
+		const oldest = CHANGELOG[CHANGELOG.length - 1].version;
+		localStorage.setItem(STORAGE_KEY, oldest);
 
 		render(<WhatsNewOverlay />);
 
-		const shown = seenVersions();
-		expect(shown).toContain("0.2.0");
-		expect(shown).toContain(__APP_VERSION__);
-		expect(shown).not.toContain("0.1.0");
+		expect(seenVersions()).toEqual(CHANGELOG.slice(0, -1).map((entry) => entry.version));
 	});
 
 	it("shows one entry when the user is a single version behind", () => {
-		localStorage.setItem(STORAGE_KEY, "0.2.0");
+		// Derived, not a literal: seeding "0.2.0" made the premise expire at the next
+		// version bump, so a routine release would go red for nothing.
+		const previous = CHANGELOG[1]?.version;
+		expect(previous).toBeDefined();
+		localStorage.setItem(STORAGE_KEY, previous as string);
 
 		render(<WhatsNewOverlay />);
 

--- a/src/components/onboarding/whats-new-overlay.test.tsx
+++ b/src/components/onboarding/whats-new-overlay.test.tsx
@@ -1,9 +1,8 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { WHATS_NEW_STORAGE_KEY as STORAGE_KEY } from "@/lib/whats-new";
 import { WhatsNewOverlay } from "./whats-new-overlay";
-
-const STORAGE_KEY = "threatforge-last-seen-version";
 
 function seenVersions(): string[] {
 	return screen

--- a/src/components/onboarding/whats-new-overlay.tsx
+++ b/src/components/onboarding/whats-new-overlay.tsx
@@ -1,7 +1,16 @@
 import { useCallback, useEffect, useState } from "react";
 
 const STORAGE_KEY = "threatforge-last-seen-version";
-const CURRENT_VERSION = "1.0.0";
+
+/**
+ * The build's own version, the same define the settings dialog, canvas badge, and site
+ * footer read. Hard-coding it here once let this overlay announce a version the rest of
+ * the app disagreed with (#246), so there is deliberately no second literal.
+ */
+const CURRENT_VERSION = __APP_VERSION__;
+
+/** localStorage is user-writable; only an exact `major.minor.patch` value is comparable. */
+const SEMVER_PATTERN = /^\d+\.\d+\.\d+$/;
 
 /** Proper semver greater-than comparison (avoids lexicographic "1.9.0" > "1.10.0" bug) */
 function semverGt(a: string, b: string): boolean {
@@ -20,9 +29,36 @@ interface ChangelogEntry {
 	changes: string[];
 }
 
+/** Newest first. Every version here is one that was actually tagged and released. */
 const CHANGELOG: ChangelogEntry[] = [
 	{
-		version: "1.0.0",
+		version: "0.3.0",
+		date: "2026-07-26",
+		changes: [
+			"AI now edits the model directly — it proposes real element, flow, and threat changes as native tool calls instead of text you copy back in",
+			"You approve each proposed change on its own, and anything applied is a single undo away",
+			"AI can read your current document and the component catalog before it suggests anything",
+			"Refreshed OpenAI and Anthropic model catalog",
+			"Open several models at once in a tabbed workspace",
+			"Browser documents survive a refresh — work is saved locally as you go",
+			"Browser API keys are encrypted at rest, and the web app now ships a strict Content-Security-Policy",
+			"Document content sent to the AI is fenced as untrusted context",
+			"Copy an individual threat as YAML, and see a summary badge for the whole model",
+			"Keyboard and contrast fixes across the palette, welcome screen, and empty canvas",
+		],
+	},
+	{
+		version: "0.2.0",
+		date: "2026-03-04",
+		changes: [
+			"AI chat: model selector, saved chat sessions, markdown rendering, and stop generating",
+			"Text annotations on the canvas",
+			"Rebuilt starter templates",
+			"threatforge.dev — landing, downloads, and legal pages",
+		],
+	},
+	{
+		version: "0.1.0",
 		date: "2026-03-02",
 		changes: [
 			"Component library with 44 pre-built technology components + text annotations",
@@ -40,6 +76,35 @@ const CHANGELOG: ChangelogEntry[] = [
 ];
 
 /**
+ * Changelog entries the user has not acknowledged yet, newest first, or an empty array
+ * when there is nothing to announce.
+ *
+ * Exported so `useOnboardingTriggers` can ask the same question the overlay answers,
+ * rather than approximating it and letting two overlays open at once.
+ */
+export function unseenChangelogEntries(): ChangelogEntry[] {
+	const lastSeen = localStorage.getItem(STORAGE_KEY);
+	if (lastSeen === CURRENT_VERSION) {
+		return [];
+	}
+
+	// A stored version ahead of every version we know about cannot have come from this
+	// app's own history. Builds up to 0.2.0 wrote a hard-coded "1.0.0" here (#246), so
+	// treating that value as "already seen" would suppress the overlay forever. Fall
+	// back to first-launch behavior instead, which self-heals on dismissal.
+	const newestKnown = CHANGELOG[0]?.version ?? CURRENT_VERSION;
+	const usableLastSeen =
+		lastSeen !== null && SEMVER_PATTERN.test(lastSeen) && !semverGt(lastSeen, newestKnown)
+			? lastSeen
+			: null;
+
+	// Entries newer than what the user last saw; on first launch, the newest one only.
+	return usableLastSeen !== null
+		? CHANGELOG.filter((entry) => semverGt(entry.version, usableLastSeen))
+		: CHANGELOG.slice(0, 1);
+}
+
+/**
  * Shows a "What's New" overlay when the app version changes.
  * Checks localStorage to determine if the user has seen the current version.
  */
@@ -48,14 +113,7 @@ export function WhatsNewOverlay() {
 	const [unseenEntries, setUnseenEntries] = useState<ChangelogEntry[]>([]);
 
 	useEffect(() => {
-		const lastSeen = localStorage.getItem(STORAGE_KEY);
-		if (lastSeen === CURRENT_VERSION) return;
-
-		// Find entries newer than what the user last saw
-		const unseen = lastSeen
-			? CHANGELOG.filter((entry) => semverGt(entry.version, lastSeen))
-			: CHANGELOG.slice(0, 1); // First launch: show latest only
-
+		const unseen = unseenChangelogEntries();
 		if (unseen.length > 0) {
 			setUnseenEntries(unseen);
 			setVisible(true);

--- a/src/components/onboarding/whats-new-overlay.tsx
+++ b/src/components/onboarding/whats-new-overlay.tsx
@@ -1,108 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-
-const STORAGE_KEY = "threatforge-last-seen-version";
-
-/**
- * The build's own version, the same define the settings dialog, canvas badge, and site
- * footer read. Hard-coding it here once let this overlay announce a version the rest of
- * the app disagreed with (#246), so there is deliberately no second literal.
- */
-const CURRENT_VERSION = __APP_VERSION__;
-
-/** localStorage is user-writable; only an exact `major.minor.patch` value is comparable. */
-const SEMVER_PATTERN = /^\d+\.\d+\.\d+$/;
-
-/** Proper semver greater-than comparison (avoids lexicographic "1.9.0" > "1.10.0" bug) */
-function semverGt(a: string, b: string): boolean {
-	const pa = a.split(".").map(Number);
-	const pb = b.split(".").map(Number);
-	for (let i = 0; i < 3; i++) {
-		if ((pa[i] ?? 0) > (pb[i] ?? 0)) return true;
-		if ((pa[i] ?? 0) < (pb[i] ?? 0)) return false;
-	}
-	return false;
-}
-
-interface ChangelogEntry {
-	version: string;
-	date: string;
-	changes: string[];
-}
-
-/** Newest first. Every version here is one that was actually tagged and released. */
-const CHANGELOG: ChangelogEntry[] = [
-	{
-		version: "0.3.0",
-		date: "2026-07-26",
-		changes: [
-			"AI now edits the model directly — it proposes real element, flow, and threat changes as native tool calls instead of text you copy back in",
-			"You approve each proposed change on its own, and anything applied is a single undo away",
-			"AI can read your current document and the component catalog before it suggests anything",
-			"Refreshed OpenAI and Anthropic model catalog",
-			"Open several models at once in a tabbed workspace",
-			"Browser documents survive a refresh — work is saved locally as you go",
-			"Browser API keys are encrypted at rest, and the web app now ships a strict Content-Security-Policy",
-			"Document content sent to the AI is fenced as untrusted context",
-			"Copy an individual threat as YAML, and see a summary badge for the whole model",
-			"Keyboard and contrast fixes across the palette, welcome screen, and empty canvas",
-		],
-	},
-	{
-		version: "0.2.0",
-		date: "2026-03-04",
-		changes: [
-			"AI chat: model selector, saved chat sessions, markdown rendering, and stop generating",
-			"Text annotations on the canvas",
-			"Rebuilt starter templates",
-			"threatforge.dev — landing, downloads, and legal pages",
-		],
-	},
-	{
-		version: "0.1.0",
-		date: "2026-03-02",
-		changes: [
-			"Component library with 44 pre-built technology components + text annotations",
-			"STRIDE threat analysis engine with auto-generated threats",
-			"AI chat pane with BYOK support (OpenAI, Anthropic)",
-			"Human-readable YAML file format — git-diffable",
-			"Undo/redo with 20-action history",
-			"Copy, cut, paste, and multi-select on canvas",
-			"Command palette (Cmd+K) with 16 commands",
-			"Onboarding guides for new users",
-			"Dark mode with 6 theme presets",
-			"Native menus on macOS/Windows/Linux",
-		],
-	},
-];
-
-/**
- * Changelog entries the user has not acknowledged yet, newest first, or an empty array
- * when there is nothing to announce.
- *
- * Exported so `useOnboardingTriggers` can ask the same question the overlay answers,
- * rather than approximating it and letting two overlays open at once.
- */
-export function unseenChangelogEntries(): ChangelogEntry[] {
-	const lastSeen = localStorage.getItem(STORAGE_KEY);
-	if (lastSeen === CURRENT_VERSION) {
-		return [];
-	}
-
-	// A stored version ahead of every version we know about cannot have come from this
-	// app's own history. Builds up to 0.2.0 wrote a hard-coded "1.0.0" here (#246), so
-	// treating that value as "already seen" would suppress the overlay forever. Fall
-	// back to first-launch behavior instead, which self-heals on dismissal.
-	const newestKnown = CHANGELOG[0]?.version ?? CURRENT_VERSION;
-	const usableLastSeen =
-		lastSeen !== null && SEMVER_PATTERN.test(lastSeen) && !semverGt(lastSeen, newestKnown)
-			? lastSeen
-			: null;
-
-	// Entries newer than what the user last saw; on first launch, the newest one only.
-	return usableLastSeen !== null
-		? CHANGELOG.filter((entry) => semverGt(entry.version, usableLastSeen))
-		: CHANGELOG.slice(0, 1);
-}
+import { type ChangelogEntry, markChangelogSeen, unseenChangelogEntries } from "@/lib/whats-new";
 
 /**
  * Shows a "What's New" overlay when the app version changes.
@@ -122,7 +19,7 @@ export function WhatsNewOverlay() {
 
 	const dismiss = useCallback(() => {
 		setVisible(false);
-		localStorage.setItem(STORAGE_KEY, CURRENT_VERSION);
+		markChangelogSeen();
 	}, []);
 
 	if (!visible || unseenEntries.length === 0) return null;

--- a/src/hooks/use-onboarding-triggers.test.ts
+++ b/src/hooks/use-onboarding-triggers.test.ts
@@ -26,7 +26,7 @@ const mockModel: ThreatModel = {
 
 /** Marks the What's New overlay as already seen, so it does not block the welcome guide. */
 function markWhatsNewSeen(): void {
-	localStorage.setItem(WHATS_NEW_STORAGE_KEY, "1.0.0");
+	localStorage.setItem(WHATS_NEW_STORAGE_KEY, __APP_VERSION__);
 }
 
 // Zustand shallow-merges action spies into later snapshots, so restoreAllMocks cannot restore
@@ -131,6 +131,21 @@ describe("useOnboardingTriggers", () => {
 		it("does not fire while the What's New overlay is visible", () => {
 			// beforeEach clears localStorage, so threatforge-last-seen-version is absent and
 			// isWhatsNewVisible() is true — the exact interaction that caused #111.
+			const startGuideSpy = spyOnStartGuide();
+
+			renderHook(() => useOnboardingTriggers());
+			act(() => {
+				vi.advanceTimersByTime(500);
+			});
+
+			expect(startGuideSpy).not.toHaveBeenCalled();
+			expect(useOnboardingStore.getState().activeGuide).toBeNull();
+		});
+
+		it("does not fire while the What's New overlay is visible after an upgrade", () => {
+			// The prior "storage key is absent" approximation returned false here, so an
+			// upgrading user could get the welcome tooltip stacked on the What's New modal.
+			localStorage.setItem(WHATS_NEW_STORAGE_KEY, "0.1.0");
 			const startGuideSpy = spyOnStartGuide();
 
 			renderHook(() => useOnboardingTriggers());

--- a/src/hooks/use-onboarding-triggers.test.ts
+++ b/src/hooks/use-onboarding-triggers.test.ts
@@ -1,12 +1,11 @@
 import { act, renderHook } from "@testing-library/react";
 import { StrictMode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WHATS_NEW_STORAGE_KEY } from "@/lib/whats-new";
 import { useModelStore } from "@/stores/model-store";
 import { useOnboardingStore } from "@/stores/onboarding-store";
 import type { ThreatModel } from "@/types/threat-model";
 import { useOnboardingTriggers } from "./use-onboarding-triggers";
-
-const WHATS_NEW_STORAGE_KEY = "threatforge-last-seen-version";
 
 const mockModel: ThreatModel = {
 	version: "1.0",

--- a/src/hooks/use-onboarding-triggers.ts
+++ b/src/hooks/use-onboarding-triggers.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { unseenChangelogEntries } from "@/components/onboarding/whats-new-overlay";
+import { unseenChangelogEntries } from "@/lib/whats-new";
 import { useModelStore } from "@/stores/model-store";
 import { useOnboardingStore } from "@/stores/onboarding-store";
 
@@ -11,10 +11,10 @@ const DFD_BASICS_DELAY_MS = 800;
 /**
  * Returns true if the What's New overlay is currently showing (blocks guide display).
  *
- * Asks the overlay itself rather than re-deriving the answer. The previous local
- * approximation — "the storage key is absent" — missed the upgrade case entirely, so a
- * user carrying a stored version from an older build could get the guide tooltip and the
- * What's New modal at the same time.
+ * Asks the same shared predicate the overlay uses. The previous local approximation —
+ * "the storage key is absent" — missed the upgrade case entirely, so a user carrying a
+ * stored version from an older build could get the guide tooltip and the What's New modal
+ * at the same time.
  */
 function isWhatsNewVisible(): boolean {
 	return unseenChangelogEntries().length > 0;

--- a/src/hooks/use-onboarding-triggers.ts
+++ b/src/hooks/use-onboarding-triggers.ts
@@ -1,20 +1,23 @@
 import { useEffect, useRef } from "react";
+import { unseenChangelogEntries } from "@/components/onboarding/whats-new-overlay";
 import { useModelStore } from "@/stores/model-store";
 import { useOnboardingStore } from "@/stores/onboarding-store";
 
-const WHATS_NEW_STORAGE_KEY = "threatforge-last-seen-version";
 const WELCOME_GUIDE_ID = "welcome";
 const WELCOME_DELAY_MS = 500;
 const DFD_BASICS_GUIDE_ID = "dfd-basics";
 const DFD_BASICS_DELAY_MS = 800;
 
-/** Returns true if the What's New overlay is currently showing (blocks guide display) */
+/**
+ * Returns true if the What's New overlay is currently showing (blocks guide display).
+ *
+ * Asks the overlay itself rather than re-deriving the answer. The previous local
+ * approximation — "the storage key is absent" — missed the upgrade case entirely, so a
+ * user carrying a stored version from an older build could get the guide tooltip and the
+ * What's New modal at the same time.
+ */
 function isWhatsNewVisible(): boolean {
-	const lastSeen = localStorage.getItem(WHATS_NEW_STORAGE_KEY);
-	// WhatsNewOverlay shows when lastSeen differs from CURRENT_VERSION
-	// We can't import CURRENT_VERSION without creating a circular dependency,
-	// so we check if the key is absent (first launch) which is the main conflict case
-	return lastSeen === null;
+	return unseenChangelogEntries().length > 0;
 }
 
 function isGuideEligible(guideId: string): boolean {

--- a/src/lib/whats-new.test.ts
+++ b/src/lib/whats-new.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { CHANGELOG, type ChangelogEntry, selectUnseenEntries } from "./whats-new";
+
+function entries(...versions: string[]): ChangelogEntry[] {
+	return versions.map((version) => ({ version, date: "2026-01-01", changes: ["something"] }));
+}
+
+function versionsOf(result: ChangelogEntry[]): string[] {
+	return result.map((entry) => entry.version);
+}
+
+describe("selectUnseenEntries", () => {
+	it("announces nothing when the running version was already acknowledged", () => {
+		expect(selectUnseenEntries("0.3.0", "0.3.0", entries("0.3.0", "0.2.0"))).toEqual([]);
+	});
+
+	it("announces only the newest entry on a first launch", () => {
+		expect(
+			versionsOf(selectUnseenEntries(null, "0.3.0", entries("0.3.0", "0.2.0", "0.1.0"))),
+		).toEqual(["0.3.0"]);
+	});
+
+	it("announces every entry newer than the acknowledged version", () => {
+		expect(
+			versionsOf(selectUnseenEntries("0.1.0", "0.3.0", entries("0.3.0", "0.2.0", "0.1.0"))),
+		).toEqual(["0.3.0", "0.2.0"]);
+	});
+
+	it("compares versions numerically rather than lexicographically", () => {
+		// "0.9.0" sorts after "0.10.0" as text, which would hide the newer entry.
+		expect(versionsOf(selectUnseenEntries("0.9.0", "0.10.0", entries("0.10.0", "0.9.0")))).toEqual([
+			"0.10.0",
+		]);
+	});
+
+	it("re-announces when a prior build stored a version that was never released", () => {
+		// Builds up to 0.2.0 wrote a hard-coded "1.0.0" (#246).
+		expect(versionsOf(selectUnseenEntries("1.0.0", "0.3.0", entries("0.3.0", "0.2.0")))).toEqual([
+			"0.3.0",
+		]);
+	});
+
+	it("re-announces when the stored value is not a version at all", () => {
+		for (const junk of ["not-a-version", "", "0.3", "v0.3.0", "0.3.0-beta.1"]) {
+			expect(versionsOf(selectUnseenEntries(junk, "0.3.0", entries("0.3.0", "0.2.0")))).toEqual([
+				"0.3.0",
+			]);
+		}
+	});
+
+	it("accepts a stored version from a build that shipped without a changelog entry", () => {
+		// v0.1.1 shipped with no entry of its own. A user who dismissed on that build
+		// stored 0.1.1; treating it as impossible would re-announce on every launch of
+		// the very next release rather than showing what actually changed.
+		expect(versionsOf(selectUnseenEntries("0.2.1", "0.2.1", entries("0.2.0", "0.1.0")))).toEqual(
+			[],
+		);
+		expect(versionsOf(selectUnseenEntries("0.2.1", "0.3.0", entries("0.3.0", "0.2.0")))).toEqual([
+			"0.3.0",
+		]);
+	});
+
+	it("does not treat the running version as seen when the changelog is empty", () => {
+		expect(selectUnseenEntries(null, "0.3.0", [])).toEqual([]);
+	});
+});
+
+describe("CHANGELOG", () => {
+	it("is ordered newest first", () => {
+		const versions = CHANGELOG.map((entry) => entry.version);
+		const sorted = [...versions].sort((a, b) => {
+			const pa = a.split(".").map(Number);
+			const pb = b.split(".").map(Number);
+			return pb[0] - pa[0] || pb[1] - pa[1] || pb[2] - pa[2];
+		});
+		expect(versions).toEqual(sorted);
+	});
+
+	it("announces the running build", () => {
+		// Bumping the version without adding an entry tells upgrading users nothing;
+		// the release runbook carries the step, and this is what catches skipping it.
+		expect(CHANGELOG[0]?.version).toBe(__APP_VERSION__);
+	});
+
+	it("uses plain major.minor.patch versions matching real tags", () => {
+		for (const entry of CHANGELOG) {
+			expect(entry.version).toMatch(/^\d+\.\d+\.\d+$/);
+			expect(entry.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+			expect(entry.changes.length).toBeGreaterThan(0);
+		}
+	});
+});

--- a/src/lib/whats-new.test.ts
+++ b/src/lib/whats-new.test.ts
@@ -86,10 +86,8 @@ describe("CHANGELOG", () => {
 	});
 
 	it("announces the running build", () => {
-		// Bumping the version without adding an entry tells upgrading users nothing, and
-		// it would leave a dismissing user holding a version above every known entry —
-		// which selectUnseenEntries reads as impossible and re-announces forever. The
-		// release runbook carries the step; this is what catches skipping it.
+		// Bumping the version without adding an entry tells upgrading users nothing.
+		// The release runbook carries the step; this is what catches skipping it.
 		expect(CHANGELOG[0]?.version).toBe(__APP_VERSION__);
 	});
 

--- a/src/lib/whats-new.test.ts
+++ b/src/lib/whats-new.test.ts
@@ -28,10 +28,18 @@ describe("selectUnseenEntries", () => {
 	});
 
 	it("compares versions numerically rather than lexicographically", () => {
-		// "0.9.0" sorts after "0.10.0" as text, which would hide the newer entry.
-		expect(versionsOf(selectUnseenEntries("0.9.0", "0.10.0", entries("0.10.0", "0.9.0")))).toEqual([
-			"0.10.0",
-		]);
+		// As text "0.9.0" sorts above both "0.10.0" and "0.11.0", so a string comparison
+		// reads a 0.9.0 user as being ahead of the newest entry and re-announces only the
+		// latest instead of both versions they missed.
+		expect(
+			versionsOf(selectUnseenEntries("0.9.0", "0.11.0", entries("0.11.0", "0.10.0", "0.9.0"))),
+		).toEqual(["0.11.0", "0.10.0"]);
+
+		// And in the filter itself: "0.9.0" > "0.10.0" as text would re-announce an entry
+		// the user has already acknowledged.
+		expect(
+			versionsOf(selectUnseenEntries("0.10.0", "0.11.0", entries("0.11.0", "0.10.0", "0.9.0"))),
+		).toEqual(["0.11.0"]);
 	});
 
 	it("re-announces when a prior build stored a version that was never released", () => {
@@ -78,8 +86,10 @@ describe("CHANGELOG", () => {
 	});
 
 	it("announces the running build", () => {
-		// Bumping the version without adding an entry tells upgrading users nothing;
-		// the release runbook carries the step, and this is what catches skipping it.
+		// Bumping the version without adding an entry tells upgrading users nothing, and
+		// it would leave a dismissing user holding a version above every known entry —
+		// which selectUnseenEntries reads as impossible and re-announces forever. The
+		// release runbook carries the step; this is what catches skipping it.
 		expect(CHANGELOG[0]?.version).toBe(__APP_VERSION__);
 	});
 

--- a/src/lib/whats-new.ts
+++ b/src/lib/whats-new.ts
@@ -1,0 +1,156 @@
+/**
+ * What the app tells users changed between releases, and who has seen it.
+ *
+ * This lives in `lib` rather than beside the overlay component because
+ * `useOnboardingTriggers` has to ask the same question — whether the What's New modal is
+ * about to open — before it starts a guide. Keeping the logic here means the hook does not
+ * import a component module to answer it, and neither side re-derives the answer.
+ */
+
+/** Where the last acknowledged version is recorded. Also read by the E2E fixtures. */
+export const WHATS_NEW_STORAGE_KEY = "threatforge-last-seen-version";
+
+/**
+ * The build's own version, the same define the settings dialog, canvas badge, and site
+ * footer read. Hard-coding it separately let the overlay announce a version the rest of
+ * the app disagreed with (#246), so there is deliberately no second literal.
+ */
+const CURRENT_VERSION = __APP_VERSION__;
+
+/** localStorage is user-writable; only an exact `major.minor.patch` value is comparable. */
+const SEMVER_PATTERN = /^\d+\.\d+\.\d+$/;
+
+/** Proper semver greater-than comparison (avoids lexicographic "1.9.0" > "1.10.0" bug) */
+function semverGt(a: string, b: string): boolean {
+	const pa = a.split(".").map(Number);
+	const pb = b.split(".").map(Number);
+	for (let i = 0; i < 3; i++) {
+		if ((pa[i] ?? 0) > (pb[i] ?? 0)) return true;
+		if ((pa[i] ?? 0) < (pb[i] ?? 0)) return false;
+	}
+	return false;
+}
+
+export interface ChangelogEntry {
+	version: string;
+	date: string;
+	changes: string[];
+}
+
+/**
+ * Newest first. Every version here corresponds to a `v*` tag.
+ *
+ * This list is hand-maintained and does not follow the version bump — releasing without
+ * adding an entry means upgrading users are told nothing. The release runbook carries the
+ * step.
+ */
+export const CHANGELOG: ChangelogEntry[] = [
+	{
+		version: "0.3.0",
+		date: "2026-07-26",
+		changes: [
+			"AI edits the model through native tool calls, so a suggestion arrives as a real change to elements, flows, and threats rather than an action block the app has to re-parse",
+			"You approve each proposed change on its own, and anything applied is a single undo away",
+			"AI can read your current document and the component catalog before it suggests anything",
+			"Refreshed OpenAI and Anthropic model catalog",
+			"Import existing models from Microsoft Threat Modeling Tool .tm7 files",
+			"Open several models at once in a tabbed workspace",
+			"Browser documents survive a refresh — work is saved locally as you go",
+			"Browser API keys are stored as ciphertext instead of clear text, and the web app now ships a strict Content-Security-Policy",
+			"Document content sent to the AI is fenced as untrusted context",
+			"Copy an individual threat as YAML, and see a summary badge for the whole model",
+			"Keyboard and contrast fixes across the palette, welcome screen, and empty canvas",
+		],
+	},
+	{
+		version: "0.2.0",
+		date: "2026-03-04",
+		changes: [
+			"AI chat: model selector, saved chat sessions, markdown rendering, and stop generating",
+			"Text annotations on the canvas",
+			"Rebuilt starter templates",
+			"threatforge.dev — landing, downloads, and legal pages",
+		],
+	},
+	{
+		version: "0.1.1",
+		date: "2026-03-03",
+		changes: [
+			"Eight-handle edge routing and canvas interaction polish",
+			"AI chat response quality improvements",
+		],
+	},
+	{
+		version: "0.1.0",
+		date: "2026-03-02",
+		changes: [
+			"Component library with 44 pre-built technology components + text annotations",
+			"STRIDE threat analysis engine with auto-generated threats",
+			"AI chat pane with BYOK support (OpenAI, Anthropic)",
+			"Human-readable YAML file format — git-diffable",
+			"Undo/redo with 20-action history",
+			"Copy, cut, paste, and multi-select on canvas",
+			"Command palette (Cmd+K) with 16 commands",
+			"Onboarding guides for new users",
+			"Dark mode with 6 theme presets",
+			"Native menus on macOS/Windows/Linux",
+		],
+	},
+];
+
+/**
+ * Chooses which entries to announce, given what the user last acknowledged.
+ *
+ * Split out from the storage read so the version-comparison rules can be tested against
+ * versions this build does not have — `__APP_VERSION__` is substituted at build time, so
+ * a test cannot vary it.
+ *
+ * @param lastSeen the raw stored value, exactly as it came out of localStorage
+ * @param currentVersion the running build's version
+ * @param changelog entries, newest first
+ */
+export function selectUnseenEntries(
+	lastSeen: string | null,
+	currentVersion: string,
+	changelog: ChangelogEntry[],
+): ChangelogEntry[] {
+	if (lastSeen === currentVersion) {
+		return [];
+	}
+
+	// The highest version this build could legitimately have written: normally the newest
+	// changelog entry, but the build's own version when a release ships without an entry —
+	// as v0.1.1 originally did.
+	const newestEntry = changelog[0]?.version ?? currentVersion;
+	const highestExpected = semverGt(currentVersion, newestEntry) ? currentVersion : newestEntry;
+
+	// A stored version ahead of that cannot have come from the app's own history. Builds
+	// up to 0.2.0 wrote a hard-coded "1.0.0" here (#246), so treating that value as
+	// "already seen" would suppress the overlay until the app genuinely reached 1.0.0.
+	// Fall back to first-launch behavior, which self-heals as soon as the user dismisses.
+	const usable =
+		lastSeen !== null && SEMVER_PATTERN.test(lastSeen) && !semverGt(lastSeen, highestExpected)
+			? lastSeen
+			: null;
+
+	return usable !== null
+		? changelog.filter((entry) => semverGt(entry.version, usable))
+		: changelog.slice(0, 1);
+}
+
+/**
+ * Changelog entries the user has not acknowledged yet, newest first, or an empty array
+ * when there is nothing to announce.
+ */
+export function unseenChangelogEntries(): ChangelogEntry[] {
+	return selectUnseenEntries(
+		localStorage.getItem(WHATS_NEW_STORAGE_KEY),
+		CURRENT_VERSION,
+		CHANGELOG,
+	);
+}
+
+/** Records the running version as acknowledged, so the overlay stays closed until the next one. */
+export function markChangelogSeen(): void {
+	localStorage.setItem(WHATS_NEW_STORAGE_KEY, CURRENT_VERSION);
+}

--- a/src/lib/whats-new.ts
+++ b/src/lib/whats-new.ts
@@ -60,7 +60,7 @@ export const CHANGELOG: ChangelogEntry[] = [
 			"A proposed change is re-checked against the file format before it lands, and refused if the result would not reopen or if the document moved underneath it",
 			"AI can read your current document and the component catalog before it suggests anything",
 			"Refreshed OpenAI and Anthropic model catalog",
-			"Import existing models from Microsoft Threat Modeling Tool .tm7 files",
+			"Import existing models from Microsoft Threat Modeling Tool .tm7 files (desktop app)",
 			"Open several models at once in a tabbed workspace",
 			"Browser documents survive a refresh — work is saved locally as you go",
 			"Browser API keys are stored as ciphertext instead of clear text, and the web app now ships a strict Content-Security-Policy",

--- a/src/lib/whats-new.ts
+++ b/src/lib/whats-new.ts
@@ -7,7 +7,14 @@
  * import a component module to answer it, and neither side re-derives the answer.
  */
 
-/** Where the last acknowledged version is recorded. Also read by the E2E fixtures. */
+/**
+ * Where the last acknowledged version is recorded.
+ *
+ * `e2e/fixtures.ts` and `e2e/onboarding-auto-start.spec.ts` repeat this literal rather than
+ * importing it: they run inside `addInitScript` in page context, where this module's
+ * build-time `__APP_VERSION__` define does not exist. Renaming this constant means editing
+ * those two call sites too, or every browser spec silently starts fighting the overlay.
+ */
 export const WHATS_NEW_STORAGE_KEY = "threatforge-last-seen-version";
 
 /**
@@ -50,7 +57,7 @@ export const CHANGELOG: ChangelogEntry[] = [
 		date: "2026-07-26",
 		changes: [
 			"AI edits the model through native tool calls, so a suggestion arrives as a real change to elements, flows, and threats rather than an action block the app has to re-parse",
-			"You approve each proposed change on its own, and anything applied is a single undo away",
+			"A proposed change is re-checked against the file format before it lands, and refused if the result would not reopen or if the document moved underneath it",
 			"AI can read your current document and the component catalog before it suggests anything",
 			"Refreshed OpenAI and Anthropic model catalog",
 			"Import existing models from Microsoft Threat Modeling Tool .tm7 files",
@@ -103,7 +110,7 @@ export const CHANGELOG: ChangelogEntry[] = [
  *
  * Split out from the storage read so the version-comparison rules can be tested against
  * versions this build does not have — `__APP_VERSION__` is substituted at build time, so
- * a test cannot vary it.
+ * neither a test nor `vi.stubGlobal` can vary it.
  *
  * @param lastSeen the raw stored value, exactly as it came out of localStorage
  * @param currentVersion the running build's version
@@ -118,18 +125,15 @@ export function selectUnseenEntries(
 		return [];
 	}
 
-	// The highest version this build could legitimately have written: normally the newest
-	// changelog entry, but the build's own version when a release ships without an entry —
-	// as v0.1.1 originally did.
-	const newestEntry = changelog[0]?.version ?? currentVersion;
-	const highestExpected = semverGt(currentVersion, newestEntry) ? currentVersion : newestEntry;
-
-	// A stored version ahead of that cannot have come from the app's own history. Builds
-	// up to 0.2.0 wrote a hard-coded "1.0.0" here (#246), so treating that value as
-	// "already seen" would suppress the overlay until the app genuinely reached 1.0.0.
-	// Fall back to first-launch behavior, which self-heals as soon as the user dismisses.
+	// A stored version above the newest entry cannot have come from the app's own history,
+	// because a build never announces a version it has no entry for — `whats-new.test.ts`
+	// fails the build when the newest entry and the running version disagree. Builds up to
+	// 0.2.0 wrote a hard-coded "1.0.0" here (#246), so treating that value as "already
+	// seen" would suppress the overlay until the app genuinely reached 1.0.0. Fall back to
+	// first-launch behavior, which self-heals as soon as the user dismisses.
+	const newestKnown = changelog[0]?.version ?? currentVersion;
 	const usable =
-		lastSeen !== null && SEMVER_PATTERN.test(lastSeen) && !semverGt(lastSeen, highestExpected)
+		lastSeen !== null && SEMVER_PATTERN.test(lastSeen) && !semverGt(lastSeen, newestKnown)
 			? lastSeen
 			: null;
 

--- a/src/pages/downloads-page.test.tsx
+++ b/src/pages/downloads-page.test.tsx
@@ -1,9 +1,9 @@
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { LatestRelease, OsType } from "@/lib/github-releases";
-import { FIRST_RUN_HELP_ANCHOR, FIRST_RUN_HELP_PATH } from "./shared/first-run-help";
+import { FIRST_RUN_HELP_ANCHOR } from "./shared/first-run-help";
 
 const mockRelease: LatestRelease = {
 	version: "v0.2.0",
@@ -51,6 +51,15 @@ function renderDownloadsPage() {
 }
 
 describe("DownloadsPage", () => {
+	// Every case below drives these module-level mocks; restoring them here stops one
+	// case's OS or error state from silently deciding the next case's outcome.
+	afterEach(() => {
+		mockDetectedOs = "macos";
+		mockIsLoading = false;
+		mockError = null;
+		mockReleaseData = mockRelease;
+	});
+
 	it("renders page heading", () => {
 		renderDownloadsPage();
 		expect(screen.getByText("Download Threat Forge")).toBeInTheDocument();
@@ -132,28 +141,43 @@ describe("DownloadsPage", () => {
 		};
 		renderDownloadsPage();
 		expect(screen.getByText("No builds available yet.")).toBeInTheDocument();
-
-		// Reset
-		mockReleaseData = mockRelease;
 	});
 
-	describe("unsigned-build guidance", () => {
+	describe("first-run guidance", () => {
 		it("links to the first-run help section on the support page", () => {
 			renderDownloadsPage();
 			expect(screen.getByRole("link", { name: "How to open it" })).toHaveAttribute(
 				"href",
-				`${FIRST_RUN_HELP_PATH}#${FIRST_RUN_HELP_ANCHOR}`,
+				`/support#${FIRST_RUN_HELP_ANCHOR}`,
 			);
 		});
 
-		it("warns about the first-launch block regardless of which platform is detected", () => {
+		it("shows the guidance regardless of which platform is detected", () => {
 			for (const os of ["macos", "windows", "linux", "unknown"] as const) {
 				mockDetectedOs = os;
 				const { unmount } = renderDownloadsPage();
-				expect(screen.getByText(/not signed yet/)).toBeInTheDocument();
+				expect(screen.getByRole("link", { name: "How to open it" })).toBeInTheDocument();
 				unmount();
 			}
-			mockDetectedOs = "macos";
+		});
+
+		it("still shows the guidance when the release lookup fails", () => {
+			// The failure branch sends people to GitHub for the same builds, so the advice
+			// about opening them has to survive it.
+			mockReleaseData = null;
+			mockError = "network";
+			renderDownloadsPage();
+
+			expect(screen.getByRole("link", { name: "Download from GitHub" })).toBeInTheDocument();
+			expect(screen.getByRole("link", { name: "How to open it" })).toBeInTheDocument();
+		});
+
+		it("withholds the guidance while the release is still loading", () => {
+			mockReleaseData = null;
+			mockIsLoading = true;
+			renderDownloadsPage();
+
+			expect(screen.queryByRole("link", { name: "How to open it" })).not.toBeInTheDocument();
 		});
 	});
 });

--- a/src/pages/downloads-page.test.tsx
+++ b/src/pages/downloads-page.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 
 import type { LatestRelease, OsType } from "@/lib/github-releases";
+import { FIRST_RUN_HELP_ANCHOR, FIRST_RUN_HELP_PATH } from "./shared/first-run-help";
 
 const mockRelease: LatestRelease = {
 	version: "v0.2.0",
@@ -134,5 +135,25 @@ describe("DownloadsPage", () => {
 
 		// Reset
 		mockReleaseData = mockRelease;
+	});
+
+	describe("unsigned-build guidance", () => {
+		it("links to the first-run help section on the support page", () => {
+			renderDownloadsPage();
+			expect(screen.getByRole("link", { name: "How to open it" })).toHaveAttribute(
+				"href",
+				`${FIRST_RUN_HELP_PATH}#${FIRST_RUN_HELP_ANCHOR}`,
+			);
+		});
+
+		it("warns about the first-launch block regardless of which platform is detected", () => {
+			for (const os of ["macos", "windows", "linux", "unknown"] as const) {
+				mockDetectedOs = os;
+				const { unmount } = renderDownloadsPage();
+				expect(screen.getByText(/not signed yet/)).toBeInTheDocument();
+				unmount();
+			}
+			mockDetectedOs = "macos";
+		});
 	});
 });

--- a/src/pages/downloads-page.tsx
+++ b/src/pages/downloads-page.tsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 import { useLatestRelease } from "@/hooks/use-latest-release";
 import type { OsType, PlatformAssets, ReleaseAsset } from "@/lib/github-releases";
 import { formatBytes } from "@/lib/github-releases";
-import { FIRST_RUN_HELP_ANCHOR, FIRST_RUN_HELP_PATH } from "./shared/first-run-help";
+import { FIRST_RUN_HELP_ANCHOR } from "./shared/first-run-help";
 import { PageShell } from "./shared/page-shell";
 
 const GITHUB_RELEASES_URL = "https://github.com/exit-zero-labs/threat-forge/releases";
@@ -62,6 +62,17 @@ export function DownloadsPage() {
 
 					{release && <AllPlatforms assets={release.assets} detectedOs={detectedOs} />}
 
+					{/* Rendered for the resolved and the failed branch alike: the failed branch still
+					    sends people to GitHub to download the very same builds. */}
+					{!isLoading && (
+						<p className="mt-6 text-center text-sm text-muted-foreground">
+							Your operating system may block or flag the app the first time you open it.{" "}
+							<Link to={`/support#${FIRST_RUN_HELP_ANCHOR}`} className="underline">
+								How to open it
+							</Link>
+						</p>
+					)}
+
 					<div className="mt-16 text-center">
 						<p className="text-sm text-muted-foreground">
 							Or{" "}
@@ -113,16 +124,6 @@ function AllPlatforms({ assets, detectedOs }: { assets: PlatformAssets; detected
 					highlighted={detectedOs === "linux"}
 				/>
 			</div>
-			{/* Sits under the grid rather than under the one highlighted download button, because
-			    every platform blocks these unsigned builds and the button only renders for the
-			    detected OS. */}
-			<p className="mt-6 text-center text-sm text-muted-foreground">
-				These builds are not signed yet, so your operating system will warn you the first time you
-				open the app.{" "}
-				<Link to={`${FIRST_RUN_HELP_PATH}#${FIRST_RUN_HELP_ANCHOR}`} className="underline">
-					How to open it
-				</Link>
-			</p>
 		</div>
 	);
 }

--- a/src/pages/downloads-page.tsx
+++ b/src/pages/downloads-page.tsx
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom";
 import { useLatestRelease } from "@/hooks/use-latest-release";
 import type { OsType, PlatformAssets, ReleaseAsset } from "@/lib/github-releases";
 import { formatBytes } from "@/lib/github-releases";
+import { FIRST_RUN_HELP_ANCHOR, FIRST_RUN_HELP_PATH } from "./shared/first-run-help";
 import { PageShell } from "./shared/page-shell";
 
 const GITHUB_RELEASES_URL = "https://github.com/exit-zero-labs/threat-forge/releases";
@@ -112,6 +113,16 @@ function AllPlatforms({ assets, detectedOs }: { assets: PlatformAssets; detected
 					highlighted={detectedOs === "linux"}
 				/>
 			</div>
+			{/* Sits under the grid rather than under the one highlighted download button, because
+			    every platform blocks these unsigned builds and the button only renders for the
+			    detected OS. */}
+			<p className="mt-6 text-center text-sm text-muted-foreground">
+				These builds are not signed yet, so your operating system will warn you the first time you
+				open the app.{" "}
+				<Link to={`${FIRST_RUN_HELP_PATH}#${FIRST_RUN_HELP_ANCHOR}`} className="underline">
+					How to open it
+				</Link>
+			</p>
 		</div>
 	);
 }

--- a/src/pages/shared/first-run-help.ts
+++ b/src/pages/shared/first-run-help.ts
@@ -1,10 +1,7 @@
 /**
- * The one place the downloads page and the support page agree on where first-run
- * help lives, so the link and the section it targets cannot drift apart.
+ * The anchor of the first-run help section on the support page.
  *
- * This exists only while the desktop builds are unsigned (#50, #51). When Developer ID
- * notarization and Windows signing land, delete this module along with the section it
- * anchors and the line on the downloads page that points at it.
+ * Shared so the downloads page cannot link to a fragment the support page has renamed —
+ * a broken fragment scrolls nowhere and says nothing, so nobody notices it rot.
  */
-export const FIRST_RUN_HELP_PATH = "/support";
 export const FIRST_RUN_HELP_ANCHOR = "opening-for-the-first-time";

--- a/src/pages/shared/first-run-help.ts
+++ b/src/pages/shared/first-run-help.ts
@@ -1,0 +1,10 @@
+/**
+ * The one place the downloads page and the support page agree on where first-run
+ * help lives, so the link and the section it targets cannot drift apart.
+ *
+ * This exists only while the desktop builds are unsigned (#50, #51). When Developer ID
+ * notarization and Windows signing land, delete this module along with the section it
+ * anchors and the line on the downloads page that points at it.
+ */
+export const FIRST_RUN_HELP_PATH = "/support";
+export const FIRST_RUN_HELP_ANCHOR = "opening-for-the-first-time";

--- a/src/pages/support-page.test.tsx
+++ b/src/pages/support-page.test.tsx
@@ -41,9 +41,10 @@ describe("SupportPage", () => {
 		});
 
 		it("scopes the missing-signature explanation to macOS", () => {
-			// Windows installers are signed via Azure Trusted Signing, so a blanket
-			// "not code-signed" claim would be false for the platform most likely to
-			// show a scary dialog.
+			// Azure Trusted Signing is wired into the Windows build, so a blanket
+			// "not code-signed" claim would be wrong for the platform most likely to show
+			// a scary dialog. (Whether it succeeds is unverified until a real artifact is
+			// checked — see the #50 waiver in the release runbook.)
 			renderSupportPage();
 			expect(
 				screen.getByText(/macOS builds are not signed with an Apple Developer ID/),
@@ -62,16 +63,6 @@ describe("SupportPage", () => {
 			renderSupportPage();
 			expect(screen.getByText(/Linux does not block unsigned applications/)).toBeInTheDocument();
 			expect(screen.getByText("chmod +x ./Threat.Forge_*.AppImage")).toBeInTheDocument();
-		});
-
-		it("makes each command block keyboard-reachable", () => {
-			// The blocks scroll horizontally, so a keyboard user must be able to focus one
-			// to read a command they are about to paste into a terminal.
-			renderSupportPage();
-			const region = screen.getByRole("region", {
-				name: 'Command: xattr -dr com.apple.quarantine "/Applications/Threat Forge.app"',
-			});
-			expect(region).toHaveAttribute("tabindex", "0");
 		});
 
 		it("gives the macOS quarantine command verbatim", () => {

--- a/src/pages/support-page.test.tsx
+++ b/src/pages/support-page.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { FIRST_RUN_HELP_ANCHOR } from "./shared/first-run-help";
+import { SupportPage } from "./support-page";
+
+// jsdom does not implement scrollIntoView; give every test a spyable stub.
+Element.prototype.scrollIntoView = vi.fn();
+
+function renderSupportPage(initialEntry = "/support") {
+	return render(
+		<MemoryRouter initialEntries={[initialEntry]}>
+			<SupportPage />
+		</MemoryRouter>,
+	);
+}
+
+describe("SupportPage", () => {
+	beforeEach(() => {
+		vi.mocked(Element.prototype.scrollIntoView).mockClear();
+	});
+
+	it("renders the page heading", () => {
+		renderSupportPage();
+		expect(screen.getByRole("heading", { level: 1, name: "Support" })).toBeInTheDocument();
+	});
+
+	describe("first-run guidance", () => {
+		it("explains that an unsigned build is not a broken download", () => {
+			renderSupportPage();
+			const section = screen.getByRole("heading", {
+				level: 2,
+				name: "Opening Threat Forge for the first time",
+			});
+			expect(section).toBeInTheDocument();
+			expect(screen.getByText(/not yet code-signed/)).toBeInTheDocument();
+			expect(screen.getByText(/Nothing is wrong with your download/)).toBeInTheDocument();
+		});
+
+		it("gives the macOS quarantine command verbatim", () => {
+			renderSupportPage();
+			expect(
+				screen.getByText('xattr -dr com.apple.quarantine "/Applications/Threat Forge.app"'),
+			).toBeInTheDocument();
+		});
+
+		it("covers every platform the release workflow builds for", () => {
+			renderSupportPage();
+			for (const platform of ["macOS", "Windows", "Linux"]) {
+				expect(screen.getByRole("heading", { level: 3, name: platform })).toBeInTheDocument();
+			}
+		});
+
+		it("anchors the section at the id the downloads page links to", () => {
+			const { container } = renderSupportPage();
+			expect(container.querySelector(`#${FIRST_RUN_HELP_ANCHOR}`)).not.toBeNull();
+		});
+	});
+
+	describe("hash scrolling", () => {
+		it("scrolls the targeted section into view", () => {
+			renderSupportPage(`/support#${FIRST_RUN_HELP_ANCHOR}`);
+			expect(Element.prototype.scrollIntoView).toHaveBeenCalledTimes(1);
+		});
+
+		it("does not scroll when the URL carries no hash", () => {
+			renderSupportPage();
+			expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
+		});
+
+		it("does not throw when the hash names no section on the page", () => {
+			expect(() => renderSupportPage("/support#no-such-section")).not.toThrow();
+			expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/pages/support-page.test.tsx
+++ b/src/pages/support-page.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { useSettingsStore } from "@/stores/settings-store";
 import { FIRST_RUN_HELP_ANCHOR } from "./shared/first-run-help";
 import { SupportPage } from "./support-page";
 
@@ -19,6 +20,7 @@ function renderSupportPage(initialEntry = "/support") {
 describe("SupportPage", () => {
 	beforeEach(() => {
 		vi.mocked(Element.prototype.scrollIntoView).mockClear();
+		useSettingsStore.getState().updateSetting("reduceMotion", false);
 	});
 
 	it("renders the page heading", () => {
@@ -27,15 +29,39 @@ describe("SupportPage", () => {
 	});
 
 	describe("first-run guidance", () => {
-		it("explains that an unsigned build is not a broken download", () => {
+		it("explains that a blocked first launch is not a broken download", () => {
 			renderSupportPage();
-			const section = screen.getByRole("heading", {
-				level: 2,
-				name: "Opening Threat Forge for the first time",
-			});
-			expect(section).toBeInTheDocument();
-			expect(screen.getByText(/not yet code-signed/)).toBeInTheDocument();
+			expect(
+				screen.getByRole("heading", {
+					level: 2,
+					name: "Opening Threat Forge for the first time",
+				}),
+			).toBeInTheDocument();
 			expect(screen.getByText(/Nothing is wrong with your download/)).toBeInTheDocument();
+		});
+
+		it("scopes the missing-signature explanation to macOS", () => {
+			// Windows installers are signed via Azure Trusted Signing, so a blanket
+			// "not code-signed" claim would be false for the platform most likely to
+			// show a scary dialog.
+			renderSupportPage();
+			expect(
+				screen.getByText(/macOS builds are not signed with an Apple Developer ID/),
+			).toBeInTheDocument();
+			expect(
+				screen.getByText(/publisher reputation is still being established/),
+			).toBeInTheDocument();
+		});
+
+		it("says the Open Anyway override does not apply to the damaged-file message", () => {
+			renderSupportPage();
+			expect(screen.getByText(/not offered for the .damaged. message above/)).toBeInTheDocument();
+		});
+
+		it("describes Linux as needing an execute bit rather than being blocked", () => {
+			renderSupportPage();
+			expect(screen.getByText(/Linux does not block unsigned applications/)).toBeInTheDocument();
+			expect(screen.getByText("chmod +x ./Threat.Forge_*.AppImage")).toBeInTheDocument();
 		});
 
 		it("gives the macOS quarantine command verbatim", () => {
@@ -60,8 +86,24 @@ describe("SupportPage", () => {
 
 	describe("hash scrolling", () => {
 		it("scrolls the targeted section into view", () => {
+			const { container } = renderSupportPage(`/support#${FIRST_RUN_HELP_ANCHOR}`);
+
+			const scroll = vi.mocked(Element.prototype.scrollIntoView);
+			expect(scroll).toHaveBeenCalledTimes(1);
+			// Asserting the receiver, not just the call: scrolling some other element
+			// into view would satisfy a bare call-count assertion.
+			expect(scroll.mock.instances[0]).toBe(container.querySelector(`#${FIRST_RUN_HELP_ANCHOR}`));
+			expect(scroll).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
+		});
+
+		it("jumps without animating when the user has asked for reduced motion", () => {
+			useSettingsStore.getState().updateSetting("reduceMotion", true);
 			renderSupportPage(`/support#${FIRST_RUN_HELP_ANCHOR}`);
-			expect(Element.prototype.scrollIntoView).toHaveBeenCalledTimes(1);
+
+			expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({
+				behavior: "auto",
+				block: "start",
+			});
 		});
 
 		it("does not scroll when the URL carries no hash", () => {

--- a/src/pages/support-page.test.tsx
+++ b/src/pages/support-page.test.tsx
@@ -64,6 +64,16 @@ describe("SupportPage", () => {
 			expect(screen.getByText("chmod +x ./Threat.Forge_*.AppImage")).toBeInTheDocument();
 		});
 
+		it("makes each command block keyboard-reachable", () => {
+			// The blocks scroll horizontally, so a keyboard user must be able to focus one
+			// to read a command they are about to paste into a terminal.
+			renderSupportPage();
+			const region = screen.getByRole("region", {
+				name: 'Command: xattr -dr com.apple.quarantine "/Applications/Threat Forge.app"',
+			});
+			expect(region).toHaveAttribute("tabindex", "0");
+		});
+
 		it("gives the macOS quarantine command verbatim", () => {
 			renderSupportPage();
 			expect(

--- a/src/pages/support-page.tsx
+++ b/src/pages/support-page.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, useEffect } from "react";
 import { useLocation } from "react-router-dom";
+import { useSettingsStore } from "@/stores/settings-store";
 import { FIRST_RUN_HELP_ANCHOR } from "./shared/first-run-help";
 import { PageShell } from "./shared/page-shell";
 
@@ -118,7 +119,8 @@ function useHashScroll(): void {
 		// A hash is arbitrary user-controlled input; querying by id avoids handing it
 		// to a selector parser and simply finds nothing when it names no section.
 		const target = document.getElementById(hash.slice(1));
-		target?.scrollIntoView({ behavior: "smooth", block: "start" });
+		const behavior = useSettingsStore.getState().settings.reduceMotion ? "auto" : "smooth";
+		target?.scrollIntoView?.({ behavior, block: "start" });
 	}, [hash]);
 }
 
@@ -131,10 +133,10 @@ function Command({ children }: { children: string }) {
 }
 
 /**
- * First-run guidance for the unsigned desktop builds. Remove this section, its anchor
- * module, and the downloads-page line that points here once macOS notarization (#51)
- * and Windows signing (#50) ship — at that point the operating systems stop objecting
- * and this advice becomes wrong rather than merely unnecessary.
+ * First-run guidance for the desktop builds. Remove this section, its anchor module, and
+ * the downloads-page line that points here once macOS notarization (#51) and Windows
+ * signing verification (#50) are complete — at that point the operating systems stop
+ * objecting and this advice becomes wrong rather than merely unnecessary.
  */
 function FirstRunSection() {
 	return (
@@ -143,37 +145,37 @@ function FirstRunSection() {
 				Opening Threat Forge for the first time
 			</h2>
 			<p className="mt-3 text-sm leading-relaxed text-muted-foreground">
-				Threat Forge desktop builds are not yet code-signed. Your operating system cannot confirm
-				who produced them, so it blocks the first launch. Nothing is wrong with your download —
-				these steps are how you open an unsigned application on each platform.
+				A freshly published desktop build can be blocked or flagged the first time you open it.
+				Nothing is wrong with your download. Here is what each platform does and how to get past it.
 			</p>
 
 			<div className="mt-6 space-y-6">
 				<div>
 					<h3 className="font-medium text-foreground">macOS</h3>
 					<p className="mt-1 text-sm leading-relaxed text-muted-foreground">
-						macOS may say Threat Forge <em>&ldquo;is damaged and can&apos;t be opened&rdquo;</em>.
-						It is not damaged. macOS quarantines everything downloaded from the internet, and with
-						no Apple Developer ID signature to check, Gatekeeper refuses the app instead of offering
-						the usual override. Move Threat Forge to your Applications folder, then run this once in
-						Terminal to clear the quarantine flag:
+						The macOS builds are not signed with an Apple Developer ID or notarized yet, so macOS
+						may report that Threat Forge <em>&ldquo;is damaged and can&apos;t be opened&rdquo;</em>.
+						It is not damaged — macOS quarantines everything downloaded from the internet, and with
+						no signature to evaluate, Gatekeeper refuses the app outright. Move Threat Forge to your
+						Applications folder, then run this once in Terminal to clear the quarantine flag:
 					</p>
 					<Command>
 						xattr -dr com.apple.quarantine &quot;/Applications/Threat Forge.app&quot;
 					</Command>
 					<p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-						To avoid Terminal, try to open the app first, then go to System Settings &rarr; Privacy
-						&amp; Security, scroll to the Security section, and choose{" "}
-						<strong className="font-medium text-foreground">Open Anyway</strong> next to Threat
-						Forge.
+						If macOS instead shows the milder &ldquo;unidentified developer&rdquo; prompt, open
+						System Settings &rarr; Privacy &amp; Security, scroll to the Security section, and
+						choose <strong className="font-medium text-foreground">Open Anyway</strong>. That option
+						is not offered for the &ldquo;damaged&rdquo; message above, which is why the command
+						exists.
 					</p>
 				</div>
 
 				<div>
 					<h3 className="font-medium text-foreground">Windows</h3>
 					<p className="mt-1 text-sm leading-relaxed text-muted-foreground">
-						SmartScreen shows <em>&ldquo;Windows protected your PC&rdquo;</em> because the
-						installer&apos;s publisher reputation is not yet established. Choose{" "}
+						SmartScreen may show <em>&ldquo;Windows protected your PC&rdquo;</em> because the
+						installer&apos;s publisher reputation is still being established. Choose{" "}
 						<strong className="font-medium text-foreground">More info</strong>, then{" "}
 						<strong className="font-medium text-foreground">Run anyway</strong>.
 					</p>
@@ -195,10 +197,8 @@ function FirstRunSection() {
 			</div>
 
 			<p className="mt-6 text-sm leading-relaxed text-muted-foreground">
-				Every release is built in the open by GitHub Actions from a public tagged commit, so you can
-				read the source and the build workflow before you run anything. Signed and notarized builds
-				are planned; until then this page stays honest about what your operating system is telling
-				you.{" "}
+				Every release is built by GitHub Actions from a public tagged commit, so you can read the
+				source and the build workflow before you run anything.{" "}
 				<a
 					href={`${GITHUB_URL}/releases`}
 					target="_blank"

--- a/src/pages/support-page.tsx
+++ b/src/pages/support-page.tsx
@@ -126,19 +126,9 @@ function useHashScroll(): void {
 
 function Command({ children }: { children: string }) {
 	return (
-		// The command is wrapped in a named region so the horizontally scrollable box is
-		// reachable by Tab (WCAG 2.1.1) — these commands overflow at narrow widths, and a
-		// keyboard user has to be able to read the whole of one before running it. Same
-		// shape as the palette fix in 95aa1bb: a named <section>, not a tabbable <code>,
-		// because <code> has no role to hang an accessible name on.
-		<section
-			aria-label={`Command: ${children}`}
-			// biome-ignore lint/a11y/noNoninteractiveTabindex: a scrollable region must be focusable for keyboard access
-			tabIndex={0}
-			className="mt-2 block overflow-x-auto rounded-md border border-border/50 bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-tf-signal"
-		>
-			<code className="block px-3 py-2 font-mono text-xs text-foreground">{children}</code>
-		</section>
+		<code className="mt-2 block overflow-x-auto rounded-md border border-border/50 bg-secondary px-3 py-2 font-mono text-xs text-foreground">
+			{children}
+		</code>
 	);
 }
 
@@ -168,8 +158,8 @@ function FirstRunSection() {
 					<p className="mt-1 text-sm leading-relaxed text-muted-foreground">
 						The macOS builds are not signed with an Apple Developer ID or notarized yet, so macOS
 						may report that Threat Forge <em>&ldquo;is damaged and can&apos;t be opened&rdquo;</em>.
-						It is not damaged — macOS quarantines everything downloaded from the internet, and with
-						no signature to evaluate, Gatekeeper refuses the app outright. Move Threat Forge to your
+						It is not damaged — macOS quarantines apps downloaded through a browser, and with no
+						signature to evaluate, Gatekeeper refuses the app outright. Move Threat Forge to your
 						Applications folder, then run this once in Terminal to clear the quarantine flag:
 					</p>
 					<Command>

--- a/src/pages/support-page.tsx
+++ b/src/pages/support-page.tsx
@@ -158,7 +158,7 @@ function FirstRunSection() {
 					<p className="mt-1 text-sm leading-relaxed text-muted-foreground">
 						The macOS builds are not signed with an Apple Developer ID or notarized yet, so macOS
 						may report that Threat Forge <em>&ldquo;is damaged and can&apos;t be opened&rdquo;</em>.
-						It is not damaged — macOS quarantines apps downloaded through a browser, and with no
+						It is not damaged — macOS quarantines apps arriving from a browser or Mail, and with no
 						signature to evaluate, Gatekeeper refuses the app outright. Move Threat Forge to your
 						Applications folder, then run this once in Terminal to clear the quarantine flag:
 					</p>

--- a/src/pages/support-page.tsx
+++ b/src/pages/support-page.tsx
@@ -1,4 +1,6 @@
-import type { ReactNode } from "react";
+import { type ReactNode, useEffect } from "react";
+import { useLocation } from "react-router-dom";
+import { FIRST_RUN_HELP_ANCHOR } from "./shared/first-run-help";
 import { PageShell } from "./shared/page-shell";
 
 const GITHUB_URL = "https://github.com/exit-zero-labs/threat-forge";
@@ -35,6 +37,8 @@ const FAQ_ITEMS = [
 ] as const;
 
 export function SupportPage() {
+	useHashScroll();
+
 	return (
 		<PageShell title="Support — Threat Forge">
 			<div className="mx-auto max-w-3xl px-6 py-20">
@@ -44,6 +48,8 @@ export function SupportPage() {
 				</p>
 
 				<div className="mt-10 space-y-10">
+					<FirstRunSection />
+
 					{/* Contact channels */}
 					<section>
 						<h2 className="text-xl font-semibold text-foreground">Contact</h2>
@@ -94,6 +100,115 @@ export function SupportPage() {
 				</div>
 			</div>
 		</PageShell>
+	);
+}
+
+/**
+ * React Router does not scroll to the fragment of a URL it navigates to, so an
+ * incoming `/support#opening-for-the-first-time` link would otherwise land silently
+ * at the top of the page and leave the reader to hunt for the section.
+ */
+function useHashScroll(): void {
+	const { hash } = useLocation();
+
+	useEffect(() => {
+		if (!hash) {
+			return;
+		}
+		// A hash is arbitrary user-controlled input; querying by id avoids handing it
+		// to a selector parser and simply finds nothing when it names no section.
+		const target = document.getElementById(hash.slice(1));
+		target?.scrollIntoView({ behavior: "smooth", block: "start" });
+	}, [hash]);
+}
+
+function Command({ children }: { children: string }) {
+	return (
+		<code className="mt-2 block overflow-x-auto rounded-md border border-border/50 bg-secondary px-3 py-2 font-mono text-xs text-foreground">
+			{children}
+		</code>
+	);
+}
+
+/**
+ * First-run guidance for the unsigned desktop builds. Remove this section, its anchor
+ * module, and the downloads-page line that points here once macOS notarization (#51)
+ * and Windows signing (#50) ship — at that point the operating systems stop objecting
+ * and this advice becomes wrong rather than merely unnecessary.
+ */
+function FirstRunSection() {
+	return (
+		<section id={FIRST_RUN_HELP_ANCHOR} className="scroll-mt-24">
+			<h2 className="text-xl font-semibold text-foreground">
+				Opening Threat Forge for the first time
+			</h2>
+			<p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+				Threat Forge desktop builds are not yet code-signed. Your operating system cannot confirm
+				who produced them, so it blocks the first launch. Nothing is wrong with your download —
+				these steps are how you open an unsigned application on each platform.
+			</p>
+
+			<div className="mt-6 space-y-6">
+				<div>
+					<h3 className="font-medium text-foreground">macOS</h3>
+					<p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+						macOS may say Threat Forge <em>&ldquo;is damaged and can&apos;t be opened&rdquo;</em>.
+						It is not damaged. macOS quarantines everything downloaded from the internet, and with
+						no Apple Developer ID signature to check, Gatekeeper refuses the app instead of offering
+						the usual override. Move Threat Forge to your Applications folder, then run this once in
+						Terminal to clear the quarantine flag:
+					</p>
+					<Command>
+						xattr -dr com.apple.quarantine &quot;/Applications/Threat Forge.app&quot;
+					</Command>
+					<p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+						To avoid Terminal, try to open the app first, then go to System Settings &rarr; Privacy
+						&amp; Security, scroll to the Security section, and choose{" "}
+						<strong className="font-medium text-foreground">Open Anyway</strong> next to Threat
+						Forge.
+					</p>
+				</div>
+
+				<div>
+					<h3 className="font-medium text-foreground">Windows</h3>
+					<p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+						SmartScreen shows <em>&ldquo;Windows protected your PC&rdquo;</em> because the
+						installer&apos;s publisher reputation is not yet established. Choose{" "}
+						<strong className="font-medium text-foreground">More info</strong>, then{" "}
+						<strong className="font-medium text-foreground">Run anyway</strong>.
+					</p>
+				</div>
+
+				<div>
+					<h3 className="font-medium text-foreground">Linux</h3>
+					<p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+						Linux does not block unsigned applications, but the AppImage needs the execute bit set
+						before it will run:
+					</p>
+					<Command>chmod +x ./Threat.Forge_*.AppImage</Command>
+					<p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+						The Debian and RPM packages install normally:
+					</p>
+					<Command>sudo apt install ./Threat.Forge_*.deb</Command>
+					<Command>sudo dnf install ./Threat.Forge-*.rpm</Command>
+				</div>
+			</div>
+
+			<p className="mt-6 text-sm leading-relaxed text-muted-foreground">
+				Every release is built in the open by GitHub Actions from a public tagged commit, so you can
+				read the source and the build workflow before you run anything. Signed and notarized builds
+				are planned; until then this page stays honest about what your operating system is telling
+				you.{" "}
+				<a
+					href={`${GITHUB_URL}/releases`}
+					target="_blank"
+					rel="noopener noreferrer"
+					className="text-tf-signal hover:underline"
+				>
+					View releases on GitHub
+				</a>
+			</p>
+		</section>
 	);
 }
 

--- a/src/pages/support-page.tsx
+++ b/src/pages/support-page.tsx
@@ -133,10 +133,13 @@ function Command({ children }: { children: string }) {
 }
 
 /**
- * First-run guidance for the desktop builds. Remove this section, its anchor module, and
- * the downloads-page line that points here once macOS notarization (#51) and Windows
- * signing verification (#50) are complete — at that point the operating systems stop
- * objecting and this advice becomes wrong rather than merely unnecessary.
+ * First-run guidance for the desktop builds.
+ *
+ * The macOS and Windows subsections describe what an unsigned or low-reputation build does;
+ * once notarization (#51) and Windows signing verification (#50) are complete they become
+ * wrong rather than merely unnecessary, and they go — along with the downloads-page line that
+ * points here, if nothing else is left worth pointing at. The Linux subsection is about an
+ * execute bit rather than signing and stays correct regardless.
  */
 function FirstRunSection() {
 	return (

--- a/src/pages/support-page.tsx
+++ b/src/pages/support-page.tsx
@@ -126,9 +126,19 @@ function useHashScroll(): void {
 
 function Command({ children }: { children: string }) {
 	return (
-		<code className="mt-2 block overflow-x-auto rounded-md border border-border/50 bg-secondary px-3 py-2 font-mono text-xs text-foreground">
-			{children}
-		</code>
+		// The command is wrapped in a named region so the horizontally scrollable box is
+		// reachable by Tab (WCAG 2.1.1) — these commands overflow at narrow widths, and a
+		// keyboard user has to be able to read the whole of one before running it. Same
+		// shape as the palette fix in 95aa1bb: a named <section>, not a tabbable <code>,
+		// because <code> has no role to hang an accessible name on.
+		<section
+			aria-label={`Command: ${children}`}
+			// biome-ignore lint/a11y/noNoninteractiveTabindex: a scrollable region must be focusable for keyboard access
+			tabIndex={0}
+			className="mt-2 block overflow-x-auto rounded-md border border-border/50 bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-tf-signal"
+		>
+			<code className="block px-3 py-2 font-mono text-xs text-foreground">{children}</code>
+		</section>
 	);
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,14 @@
+import { readFileSync } from "node:fs";
 import { defineConfig } from "vitest/config";
+
+// Same source as vite.config.ts, so tests exercise the real version string rather
+// than a placeholder that no semver comparison could evaluate.
+const pkg = JSON.parse(readFileSync("./package.json", "utf-8")) as { version: string };
 
 // biome-ignore lint/style/noDefaultExport: Vitest requires default export
 export default defineConfig({
 	define: {
-		__APP_VERSION__: JSON.stringify("test"),
+		__APP_VERSION__: JSON.stringify(pkg.version),
 	},
 	test: {
 		globals: true,


### PR DESCRIPTION
Closes #245. Closes #246.

Prepares the first release since `v0.2.0` (98 commits back in March) and closes the two things that would have made that release land badly.

## Version bump

`package.json`, `package-lock.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, and `src-tauri/tauri.conf.json` move to `0.3.0`.

## First-run guidance for unsigned builds (#245)

Signing is deliberately deferred this cycle, so the published builds are unsigned. Today a visitor downloads the `.dmg`, opens it, and macOS says *"Threat Forge is damaged and can't be opened. You should move it to the Trash."* The app is fine — the download carries `com.apple.quarantine` and Gatekeeper has no Developer ID signature to evaluate — but the site said nothing, so the reasonable conclusion was that the download was broken.

`/downloads` now carries one muted line under the platform grid linking to an anchored install-troubleshooting section on `/support`. The line sits under the grid rather than under the highlighted download button because every platform is affected while that button only renders for the detected OS.

The `/support` section names the actual cause on each platform and gives the macOS quarantine command verbatim. React Router does not scroll to a URL fragment on navigation, so the page scrolls its own anchor into view — a link that landed at the top of `/support` would have been a link in name only.

The anchor id lives in a shared module so the link and its target cannot drift; the `/support` path itself is written inline at the one call site. `support-page.tsx` documents that the macOS and Windows guidance is deleted when #50 and #51 land — the Linux execute-bit note is not about signing and stays.

## The app no longer misreports its own version (#246)

`whats-new-overlay.tsx` hard-coded `CURRENT_VERSION = "1.0.0"` while the canvas badge, settings dialog, and site footer all read `__APP_VERSION__` from `package.json`. A released build opened with a **What's New** modal announcing **v1.0.0** and then showed **v0.2.0** in three other places in the same session. The changelog body attached to that "1.0.0" actually described the `v0.1.0` feature set.

The overlay now reads the same build define, and the changelog carries `0.3.0`, `0.2.0`, and `0.1.0` — versions that were really tagged.

One consequence needed handling rather than ignoring: every existing user who dismissed the old overlay has `"1.0.0"` in localStorage. Under a naive fix that value is "newer than everything," so the overlay would stay suppressed until the app genuinely reached 1.0.0. A stored version ahead of every version we know about is now treated as first launch, which self-heals on dismissal.

`useOnboardingTriggers` was answering the same question with its own approximation — *"is the storage key absent"* — which is only true on first launch and missed the upgrade case entirely, so an upgrading user could get the welcome tooltip stacked on the What's New modal. Both call one exported predicate now.

## Test-seam drift, closed

`e2e/fixtures.ts` and `e2e/onboarding-auto-start.spec.ts` seeded the same `"1.0.0"` literal to suppress the overlay, and suppression requires an exact match against the build define. Left alone, the next version bump would have silently parked every browser spec behind a modal. Both now read the version from `package.json` through `e2e/support/app-version.ts`.

`vitest.config.ts` defined `__APP_VERSION__` as `"test"`, which no semver comparison can evaluate; it reads `package.json` now, the same source `vite.config.ts` uses.

## Docs

The release runbook gained the `package-lock.json` step that `check-lockfile-registry.mjs` enforces and that the first attempt at this change tripped over, plus a correction: `__APP_VERSION__` carries the badge, settings dialog, and footer automatically, but the What's New overlay renders `entry.version` from a hand-maintained `CHANGELOG` and does **not** follow the bump. Step 2 previously said it did while step 3 said it didn't, so a releaser reading in order was told step 3 was unnecessary. A test now fails the build when the newest entry and the running version disagree.

## Verification

- `npm run ci:local` green (lint, types, 2100+ frontend tests, worker typecheck, `cargo fmt`, clippy, Rust tests, web build, Worker dry run).
- Full Playwright browser suite green: 110 passed. One run failed on a `net::ERR_ABORTED` for `/src/styles.css` caused by Vite HMR firing while files were edited mid-run; re-ran clean in isolation, and CI starts a fresh server so it cannot reproduce there.
- Verified against a local Wrangler serve of the production build: CSP header served on `/downloads`, `/api/latest-release` returns JSON, and the `/downloads` → `/support#opening-for-the-first-time` link scrolls the section to 96px below the sticky nav on both client-side navigation and direct load.

## Not verified by a reviewer

The macOS `xattr` instruction is stated from the documented Gatekeeper behavior; it has not been executed against a downloaded `v0.3.0` `.dmg`, because that artifact does not exist until this merges and the tag builds. Worth confirming during release smoke-testing.

