### PR TITLE
Correct the board priority scale and the field-discovery instructions

### DIFF
--- a/.claude/skills/autonomous-issue-triage/SKILL.md
+++ b/.claude/skills/autonomous-issue-triage/SKILL.md
@@ -13,15 +13,15 @@ Reject candidates with:
 - unresolved dependencies or research
 - required secrets, provisioning, or account access
 - unmade product, design, security, or licensing decisions
-- size XL
-- a missing committed plan for M/L
+- `Effort` of `High` that has not been decomposed into executable sub-issues
+- a missing committed plan for `Medium` or `High`
 
 Rank remaining work by:
 
 1. active roadmap/parent initiative
-2. P0, then P1, then P2
+2. `Urgent`, then `High`, then `Medium`, then `Low`
 3. dependency leverage and unblock value
-4. smaller executable size
+4. lower `Effort`
 5. oldest settled Ready item
 
 Recommend one issue with evidence. Begin implementation only when the user has requested it.

--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -11,12 +11,17 @@ Triage one issue. Do not plan M/L work or edit production code.
 1. Read `AGENTS.md`, the full issue/comments, related issues/PRs, roadmap context, and relevant
    repository evidence.
 2. If the report is a vulnerability, stop public discussion and follow `SECURITY.md`.
-3. Discover current Project 2 field and option IDs with `gh project field-list`; never rely on
-   saved IDs.
+3. Discover the live IDs before writing. `Status` is a project field, so `gh project field-list`
+   finds it. `Priority`, `Effort`, and `Type` are **native org issue fields and do not appear
+   there at all** — enumerate them from `organization.issueFields` and `organization.issueTypes`
+   on the GraphQL API, and write them with `setIssueFieldValue` / `updateIssueIssueType`. Reading
+   them through the project API returns nothing and raises no error, which reads as "unset" on a
+   board that is fully populated.
 4. Decide and explain:
    - native issue type: `Task`, `Bug`, or `Feature`
    - relevant domain labels
-   - `Priority`: P0/P1/P2
+   - `Priority`: `Urgent`/`High`/`Medium`/`Low`, answering how soon *within* the milestone.
+     `Urgent` and `High` require a comment naming what specifically goes wrong if this waits.
    - `Effort`: High/Medium/Low, with the matching `model/opus|sonnet|haiku` label
    - exactly one autonomy label: `AUTO` or `HITL`
    - parent, dependencies, and acceptance criteria

--- a/.github/instructions/github.instructions.md
+++ b/.github/instructions/github.instructions.md
@@ -11,5 +11,5 @@ Follow `AGENTS.md` and `CONTRIBUTING.md`; this file adds repository-operation ru
 - Preserve exact required-check names, CODEOWNERS coverage, and owner-validation boundaries.
 - Treat Project 2 fields and lifecycle values as canonical; discover live IDs instead of hard-coding
   mutable node or option IDs.
-- Keep reporter urgency distinct from maintainer-owned P0/P1/P2 priority.
+- Keep reporter urgency distinct from maintainer-owned `Urgent`/`High`/`Medium`/`Low` priority.
 - Do not mutate GitHub state without explicit authorization and never use owner bypass.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ execution tracker. Do not create a parallel Markdown or agent-only backlog.
 
 Every non-trivial change requires an issue with:
 
-- `Status`, `Priority`, and `Effort`
+- `Status`, `Priority`, `Effort`, and `Type`
 - measurable acceptance criteria
 - dependencies and parent initiative when applicable
 - exactly one autonomy label: `AUTO` or `HITL`
@@ -79,8 +79,20 @@ claimed to deliver. Merging is verification; that walkthrough is validation.
 
 See `.e0l/first-principles/planning.md` for the full model.
 
