### PR TITLE
fix(test): count work instead of wall-clock time in the registry scale guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,29 @@ Under it the following still hold without exception:
 - owner validation is deferred, not waived — the merged PR remains the record the owner
   reviews, and anything a reviewer could not verify is called out in the PR body
 
+## Local machine resources
+
+Agent work runs on the owner's workstation, shared with their editor, their browser, and other
+concurrent agent sessions across other repositories. CPU, memory, and process count are a shared
+budget, not a free resource. A saturated machine is an outage for the owner.
+
+- **Never spawn synthetic load.** No CPU burners, busy-loops, `stress`/`yes` processes, or
+  parallel job fans to simulate a loaded CI runner. If a timing assertion only fails under
+  manufactured contention, that is evidence the assertion measures machine speed rather than a
+  property of the code — fix the assertion instead of reproducing the noise. This rule is
+  written from an incident: a review agent spawned 34 detached `node -e` busy-loops to model CI
+  contention and drove the workstation to load 118 with 0% idle.
+- **Never detach a process you will not reap.** Anything backgrounded during a task is stopped
+  before that task reports. A process reparented to `launchd` (PPID 1) outlives the agent that
+  started it and nobody sweeps it. Long-lived servers — `wrangler dev`, `vite preview`,
+  Playwright servers — are stopped when the work that needed them ends.
+- **Do not run the full suite in parallel lanes.** `npm run ci:local` and a bare `vitest run`
+  are whole-machine operations. Concurrent review lanes must use the smallest targeted selector;
+  only one lane runs the full gate, and preferably the orchestrator runs it once on their behalf.
+- **Prefer a cheaper measurement.** Reach for a ratio, a complexity property, or a counted
+  operation before reaching for wall-clock timing under load. See
+  `src/lib/registry/registry-scale.test.ts` for the shape this should take.
+
 ## Engineering workflow
 
 1. **Triage:** shape the issue and populate Project 2 metadata. Do not code.

--- a/src/lib/registry/registry-scale.test.ts
+++ b/src/lib/registry/registry-scale.test.ts
@@ -3,10 +3,28 @@ import { createRegistry } from "@/lib/registry/registry";
 import type { ComponentEntry, ComponentVariant, IconEntry, ProviderId } from "@/lib/registry/types";
 
 /**
- * A scale trip-wire, not a benchmark. The budgets carry ~an order of magnitude of headroom
- * over the shipped registry so a regression — e.g. reintroducing a linear `Array.find` or a
- * per-query `new RegExp` — trips them, while normal variance does not. The measured local
- * timing is recorded in the PR body.
+ * A scale trip-wire, not a benchmark.
+ *
+ * Every guard here counts work rather than measuring time. The fixture arrays and entries handed
+ * to `createRegistry` are wrapped in proxies that tally reads, so each test asserts an exact
+ * integer: a `Map`-backed lookup touches zero array elements, a cached haystack never reads
+ * `keywords`, and construction visits each entry once. Those counts are identical on an idle
+ * laptop and on a saturated CI runner, which is the whole point.
+ *
+ * The file previously asserted wall-clock budgets and #248 is the record of why it no longer
+ * does. The mixed-query budget flaked on CI at 250.7ms and 278.6ms against a 250ms limit while
+ * passing locally, and measurement showed it did not detect the per-query `new RegExp`
+ * regression its docblock claimed to guard — timings were indistinguishable with and without it.
+ * A ratio between two timed windows was tried next and rejected for the same root cause: it
+ * cancels sustained slowness but not scheduler preemption, and reviewers reproduced it going red
+ * on healthy code in roughly a fifth of full-suite runs. The construction budget was dropped
+ * last, having been caught failing once in eighteen loaded runs despite ~20x headroom measured
+ * in isolation — headroom measured on an idle machine is not headroom.
+ *
+ * What is deliberately not guarded: the constant factor of `searchComponents`. It scans every
+ * entry by design, so its cost is linear even when healthy. This file catches the algorithmic
+ * regressions — losing an index, losing a memo — and pinning a constant needs a benchmark
+ * harness rather than a trip-wire.
  */
 
 const SIZE = 5000;
