### PR TITLE
fix(ci): let the lockfile registry guard run on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,12 @@ jobs:
             libssl-dev \
             xdg-utils
 
+      # The Lockfile job runs this on Linux only, so a Windows-specific break in the guard
+      # itself stayed invisible until it failed the v0.3.0 release build. The release matrix
+      # runs it on every platform; this makes pull requests do the same.
+      - name: Verify package registry and integrity
+        run: node scripts/check-lockfile-registry.mjs
+
       - name: Build Tauri app
         run: |
           cargo fetch --manifest-path src-tauri/Cargo.toml --locked

--- a/scripts/check-lockfile-registry.mjs
+++ b/scripts/check-lockfile-registry.mjs
@@ -36,8 +36,28 @@ for (const dependencyType of ["dependencies", "devDependencies", "optionalDepend
 	}
 }
 
+/**
+ * Reads an effective npm config value.
+ *
+ * On Windows the launcher is `npm.cmd`, and since Node 20.12 — the fix for CVE-2024-27980,
+ * batch-file argument injection — `spawnSync` refuses to execute a `.cmd` without
+ * `shell: true`. Every Windows runner therefore reported "unable to read effective value"
+ * and this supply-chain guard failed closed for the wrong reason, which is what broke the
+ * v0.3.0 Windows release build while every Linux and macOS job passed.
+ */
 function readNpmConfig(key) {
-	const result = spawnSync("npm", ["config", "get", key], { encoding: "utf8" });
+	// The shell is only reachable with a key matching this pattern, so no caller can smuggle
+	// shell metacharacters through it. Both call sites pass literals; this keeps that true.
+	if (!/^[a-z][a-z-]*$/.test(key)) {
+		violations.push(`npm config ${key}: refusing to query a key that is not a plain literal`);
+		return null;
+	}
+
+	const isWindows = process.platform === "win32";
+	const result = spawnSync(isWindows ? "npm.cmd" : "npm", ["config", "get", key], {
+		encoding: "utf8",
+		shell: isWindows,
+	});
 	if (result.error || result.status !== 0) {
 		violations.push(`npm config ${key}: unable to read effective value`);
 		return null;


### PR DESCRIPTION
Unblocks the `v0.3.0` Windows release build. Closes #251.

## What happened

Release run [30219084677](https://github.com/exit-zero-labs/threat-forge/actions/runs/30219084677) built macOS (aarch64, x64) and Linux successfully — 7 assets on the draft release — and **`Release (windows-latest)` failed before it built anything**:

```
Package lockfile registry validation failed:
- npm config registry: unable to read effective value
- npm registry: expected https://registry.npmjs.org/, found null
- npm config replace-registry-host: unable to read effective value
- npm replace-registry-host: expected never, found missing
```

That is the supply-chain guard failing **closed for the wrong reason**, not a compromised lockfile.

## Cause

```js
spawnSync("npm", ["config", "get", key], { encoding: "utf8" })
```

On Windows the launcher is `npm.cmd`. Since Node 20.12 — the fix for **CVE-2024-27980**, batch-file argument injection — `spawnSync` refuses to execute a `.cmd` without `shell: true`. The spawn fails, `readNpmConfig` returns `null`, and both config assertions record violations that describe the guard's own failure.

## Why no PR ever caught it

| Workflow | Runs the check on |
|---|---|
| `release.yml` | every matrix platform |
| `ci.yml` | `Lockfile` job only — `ubuntu-latest` |

No pull request had ever executed this script on Windows. The break could only surface during a release, after a tag was cut.

## Fix

1. **Use `npm.cmd` with `shell: true` on Windows only.** Passing `shell` reopens the argument-injection surface the Node change closed, so `key` is now validated against `/^[a-z][a-z-]*$/` before use. Both call sites pass literals today; the guard keeps that true for any future one instead of relying on the convention holding.
2. **Run the check in the `Build` matrix job of `ci.yml`**, so pull requests exercise it on Windows, macOS, and Linux. This is the durable half — it closes the visibility gap, not just the bug.

## Verification

The important property is that a supply-chain guard that *passes* when it shouldn't is far worse than one that's broken. Re-verified fail-closed against copies of the real manifests:

| Input | Result |
|---|---|
| Untampered lockfile + repo `.npmrc` | passes |
| `resolved` host rewritten to `https://evil.example.com/pkg.tgz` | **rejected** — `non-canonical registry` |
| Effective registry not `registry.npmjs.org` | **rejected** |
| `npm-shrinkwrap.json` present | **rejected** |

The Windows path itself cannot be verified on macOS — the `Build (windows-latest)` job on this PR is the proof, which is exactly the gap being closed.

## Follow-on

The Windows job never reached its signing step, so **Azure Trusted Signing (#50) remains unverified on a real artifact.** The `v0.3.0` release runbook waiver already treats it as unconfirmed; this PR does not change that. If signing fails on the re-run, `scripts/sign-windows.ps1` exits non-zero, so no unsigned installer can ship silently.