-Priority remains `P0` → `P1` → `P2`. `Effort` is the reasoning class the work needs — not how
-long it takes:
+`Status` is a project field. `Priority` and `Effort` are **native organization issue fields**,
+which matters more than it sounds: an org issue field is invisible to `gh project item-list`,
+which returns no key for it and no error either. Tooling that reads them through the project API
+sees an empty board and reports it as missing metadata. Read and write them through
+`setIssueFieldValue` on the GraphQL API instead, and enumerate the option IDs from
+`organization.issueFields`.
+
+`Priority` is `Urgent` → `High` → `Medium` → `Low`, and answers *how soon* within the current
+milestone. It never means how big, and it never overrides the milestone. Every `Urgent` or `High`
+issue carries a comment naming the cost of delay; a priority with no stated reason is
+indistinguishable from one set by whoever filed it last. If more than about a fifth of open issues
+sit in the top two, the field has stopped routing anything.
+
+`Effort` is the reasoning class the work needs — not how long it takes:
 
 | Effort | Model tier | Planning contract |
 |--------|-----------|-------------------|
@@ -91,11 +103,11 @@ long it takes:
 The tier is a floor, not a ceiling. Any work touching cryptography, the IPC boundary, the
 `.thf` schema, or a trust boundary is `High` regardless of how small the diff looks.
 
-`Effort` replaced the former `Size` field in the doctrine v1 migration, and the `size/XS`–`size/XL`
-labels were deleted with it. The `model/*` labels are **kept**: they state the reasoning class
-directly, and during the migration they proved more accurate than `Size` — the two disagreed on 53
-issues, so `Effort` was derived from the model label wherever one exists. The `Effort` field is
-authoritative; the label must not contradict it.
+`Effort` replaced the former `Size` field in the doctrine v1 migration. The `size/XS`–`size/XL`
+labels outlived it on 92 issues and were deleted in the #243 sweep. The `model/*` labels are
+**kept**: they state the reasoning class directly, and during the migration they proved more
+accurate than `Size` — the two disagreed on 53 issues, so `Effort` was derived from the model
+label wherever one exists. The `Effort` field is authoritative; the label must not contradict it.
 
 `AUTO` means an agent can reach a verification-complete PR without earlier human action. Final
 owner validation is still required. `HITL` means a secret, provisioning step, unresolved

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,14 +26,16 @@ execution tracker.
 
 | Status | Meaning |
 |--------|---------|
-| `Backlog` | New and not yet shaped |
-| `Backlog` | Triaged but not executable or selected |
+| `Backlog` | Filed but not yet shaped. Never picked up directly |
 | `Ready` | Criteria, dependencies, ownership, and autonomy are settled |
-| `In progress` | Implementation is underway |
-| `In progress` | Verification and agent preflight are complete; owner validation remains |
-| `Done` | Merged or closed after validation |
+| `In progress` | Claimed. Held through the whole PR cycle, including the window where verification and preflight are done and only owner validation remains |
+| `Done` | Merged and validated on a local `main`, or rejected with the `Reject` label |
 
-Every non-trivial issue receives P0/P1/P2 priority, a High/Medium/Low `Effort`, and exactly one
+There are four states and no `In review`: for a solo studio there is nobody to hand to, so an
+issue stays `In progress` until it merges.
+
+Every non-trivial issue receives an `Urgent`/`High`/`Medium`/`Low` `Priority`, a
+`High`/`Medium`/`Low` `Effort`, a `Task`/`Bug`/`Feature` `Type`, and exactly one
 autonomy label:
 
 - `AUTO` — an agent can reach a verification-complete PR without earlier human action

--- a/docs/plans/0000-template.md
+++ b/docs/plans/0000-template.md
@@ -9,8 +9,8 @@ State the measurable user or system outcome.
 - **Issue:** `#N`
 - **Parent initiative:** `#N` or `N/A`
 - **Type:** `Task`, `Bug`, or `Feature`
-- **Size:** `M` or `L`
-- **Priority:** `P0`, `P1`, or `P2`
+- **Effort:** `Medium` or `High`
+- **Priority:** `Urgent`, `High`, `Medium`, or `Low`
 - **Autonomy:** `AUTO` or `HITL`
 - **Dependencies:** linked issues, external prerequisites, or `None`
 - **Non-goals:** behavior explicitly excluded from this change