@@ -78,19 +96,79 @@ function synthetic(): { components: ComponentEntry[]; icons: IconEntry[] } {
 	return { components, icons };
 }
 
+/**
+ * Instruments the fixture so a test can assert how much work a call did instead of how long it
+ * took. `watchArray` tallies indexed reads, which is how losing an index shows up: a `Map` lookup
+ * reads no elements while an `Array.find` reads thousands. `watchEntry` tallies reads of a single
+ * property, which is how losing a memo shows up: `buildHaystack` reads `keywords`, and a cached
+ * haystack never does.
+ */
+function scanCounter(watchedProperty: keyof ComponentEntry) {
+	let arrayReads = 0;
+	let propertyReads = 0;
+
+	function watchArray<T extends object>(items: readonly T[]): readonly T[] {
+		return new Proxy(items, {
+			get(target, prop, receiver) {
+				if (typeof prop === "string" && Number.isInteger(Number(prop))) arrayReads += 1;
+				return Reflect.get(target, prop, receiver);
+			},
+		});
+	}
+
+	function watchEntry(entry: ComponentEntry): ComponentEntry {
+		return new Proxy(entry, {
+			get(target, prop, receiver) {
+				if (prop === watchedProperty) propertyReads += 1;
+				return Reflect.get(target, prop, receiver);
+			},
+		});
+	}
+
+	return {
+		watchArray,
+		watchEntry,
+		arrayReads: () => arrayReads,
+		propertyReads: () => propertyReads,
+		reset: () => {
+			arrayReads = 0;
+			propertyReads = 0;
+		},
+	};
+}
+
+/** Wires the whole fixture through one counter, including the per-component variant arrays. */
+function instrumented(components: ComponentEntry[], icons: IconEntry[]) {
+	const counter = scanCounter("keywords");
+	const entries = components.map((entry) =>
+		counter.watchEntry({
+			...entry,
+			variants: counter.watchArray(entry.variants) as ComponentVariant[],
+		}),
+	);
+	const registry = createRegistry(counter.watchArray(entries), counter.watchArray(icons));
+	return { registry, counter };
+}
+
 describe("registry scale budget", () => {
 	const { components, icons } = synthetic();
+	// Every watched array element: components, icons, and the generic component's variants.
+	const ELEMENT_COUNT = SIZE + 1 + SIZE + SIZE;
 
-	it("constructs a 5,000-entry registry under 100 ms", () => {
-		const start = performance.now();
-		createRegistry(components, icons);
-		const elapsed = performance.now() - start;
-		expect(elapsed, `construction took ${elapsed.toFixed(1)}ms`).toBeLessThan(100);
+	it("builds its indexes in a single pass over each entry", () => {
+		const { counter } = instrumented(components, icons);
+		// Measured at 25,001 reads for 15,001 elements: entries once, variants three times (the
+		// variant index, the haystack, and the provider set). A nested scan measures 12.5M.
+		expect(
+			counter.arrayReads(),
+			`construction read ${counter.arrayReads()} array elements for ${ELEMENT_COUNT} ` +
+				"elements; a bounded number of passes is expected, a large multiple means a nested scan",
+		).toBeLessThanOrEqual(ELEMENT_COUNT * 4);
 	});
 
-	it("answers 200 mixed queries under 250 ms and stays correct at scale", () => {
+	it("stays correct at scale", () => {
 		const registry = createRegistry(components, icons);
-		const start = performance.now();
+		expect(registry.listComponents({ category: "services" })).toHaveLength(SIZE);
 		for (let i = 0; i < 200; i++) {
 			const n = (i * 37) % SIZE;
 			expect(registry.getComponent(`component-${n}`)?.id).toBe(`component-${n}`);
@@ -101,15 +179,63 @@ describe("registry scale budget", () => {
 					subtype: `variant-alias-${n}`,
 				}).id,
 			).toBe(`icon-${n}`);
-			registry.searchComponents(`keyword-${n}`);
-			registry.listComponents({ category: "services" });
-			registry.listComponents({ provider: PROVIDERS[n % PROVIDERS.length] });
+
+			// `keyword-42` is a substring of `keyword-420`, so the match set is a prefix family
+			// rather than a single entry. Asserting the family pins that search honours its query;
+			// `toContain` alone stays green when the query is ignored entirely.
+			const hits = registry.searchComponents(`keyword-${n}`).map((e) => e.id);
+			expect(hits).toContain(`component-${n}`);
+			expect(hits.filter((id) => !id.startsWith(`component-${n}`))).toEqual([]);
+
+			const provider = PROVIDERS[n % PROVIDERS.length];
+			const listed = registry.listComponents({ provider });
+			expect(listed.length).toBeGreaterThan(0);
+			expect(
+				listed.every(
+					(e) => e.provider === provider || e.variants.some((v) => v.provider === provider),
+				),
+				`listComponents({ provider: "${provider}" }) returned an entry from another provider`,
+			).toBe(true);
 		}
-		const elapsed = performance.now() - start;
-		expect(elapsed, `200 mixed queries took ${elapsed.toFixed(1)}ms`).toBeLessThan(250);
 	});
 
-	it("exact-ID lookup at scale returns the right entry (guards against linear find)", () => {
+	it("resolves ids, aliases, and variants without scanning any entry array", () => {
+		const { registry, counter } = instrumented(components, icons);
+
+		// Construction is allowed one pass over everything; only lookups are under test.
+		counter.reset();
+		for (let i = 0; i < 200; i++) {
+			const n = (i * 37) % SIZE;
+			expect(registry.getComponent(`component-${n}`)?.id).toBe(`component-${n}`);
+			expect(registry.resolveComponent(`alias-${n}`).id).toBe(`component-${n}`);
+			expect(
+				registry.resolveElementIcon({ type: "generic", subtype: `variant-alias-${n}` }).id,
+			).toBe(`icon-${n}`);
+		}
+
+		expect(
+			counter.arrayReads(),
+			`lookups walked ${counter.arrayReads()} array elements; a map-backed registry walks ` +
+				"none, so this is a linear scan reintroduced on the lookup path",
+		).toBe(0);
+	});
+
+	it("searches the prebuilt haystack instead of rebuilding it per query", () => {
+		const { registry, counter } = instrumented(components, icons);
+
+		counter.reset();
+		for (let i = 0; i < 20; i++) {
+			expect(registry.searchComponents(`keyword-${i}`).length).toBeGreaterThan(0);
+		}
+
+		expect(
+			counter.propertyReads(),
+			`search read entry.keywords ${counter.propertyReads()} times; the haystack is built ` +
+				"once during construction, so any read here means it is being rebuilt per query",
+		).toBe(0);
+	});
+
+	it("resolves the last entry, the worst case for any scan-based lookup", () => {
 		const registry = createRegistry(components, icons);
 		expect(registry.getComponent(`component-${SIZE - 1}`)?.iconId).toBe(`icon-${SIZE - 1}`);
 		expect(

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,11 @@ export default defineConfig({
 		environment: "jsdom",
 		setupFiles: ["./src/test-setup.ts"],
 		include: ["src/**/*.test.{ts,tsx}", "worker/**/*.test.ts", "scripts/**/*.test.mjs"],
+		// Vitest otherwise takes every core but one. On a developer workstation that starves
+		// the editor and any parallel agent session; capping at half leaves the machine usable
+		// and costs little, since the suite is dominated by startup rather than by width.
+		// CI runners have few cores, where the cap is at or below the default anyway.
+		maxWorkers: "50%",
 	},
 	resolve: {
 		alias: {


### PR DESCRIPTION
Unblocks the `v0.3.0` release. Closes #248.

## The bug

The `Validate` job of release run [30216569888](https://github.com/exit-zero-labs/threat-forge/actions/runs/30216569888) failed on `registry-scale.test.ts` at **250.7ms against a 250ms budget**. The same assertion had failed a PR run at **278.6ms**. It passes locally every time.

Measuring it showed the budget was wrong in both directions:

- **It measured machine speed, not the code.** Local cost is ~65ms. A CI runner sharing cores between Vitest workers reaches 250ms through scheduling alone.
- **It did not detect what it claimed to.** Its docblock said it guarded against "a per-query `new RegExp`". Patched in, the workload timed **identically** (55–70ms with and without), because cost is dominated by the by-design linear scan in `searchComponents`, not by matcher construction.
- My first hypothesis — that the 600 `expect()` calls inside the timed region were the cost — was **wrong**. They account for 3.5ms. Measuring beat guessing.

## The fix

Every guard now counts work instead of timing it. The fixture arrays and entries handed to `createRegistry` are wrapped in proxies that tally reads, so each assertion is an exact integer, identical on an idle laptop and a saturated runner.

| Guard | Healthy | Regressed |
|---|---|---|
| Array elements walked during lookups | **0** | 1,833,800 (linear `Array.find`) |
| `entry.keywords` reads during search | **0** | 100,020 (haystack memo dropped) |
| Element reads during construction | 25,001 | 12,512,501 (nested scan) |

The wall-clock construction budget is gone too. A reviewer caught it failing **once in eighteen** loaded runs despite ~20x headroom measured in isolation — headroom measured on an idle machine is not headroom.

## Why not just widen the budget

An intermediate version used a **ratio** between two timed windows to cancel machine speed. Both review lanes independently reproduced it going red on healthy code in roughly a fifth of full-suite runs (4/10 and 5/23), because a ratio cancels *sustained* slowness but not *scheduler preemption*, and the windows were only 1.4–4.3ms wide. Both recommended widening the window and adding retries. I didn't take that: it is the same class of test that produced #248. Counting removes the failure mode rather than enlarging it.

## Verification

Coverage is mutation-verified, not asserted. **Seven independent regressions each turn the file red:**

1. linear `Array.find` in `getComponent`
2. linear `Array.find` in `getIcon`
3. linear scan in `findVariant`
4. haystack memo dropped (rebuilt per query)
5. quadratic construction
6. `listComponents` provider filter ignored
7. `searchComponents` ignores its query

**Regressions 4, 6 and 7 were green before this change** — the old `toContain` and `toBeGreaterThan(0)` assertions did not discriminate, and the deleted budget was the only thing covering the memo. So this is a net coverage increase, not a trade.

- `npm run ci:local` — all checks pass
- 5 consecutive full-suite runs: **2123/2123**, zero `registry-scale` failures
- `registry.ts` confirmed byte-identical to `HEAD` after every mutation

## Second commit: CPU guardrails

While reviewing this, two agent lanes drove the maintainer's workstation to **load 118 with 0% idle**. One lane spawned 34 detached `node -e` busy-loops to simulate a contended CI runner; they were reparented to `launchd` and nothing would have reaped them.

- `AGENTS.md` gains **"Local machine resources"** — forbids synthetic load, forbids detaching processes that are never reaped, forbids parallel lanes each running the full suite, and points at the alternative this PR demonstrates.
- `vitest.config.ts` gains `maxWorkers: "50%"`. Vitest otherwise takes 17 of 18 cores. Verified by counting worker processes (9, not assumed). CI runners have few cores, where the cap is at or below the default already.

## Reviewer findings not adopted

- **`LOOKUP_REPS = 50_000` / `retry: 3`** — both lanes' proposed fix. Superseded: there is no timed region left to widen.
- **"whole query surface" covers 5 of 9 `Registry` methods** — test renamed to "stays correct at scale" rather than expanding scope in a release-blocking fix.

## Reviewer findings adopted

- Search assertion strengthened to pin the prefix family, closing the "search ignores its query" hole.
- Provider assertion now checks every returned entry belongs to the provider.
- The haystack-memo coverage gap the deleted budget had covered is now guarded directly.
- Commit message claims "so no coverage is lost" and "has never flaked" were **falsified by review** and removed.