### PR TITLE
fix(web): correct the analytics claims the CSP change got wrong

### DIFF
--- a/docs/runbooks/deploying-the-website.md
+++ b/docs/runbooks/deploying-the-website.md
@@ -68,9 +68,14 @@ Wrangler serves the production build with the same SPA fallback behavior used at
   `curl -sI https://threatforge.dev | grep -i content-security-policy`.
 - Confirm the zone has not started injecting anything the repo cannot see. Cloudflare can add
   an analytics beacon to the served HTML and set cookies without any change here, which would
-  make the privacy page's claims false even though every test still passes. Both must return
-  no match: `curl -s https://threatforge.dev | grep -i cloudflareinsights` and
-  `curl -sI https://threatforge.dev | grep -i set-cookie`.
+  make the privacy page's claims false even though every test still passes. **`curl` alone will
+  not catch this** — Cloudflare's Web Analytics auto-injection is conditional on a browser-like
+  `User-Agent`, so a plain `curl` returns clean HTML while every real visitor gets the script.
+  Send a browser UA:
+  `curl -s https://threatforge.dev -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36' | grep -i cloudflareinsights`
+  and `curl -sI https://threatforge.dev | grep -i set-cookie`. Both must return no match.
+- Load the site in a real browser and confirm the console is clean. A CSP violation here means
+  the edge is injecting a script the policy blocks — safe, but visible to every visitor.
 
 ## Roll Back
 

--- a/public/_headers
+++ b/public/_headers
@@ -39,8 +39,10 @@
 # No third-party script origin is admitted, and adding one is a key-confidentiality
 # decision rather than a convenience: an analytics beacon origin was allowed here
 # until #232 removed it, and because the beacon is versionless an SRI hash was not
-# available to constrain it. Usage insight, if it is ever wanted, belongs in the
-# Worker, which already sees every request.
+# available to constrain it. Note that Cloudflare's zone-level Web Analytics injects
+# that beacon into the served HTML for browser-like requests regardless of what this
+# repository contains — script-src is what stops it executing, so a widened script-src
+# silently re-enables a third-party script this codebase never asked for. See #261.
 /*
   Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://api.anthropic.com https://api.openai.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'
   X-Content-Type-Options: nosniff

--- a/src/pages/privacy-page.tsx
+++ b/src/pages/privacy-page.tsx
@@ -39,10 +39,10 @@ export function PrivacyPage() {
 							The web version at threatforge.dev runs on Cloudflare Workers. Standard hosting logs —
 							IP addresses, request timestamps — may be collected as the infrastructure operates,
 							and Cloudflare asks your browser to report network errors it runs into while loading
-							the site. Threat Forge itself adds nothing on top of that: no analytics script, no
-							telemetry, no cookies. The content security policy admits no third-party script at
-							all, so there is nothing we could quietly add later without changing the policy in
-							public.
+							the site. Threat Forge itself adds nothing on top of that: no analytics, no telemetry,
+							no cookies. The content security policy admits no third-party script at all, so
+							nothing executes on this page that we did not ship — not even something inserted at
+							the edge after the fact.
 						</p>
 						<p>
 							The browser does keep a fair amount on your behalf. Your threat models and your


### PR DESCRIPTION
Refs #261, #232.

Post-deploy browser verification of #232 turned up something the whole review missed, and the honest thing is to say so plainly: **a claim in that PR was false.**

## What was wrong

#232 asserted the analytics beacon "never loaded on threatforge.dev". It did.

What I actually verified is that *this repository's* `CloudflareAnalytics` component never ran — `VITE_CF_BEACON_TOKEN` was set in no environment, so it returned early and Vite tree-shook it out of the bundle. That part holds up under re-checking. I then concluded the beacon never loaded, which is a broader claim than the evidence supported.

Cloudflare Web Analytics is enabled at the **zone** with automatic injection. It inserts the beacon `<script>` into the served HTML at the edge, on every route, with nothing in this repository to show for it — and it was executing perfectly well through exactly the two CSP origins #232 removed. Those entries weren't vestigial. They were load-bearing for a script the codebase never asked for.

## Why three independent checks missed it

Me, the security auditor, and the slop auditor all verified with `curl`. **Cloudflare's auto-injection is conditional on a browser-like `User-Agent`** — plain `curl` gets clean HTML back while every real visitor gets the script. Three passes, one shared blind spot, all confirming each other.

What caught it was loading the deployed page in an actual browser and reading the console, where the CSP violation was sitting in plain sight.

That is the transferable lesson, and it is why the runbook change here is not cosmetic: `curl` cannot see UA-conditional edge injection, so the post-deploy check now sends a browser UA and adds a real-browser console check.

## What this does and does not change

**The security rationale is unaffected — arguably stronger.** A versionless third-party script that SRI cannot constrain was genuinely executing on a page holding the BYOK API key in IndexedDB under a non-extractable wrapping key any same-origin script can use. That was the hole. It is closed, and now browser-verified closed rather than assumed closed.

**What changes is the cost side.** #232 was not the free deletion it described. It removed analytics that were actually collecting data. That turns #260 (do we want usage insight, and of what kind?) from a hypothetical into a live question with a real answer to "what did we lose".

## The changes

- **`privacy-page.tsx`** said Threat Forge adds "no analytics script". The served HTML does contain one; the browser refuses it. The claim is now about what *executes* rather than what is *present* — true today, and still true once the zone setting is off, so the copy does not have to ping-pong.
- **`public/_headers`** records that the zone injects this beacon regardless of repository contents, and that `script-src` is the only thing stopping it. A future editor widening `script-src` would silently re-enable a third-party script next to the key vault. That is the non-obvious fact worth a comment.
- **`deploying-the-website.md`** — browser-UA injection check plus a console check.

## Still open

Disabling the zone setting needs owner dashboard access (`wrangler`'s OAuth token here has `zone (read)` and no RUM scope). Tracked in #261. Until then the CSP blocks the beacon on every page load — safe, but every visitor sees a console violation and the served HTML carries a blocked analytics tag.

## Verification

`bash scripts/ci-local.sh` green. Copy claims re-checked against the live site with both a browser UA and a real Chromium load.

🤖 Generated with [Copilot CLI](https://githubnext.com/projects/copilot-cli)