### PR DESCRIPTION
Refs #243.

## What happened

#243 asked for a `P0/P1/P2` → `High/Medium/Low` mapping decision before any board sweep. Working it, I found the premise was inverted: there was never a project-level `Priority` field to map *from*. `AGENTS.md` specified `P0`/`P1`/`P2`, but the field the board actually uses is the **native org issue field**, whose options are `Urgent`/`High`/`Medium`/`Low`. Nothing had ever written `P0` anywhere, because there was nowhere to write it.

## The trap, stated plainly

`Priority` and `Effort` are **organization** issue fields. An org issue field is **invisible to `gh project item-list`** — the item JSON has no key for it, and the call does not error.

So a fully-configured board reads as having no `Priority` field at all. I believed that reading, and got as far as **creating duplicate project-level fields on the wrong scale and backfilling 44 issues into them** before querying `organization.issueFields` and finding the real ones sitting there with the right options.

Both duplicate fields have been deleted. `AGENTS.md` and the `issue-triage` skill now state the trap outright, so the next reader loses a minute rather than an hour.

## Corrections in this diff

| File | Was | Now |
|---|---|---|
| `AGENTS.md` | `Priority remains P0 → P1 → P2` | `Urgent`/`High`/`Medium`/`Low`, plus the org-field discovery trap and the ~20% distribution ceiling |
| `AGENTS.md` | `size/XS`–`size/XL` labels "were deleted" in the v1 migration | They were not — still on 92 issues. They are now, and the sentence says when |
| `CONTRIBUTING.md` | Status table listed `Backlog` twice and `In progress` twice | Four distinct rows, matching `AGENTS.md` |
| `issue-triage` | "Discover current Project 2 field and option IDs with `gh project field-list`" | Names which fields that call *can* and *cannot* see |
| `autonomous-issue-triage` | Ranked by `size XL` and "smaller executable size" | Ranks by `Effort`, and by the real priority scale |
| `docs/plans/0000-template.md` | Asked new plans for a `Size` | Asks for `Effort` |

Historical plans under `docs/plans/` keep their `P0`/`P1` values deliberately. They are dated records of what was decided at the time; rewriting them would make them assert a scale that did not exist when they were written.

## Board state (applied out-of-band, not in this diff)

All **49 open issues** now carry `Priority`, `Effort`, `Type`, `Milestone`, and exactly one autonomy label.

- `Effort` was derived from the `model/*` labels, the derivation `AGENTS.md` already endorses.
- Three browser key-vault issues (#231, #233, #234) were raised to `High` effort under the AGENTS.md rule that anything touching cryptography is `High` "regardless of how small the diff looks". Their `model/sonnet` labels were swapped to `model/opus` to match.
- `size/XS`–`size/XL` deleted (92 issues).
- 12 issues that had no native `Type` now have one.

Priority distribution — **7/49 top-priority (14%)**, inside the ~20% ceiling doctrine sets:

| Priority | Issues |
|---|---|
| `Urgent` | #232, #233 |
| `High` | #44, #50, #51, #231, #234 |
| `Medium` | 36 |
| `Low` | #35, #194, #196, #198, #220, #235 |

Each of the 7 carries a comment naming its specific cost of delay, which doctrine requires and which is the part most likely to rot.

**#232 is the one worth a second look:** it is live on threatforge.dev right now. `script-src` admits `https://static.cloudflareinsights.com` with no `integrity`, and script from that origin reaches the same non-extractable wrapping key the app does — so browser BYOK keys are one third-party script change away from disclosure.

## Verification

- [x] `bash scripts/ci-local.sh` green
- [x] Every open issue re-queried after the writes; no missing fields
- [x] Duplicate project fields confirmed deleted (`gh project field-list` shows neither)

## Not verified by me

Whether the specific `Urgent`/`High` picks match your sense of what blocks Beta. The rationale is in each issue comment; the set is small enough to overrule in a sentence.