### PR TITLE
fix(ai): surface a clear-text API key that survived deletion

### DIFF
--- a/docs/plans/233-persistent-clear-text-key-warning.md
+++ b/docs/plans/233-persistent-clear-text-key-warning.md
@@ -32,10 +32,9 @@ again claims "No API key configured" while a readable clear-text copy exists.
 
 1. **The UI surface is an owner decision.** The issue says so ("The right surface is a design
    decision, not a mechanical one"). Four options are specified below with a recommendation.
-   Steps 1–4 are identical under all four; step 5 exists only for options B, C, and D. An
-   implementer must not pick one. **Nothing in steps 1–4 is blocked by this** — they can be
-   executed and reviewed while the decision is pending, because the store they produce is what
-   every option reads.
+   Steps 1–4 are identical under all four; step 5 exists only for options B, C, and D.
+   **Resolved 2026-07-27:** the owner delegated the choice to the implementer, who took the
+   recommended Option B, so step 5 is in scope and no longer conditional. See the replan log.
 2. **Autonomy label.** `AUTO` is accurate only after (1) is answered. If the owner prefers to
    answer it inside the PR rather than before, the issue should carry `HITL`. Recording it
    rather than changing metadata, per the planner contract.
@@ -273,7 +272,10 @@ export const useKeyResidueStore = create<KeyResidueState>()(/* ... */);
 - **Not `chat-store`**, whose `hasApiKey` answers "can I send a request". Residue is the
   opposite: a key that is *not* usable by the transport and is a storage-hygiene problem.
   Folding it in would make a conversation store carry a security surface and would tempt a future
-  reader to gate requests on it.
+  reader to gate requests on it. This is about where the state *lives*, not who may refresh it:
+  `chat-store.checkApiKey` does call `refreshResidue` after its `hasKey`, because that `hasKey`
+  runs the migration and would otherwise erase a slot with nothing left to notice. It reads
+  through the residue store's action and holds no residue state of its own.
 - **No `persist` middleware, deliberately.** Residue is derived from storage and must be
   re-derived every session; a persisted copy is a stale claim about a secret. Worse, the
   persistence target would be `localStorage` — the storage that is, by hypothesis, refusing
@@ -283,10 +285,12 @@ export const useKeyResidueStore = create<KeyResidueState>()(/* ... */);
   is in-memory and session-scoped, never persisted.
 - **`refreshResidue` never rejects.** It loads the adapter via `getKeychainAdapter()`, calls
   `adapter.readLegacyResidue?.(provider)`, and writes the result; when the method is absent it
-  writes `null`. If the adapter *module* fails to load it leaves the previous value untouched and
-  returns — it does not write `null`, because "the bundle did not load" is not evidence the slot
-  is empty. That failure already reaches the user through the panel's `ADAPTER_LOAD_ERROR` path,
-  so nothing is swallowed that is not reported elsewhere.
+  writes `null`. If it cannot get an answer at all — the adapter *module* fails to load, or the
+  read itself throws — it leaves the previous value untouched and returns. It does not write
+  `null`, because neither "the bundle did not load" nor "the read was refused" is evidence the
+  slot is empty. A module-load failure already reaches the user through the panel's
+  `ADAPTER_LOAD_ERROR` path and the launch effect's own `console.warn`, so nothing is swallowed
+  that is not reported elsewhere.
 
 **When it is read.**
 
@@ -295,7 +299,12 @@ export const useKeyResidueStore = create<KeyResidueState>()(/* ... */);
 | Panel mount, **after** both `hasKey` calls settle | `ai-settings-content.tsx` mount effect | `hasKey` runs `migrateLegacyKey`, which retries the erase; reading first would report a slot that the same tick removed |
 | After `handleSave`, success or failure | `handleSave` `finally` | `setKey` attempts `removeLegacyKey` and ignores the outcome, so a save can both clear residue and (on a refusing browser) leave it |
 | After `handleDelete`, success **and** the `LEGACY_RETAINED` branch **and** any other error | `handleDelete` `finally` | This is the state transition the issue is about; the `finally` also covers a vault error thrown after the slot was already erased |
-| Once at app start, browser only | `AppLayout` effect (options B, C, D only) | The user may never open AI settings — the whole point of escalating |
+| After `handleRecheck`, success or failure | `handleRecheck` `finally` | The notice's only control. Its `hasKey` runs the migration, so this is the read that clears the warning when a browser finally allows the erase — and the value it writes is what the retry report is derived from |
+| After `checkApiKey`'s `hasKey` settles | `chat-store.ts` | `ai-chat-tab.tsx` calls it on mount, which runs the migration outside both the launch effect and the settings panel. Without this read, opening the chat tab can erase the slot while the status bar keeps a standing warning for the rest of the session |
+| Once at app start, browser only, **and only if a slot is actually there** | `AppLayout` effect | The user may never open AI settings — the whole point of escalating. Gated on a `localStorage` probe so a profile with no clear-text slot never opens the keychain database |
+
+Two of those triggers live outside the settings panel, which is why `RESIDUE_PROVIDERS` is
+exported rather than re-typed per caller.
 
 **How it clears.** Nothing clears it manually. Every refresh recomputes from storage, so the
 warning disappears the moment the slot reads `absent`: after a successful retry, after a mount
@@ -308,26 +317,47 @@ reads storage directly and its answer is always the newest one at the moment it 
 per-provider lock orders it behind any in-flight adapter operation. Do not extend `mutated` to
 cover it — that would suppress a fresh true answer.
 
-**AC4 in the status row.** The row becomes three-state:
+**AC4 in the status row.** `keyStatus` is not a boolean. It carries `"unknown"` for a `hasKey`
+that rejected and `"unchecked"` until the mount check answers, because both used to collapse to
+`false` and be reported as a fact about storage that had not been established (replan log rows
+*"`keyStatus` gained a third state"* and *"`keyStatus` gained a not-yet-checked state"*):
 
 | `keyStatus` | `residue` | Dot | Text |
 |---|---|---|---|
 | `true` | any | green | `API key configured` |
-| `false` | `"retained"` | destructive | `Clear-text API key still in this browser` |
+| not `true` | `"retained"` | destructive | `Clear-text API key still in this browser` |
+| `"unknown"` | `"unverified"` or `null` | amber | `Key storage could not be checked` |
+| `"unchecked"` | `"unverified"` or `null` | muted | `Checking key storage…` |
 | `false` | `"unverified"` or `null` | muted | `No API key configured` |
 
 `unverified` keeps "No API key configured" because it *is* the honest summary — nothing is known
 to be readable — and the separate notice carries the uncertainty. AC4 speaks only of a *readable*
 copy.
 
-**AC5, the retry path.** Keep the existing Remove button and widen its gate to
-`keyStatus[provider] || residue[provider] !== null`, relabelling to
-`Try removing the clear-text copy again` when `!keyStatus[provider]`. It calls the unchanged
-`handleDelete`, so the retry is `deleteKey` — which runs `removeLegacyKey` first, then re-commits
-the (idempotent) `REVOKED` marker and a no-op record delete. On a browser that has started
-allowing removal this resolves and the residue refresh clears the warning; on one that has not it
-rejects with the same authored message and the persistent warning stays. Both outcomes are
-honest, and no existing code path changes.
+**AC5, the retry path.** Every residue notice carries one control, bound to its own provider,
+and it calls `handleRecheck` unconditionally: `hasKey`, then a residue re-read. It is labelled
+`Try removing it again`, which is what `hasKey` does — it runs `migrateLegacyKey`, which retries
+the erase — and it carries no destructive iconography. If the re-read still finds a reading, the
+panel authors the report `deleteKey` used to make through its rejection, and both readings get
+one. `retained` says the browser still would not delete the slot. `unverified` says the check is
+still blocked, that nothing was removed, and that whether a copy is there is still unknown —
+which is literally what happened, because `migrateLegacyKey` returns before it touches the slot
+when the read is refused. `unverified` is the reading that never resolves on a blocked-storage
+profile, so it is the one where a silent control does the most damage: same notice, no message,
+nothing to show the click did anything.
+
+Nothing in a notice may reach `deleteKey`, and a regression test asserts that across every
+combination of `keyStatus` and residue. The `Remove API key` button keeps its existing
+`keyStatus[provider] === true` gate.
+
+This supersedes the earlier instruction to widen that gate to
+`keyStatus[provider] || residue[provider] !== null` and route the retry through `handleDelete`.
+That shape was unsafe twice over — see the replan log rows *"the removal control is gated on
+`keyStatus === true || residue === "retained"` and split in two"* and *"the destructive residue
+control is removed entirely"*. In short: it decided from a render-time snapshot that a second
+tab or a pending mount check can invalidate, and `deleteKey` bought nothing there anyway, because
+in that state a retirement marker already stands and `migrateLegacyKey` runs `removeLegacyKey`
+unconditionally after a declined import.
 
 **Considered and rejected as the offered action:** having the app call `localStorage.clear()`. If
 `removeItem` is refused, `clear()` has no reason to succeed, and on the paths where it would it
@@ -342,14 +372,19 @@ placement, persistence, dismissibility, and whether they escalate outside the pa
 
 ### Shared copy (applies to every option)
 
-Fact first, no blame, one concession — per `docs/knowledge/product-voice.md`. The existing
-`deleteKey` messages are **not** changed; this copy is the standing version of them.
+Fact first, no blame, one concession — per `docs/knowledge/product-voice.md`. Both `deleteKey`
+messages and both notices carry the same concession sentence, from one shared constant
+(`CLEARING_SITE_DATA_COST`): the only remedy the app can offer for a slot the browser will not
+erase is clearing site data, and in this browser that also destroys the user's saved threat
+models. See the replan log row *"the site-data instruction states what it costs"*.
 
 *`retained`, provider named:*
 > **A clear-text Anthropic API key is still stored in this browser.**
 > It was saved before ThreatForge encrypted keys, and this browser will not delete it. Anything
 > that can read this site's storage can read the key. Clear this site's browser data to remove
 > it, and revoke the key with Anthropic if it may have been exposed.
+> Clearing this site's browser data also removes the threat models saved in this browser, so
+> export anything you need first.
 > This copy is not a backup — ThreatForge erases it as soon as the browser allows.
 > `[ Try removing it again ]`
 
@@ -358,11 +393,15 @@ scope, and it is what stops a user treating the retained slot as a recovery copy
 `getKey` erases it.
 
 *`unverified`, visibly calmer — amber, not destructive:*
-> **ThreatForge could not check for an older clear-text API key.**
+> **ThreatForge could not check for an older clear-text Anthropic API key.**
 > This browser blocked the check, so an unencrypted copy saved by an older version may or may
 > not still be there. If you used ThreatForge in this browser before keys were encrypted, clear
 > this site's browser data to be sure.
-> `[ Check again ]`
+> Clearing this site's browser data also removes the threat models saved in this browser, so
+> export anything you need first.
+> `[ Try removing it again ]`
+
+Both notices carry the same label, because both controls do the same non-destructive thing.
 
 Neither string ever interpolates key material. Provider labels come from the existing `PROVIDERS`
 list.
@@ -516,17 +555,22 @@ Steps 1–4 are common to all four options. Step 5 is written for Option B and n
 
 ### 4. Wire the panel
 
-- **Behavior:** the three-state status row; a persistent warning block while
-  `residue[provider] !== null`; the Remove/retry button gated on
-  `keyStatus[provider] || residue[provider] !== null`; residue refreshed on mount (after both
-  `hasKey` calls settle) and in the `finally` of both `handleSave` and `handleDelete`. The
-  existing one-shot `message` stays exactly as it is.
+- **Behavior:** the status row of the AC4 table above; a persistent warning block for **every**
+  provider whose `residue` is non-`null`, each carrying one non-destructive control bound to its
+  own provider; the `Remove API key` button keeps its `keyStatus[provider] === true` gate; residue
+  refreshed on mount (after both `hasKey` calls settle) and in the `finally` of `handleSave`,
+  `handleDelete`, and `handleRecheck`. The existing one-shot `message` stays, and gains the
+  report `deleteKey` used to make when a retry changes nothing.
 - **Files:** `src/components/panels/ai-settings-content.tsx`,
-  `src/components/panels/ai-settings-content.test.tsx`.
+  `src/components/panels/ai-settings-content.test.tsx`, and — added during implementation —
+  `src/stores/chat-store.ts` and `src/stores/chat-store.test.ts`, for the `checkApiKey` refresh
+  recorded in the trigger table above.
 - **Implementation:** render the block with `role="alert"` and the same visual grammar as the
   existing legacy-model warning (`AlertTriangle`, bordered tinted box) — destructive tint for
   `retained`, amber for `unverified`. Copy exactly as specified above. Keep the existing security
-  note paragraph.
+  note paragraph. `busyProviders` is a `Set<AiProvider>`, not one slot, because two notices can
+  have work in flight at once. Nothing in a notice calls `deleteKey`; see the AC5 paragraph and
+  the replan log rows it cites.
 - **Targeted verification:** `npx vitest run src/components/panels/ai-settings-content.test.tsx`.
 - **Intent validation:** the owner deletes a key in a browser with `removeItem` stubbed, closes
   and reopens settings, and reads what the panel says.
@@ -538,11 +582,14 @@ Steps 1–4 are common to all four options. Step 5 is written for Option B and n
   `unverified` and `null` show nothing. Desktop shows nothing, ever.
 - **Files:** `src/components/layout/status-bar.tsx`, `src/components/layout/status-bar.test.tsx`,
   `src/components/layout/app-layout.tsx`, `src/components/layout/app-layout.test.tsx`.
-- **Implementation:** a browser-only startup effect in `AppLayout` calling
-  `void useKeyResidueStore.getState().refreshAllResidue()`; a derived boolean in `StatusBar`.
-  Measure the startup cost of the dynamic adapter import and, if it is not negligible, defer the
-  call behind `requestIdleCallback` with a `setTimeout` fallback rather than blocking first
-  paint.
+- **Implementation:** a browser-only startup effect in `AppLayout`, and a derived boolean in
+  `StatusBar`. The effect is **not** a bare `void refreshAllResidue()`: it reads each provider's
+  slot as an uncommitted probe, settles `hasKey` for both providers only when the probe found
+  something, and commits the reading only after that. Ordering and the reason for the probe are
+  in the replan log rows *"the launch effect settles both `hasKey` calls before the first residue
+  read"* and *"the launch sequence reads the slot before it opens the vault"*. Measure the
+  startup cost of the dynamic adapter import and, if it is not negligible, defer the call behind
+  `requestIdleCallback` with a `setTimeout` fallback rather than blocking first paint.
 - **Option C delta:** new `src/components/layout/key-residue-bar.tsx` + test, rendered beside
   `UpdateBar`; no `StatusBar` change. **Option D delta:** a session-scoped `seen` flag in the
   store and a modal component; no `StatusBar` change.
@@ -571,8 +618,14 @@ adapter-mocked and must not import `fake-indexeddb`.
 | 2 — **surviving a remount** | `still warns after the settings panel is closed and reopened` | `ai-settings-content.test.tsx` | `const { unmount } = render(...)`; assert warning; `unmount()`; re-`render`; assert the warning is present again without any user action |
 | 3 — the two states differ | `distinguishes a retained copy from a check that was blocked` | `ai-settings-content.test.tsx` | Two cases, `"retained"` vs `"unverified"`; each asserts its own copy is present **and** the other's is absent |
 | 4 — no false "no key" | `does not claim the provider is unconfigured while a clear-text copy is readable` | `ai-settings-content.test.tsx` | `hasKey → false`, residue `"retained"`; `expect(screen.queryByText("No API key configured")).toBeNull()`. The existing test at ~line 162 that asserts `"No API key configured"` after a retained delete **must be updated**, not deleted — it encodes the current wrong behavior and its comment should record why it changed |
-| 5 — retry reachable | `keeps a removal control reachable while a clear-text copy remains` | `ai-settings-content.test.tsx` | `hasKey → false`, residue `"retained"`; the button renders and clicking it calls `deleteKey` again (spy asserts the second call) |
-| 6 — **warning clears** | `stops warning once the slot is actually gone` | `ai-settings-content.test.tsx` | `readLegacyResidue` returns `"retained"`, then `null` after the first `deleteKey`; click retry; the warning and the status-row text are both gone |
+| 5 — retry reachable | `keeps a retry reachable while a clear-text copy remains` | `ai-settings-content.test.tsx` | `hasKey → false`, residue `"retained"`; the control renders and clicking it calls `hasKey` again for that provider, and `deleteKey` never |
+| 5 — nothing destructive | `never reaches deleteKey from a residue notice, whatever the panel knows` | `ai-settings-content.test.tsx` | Every combination of `keyStatus` (`true`, `false`, rejected) and residue (`"retained"`, `"unverified"`) for both providers; click every control in every notice; `deleteKey` call count stays zero |
+| 5 — the retry reports | `says so when the retry changed nothing` and `says so when a blocked check is still blocked` | `ai-settings-content.test.tsx` | Residue still `"retained"` after the re-read; the panel authors the report `deleteKey`'s rejection used to carry. The `unverified` case is the same shape and matters more, because that reading never resolves on a blocked-storage profile — its report claims no removal and no absence |
+| 6 — **warning clears** | `stops warning once the slot is actually gone` | `ai-settings-content.test.tsx` | `readLegacyResidue` returns `"retained"`, then `null` once `hasKey` — which runs the migration — is allowed to erase; click retry; the warning and the status-row text are both gone |
+| 4 — not-yet-checked | `does not claim there is no key before the check has answered` | `ai-settings-content.test.tsx` | `hasKey` left pending; the row reads `Checking key storage…`, never `No API key configured`, and offers no removal |
+| rider — no plaintext in the queue | `does not park the plaintext key in the provider queue` | `browser-keychain-adapter.test.ts` | Spy `Map.prototype.set` to capture what `withProviderLock` stores under the provider key after a `getKey`; assert it resolves `undefined` |
+| launch — no vault without a slot | `does not open the key vault when there is no clear-text slot to migrate` | `app-layout.test.tsx` | No `hasKey` call at launch on a profile with no slot; plus `does not open the key vault to answer` in `browser-keychain-adapter.test.ts`, asserting `indexedDB.databases()` is empty after a residue read and non-empty after `hasKey` |
+| launch — adapter load fails | `still reads the slot when the keychain adapter fails to load first` | `app-layout.test.tsx` | First `getKeychainAdapter()` rejects; the store's own refresh still reports `"retained"` |
 | desktop parity | `shows nothing when the adapter has no residue check` | `ai-settings-content.test.tsx` | Fake adapter object with only `setKey`/`hasKey`/`deleteKey` — the shape `TauriKeychainAdapter` actually has — asserting no warning and no relabelled button |
 | store | `key-residue-store` cases | `src/stores/key-residue-store.test.ts` (new) | Adapter mock via `vi.mock("@/lib/adapters/get-keychain-adapter")`: sets from the capability; writes `null` when the method is absent; **keeps the prior value when the adapter module rejects**; `refreshAllResidue` covers both providers |
 | escalation (B) | `status-bar` cases | `src/components/layout/status-bar.test.tsx` | Seed the store with `useKeyResidueStore.setState(...)`: indicator present for `"retained"`, absent for `"unverified"` and `null`, click calls `openSettingsDialogAtTab("ai")` |
@@ -638,7 +691,8 @@ is present after a reload.
    open. Small, but measured in step 5 and deferred behind idle time if it is not.
 7. **A `retained` warning alongside a configured key.** `setKey` also attempts and ignores the
    erase, so residue can coexist with `keyStatus === true`. The copy is written to be true in
-   both cases; the status row is only overridden in the `false` case.
+   both cases; the status row is overridden for every `keyStatus` except `true`, which keeps
+   "API key configured" because that claim is still the more important one.
 
 **What must not regress.**
 
@@ -734,3 +788,23 @@ Green CI cannot decide any of these.
 | Date | Change | Evidence and reason |
 |------|--------|---------------------|
 | 2026-07-27 | Initial plan | Issue #233 body and its four comments; `browser-keychain-adapter.ts`, `browser-key-vault.ts`, `keychain-adapter.ts`, `tauri-keychain-adapter.ts`, `ai-settings-content.tsx`, `status-bar.tsx`, `update-bar.tsx`, `settings-store.ts`, and the existing adapter/panel test suites, all read on `main` |
+| 2026-07-27 | **Option B shipped; step 5 is no longer conditional.** The owner delegated the UI decision rather than answering it, so the implementer took the plan's own recommendation. "An implementer must not pick one" no longer holds and is struck from the human blockers | Owner delegation during implementation; the recommendation's stated reasoning was not re-litigated |
+| 2026-07-27 | **Deviation:** `StatusBar` adds a *second* always-mounted `sr-only` `role="status"` region rather than joining the existing `local-persistence-alert` one, as step 5 said it would | Coalescing them makes the two independent states fight: a save-failure transition would either silence a standing claim about a readable credential or re-announce it on every persistence change. Two regions cost one span and keep each announcement tied to its own condition |
+| 2026-07-27 | **Deviation:** the residue notice renders for **every** provider holding residue, not only the selected one, and each notice carries its own action bound to its own provider (plan step 4 said `residue[provider]`) | The status bar escalates *any* provider's `retained` slot (step 5) while the panel rendered only the selected one, so clicking the indicator with residue on the unselected provider opened a panel showing "No API key configured" and no control — the exact contradiction AC2/AC5 forbid. Found by the preflight review lanes |
+| 2026-07-27 | **Deviation:** the `unverified` notice copy names the provider ("could not check for an older clear-text **Anthropic** API key"), where the plan's shared copy did not | Follows from the change above: two unattributed amber blocks cannot be told apart once notices are per-provider |
+| 2026-07-27 | **Deviation:** the removal control is gated on `keyStatus === true \|\| residue === "retained"` **and** split in two — a destructive retry only where the encrypted record is known to be gone, and a non-destructive "Check again" everywhere else. Plan step 4 specified one control gated on `keyStatus[provider] \|\| residue[provider] !== null` | As written, an `unverified` reading rendered a red `Trash2` control labelled "Check again" wired to `deleteKey`, which commits a permanent `REVOKED` marker. A blocked-storage user who never had a key was told an erasure failed, and a user with a recoverable clear-text key destroyed it by asking for a read. Found by the preflight review lanes |
+| 2026-07-27 | **Deviation:** `keyStatus` gained a third state, `"unknown"`, for a `hasKey` that rejected, with its own status-row wording | The plan kept the boolean, which reported an unreadable vault as "No API key configured" — reassurance in the wrong direction on a key-storage surface, and after the change above it would also have fed a destructive gate |
+| 2026-07-27 | **Deviation:** the launch effect settles both `hasKey` calls before the first residue read, and `chat-store.checkApiKey` refreshes residue afterwards. Plan step 5 specified a bare `refreshAllResidue()` at launch | `readLegacyResidue` takes the provider lock, but at launch it is the *first* keychain call of the session, so the lock orders it behind nothing: it answered `"retained"` and the next `hasKey` migrated the slot away, leaving every pre-#133 user a standing red status-bar item over a resolved condition. The panel mount already ordered it correctly; the launch path now mirrors it |
+| 2026-07-27 | **Step 5 measurement recorded** (the plan required it and the first implementation asserted it instead). Chromium against the dev server: the whole launch sequence took a median 27ms with no legacy slot and 31ms with one to migrate; first contentful paint over 12 navigations was a median 404ms with the effect and 416ms without, inside a 396–424ms spread. No `requestIdleCallback` deferral is warranted | Temporary `performance.mark` instrumentation plus a throwaway Playwright spec, both removed after measuring |
+| 2026-07-27 | **Deviation:** the destructive residue control is removed entirely. `ResidueAction`, `residueAction()`, and the `retry-removal` branch are deleted; every residue notice binds one control to `handleRecheck`, labelled `Try removing it again` with no `Trash2`. Supersedes the row above, which split the control in two and kept a destructive branch | The split still decided from a render-time snapshot that `handleDelete` never re-verified. Reproduced end-to-end against the real IndexedDB vault: the panel settles honestly at `hasKey=false, residue="retained"`, the user saves a fresh key in a second tab, and clicking a control that speaks only about the clear-text slot destroys the new encrypted key. The pre-settle default was the same hole for ~26ms after mount, unbounded behind a cross-tab `blocked` upgrade. `deleteKey` bought nothing in that state either: a retirement marker already stands, so `hasKey` cannot re-import, and `migrateLegacyKey` runs `removeLegacyKey` unconditionally after the declined import — recheck-only measured `hasKey=false residue=null slot=null` once the browser allowed removal. Found by the PR reviewer and security lanes, independently, in round two |
+| 2026-07-27 | **Deviation:** the report `deleteKey`'s rejection used to carry is authored by the panel. `handleRecheck` re-reads residue and, if the provider still reads `"retained"`, surfaces it through the one-shot `message` | The retry is a re-read now, which resolves either way, so without this a browser that still refuses leaves an identical notice on screen and no evidence the click did anything. The adapter's "removed from encrypted storage" clause is deliberately dropped: a re-read removes nothing |
+| 2026-07-27 | **Deviation:** `keyStatus` gained a not-yet-checked state, `"unchecked"`, which is what `useState` now seeds; the status row reads `Checking key storage…` for it | `false` was doing double duty as "not asked yet" and "the encrypted record is known to be gone", and the row rendered the second reading — a false claim about storage — for the whole of every mount before `hasKey` answered |
+| 2026-07-27 | **Deviation:** the site-data instruction states what it costs. Both notices and both `deleteKey` `LEGACY_RETAINED` messages carry one shared `CLEARING_SITE_DATA_COST` sentence. The earlier note that the `deleteKey` messages are not changed is struck | The browser workspace keeps document bodies in IndexedDB with the manifest in `localStorage` (`src/lib/persistence/types.ts`, `workspace-storage.ts`), so following the instruction deletes the user's saved threat models. The plan named that cost when it rejected Option C and then shipped the instruction without it. `privacy-page.tsx` already states the same fact, in the same voice |
+| 2026-07-27 | **Deviation:** `busyProvider` became `busyProviders: Set<AiProvider>`, as `mutated` already was | With a notice per provider, two controls can have work in flight at once; the single slot let the first `finally` clear the flag while the second was still running, stopping its spinner and re-enabling its button mid-operation, and disabled `Remove API key` for either provider's work |
+| 2026-07-27 | **Rider recorded:** `withProviderLock` stores `pending.then(() => undefined, () => undefined)` rather than `pending.catch(() => undefined)`. Shipped unlogged in the first implementation; now carries a test | The stored queue link forwarded the operation's resolved value, which for `getKey` is the plaintext API key, leaving it in a module-scoped map until the provider's next call replaced it. Measured `map-stored resolves to "sk-ant-CANARY…"` before and `undefined` after, with identical microtask depth and FIFO ordering. Pinned by `does not park the plaintext key in the provider queue` |
+| 2026-07-27 | **Deviation:** the launch sequence reads the slot before it opens the vault. `AppLayout` probes `readLegacyResidue` for both providers, runs `hasKey` only if the probe found something, and commits the reading after that. Supersedes the unconditional `hasKey` in the row above; the ordering guarantee and its regression test are unchanged | `readLegacyResidue` is a `localStorage` read that never touches IndexedDB, while `hasKey` opens `threatforge-keychain` — so the unconditional version materialised that database at launch for every browser profile, including the majority that never touch AI, where previously it appeared only on first AI use. The probe's own answer is deliberately not committed, because `migrateLegacyKey` may be about to erase the slot it reported. Pinned by `does not open the key vault when there is no clear-text slot to migrate` and, at the adapter level, `does not open the key vault to answer` |
+| 2026-07-27 | **Deviation:** the retry reports for `unverified` too, not only `retained`. `retainedAfterRetryText` became `retryReportText(residue, vendor)`, and the AC5 paragraph now describes both readings | The row above authored the report for `retained` alone, which left the one state that never resolves — a blocked-storage profile reads `unverified` forever — with a control that produced no message, no state change and an identical notice. That is the exact failure that row exists to prevent. The `unverified` wording claims no removal and no absence: `migrateLegacyKey` returns before it touches the slot when the read is refused, so nothing is attempted. Found by the round-three review lanes |
+| 2026-07-27 | **Deviation:** the launch effect's `catch` logs through `console.warn`, matching `loadAdapter`. The plan and the code comment said the failure "is reported where the user can act on it, in the settings panel" | That holds only for a user who opens the panel, and the launch check exists precisely because they may never do so. A permanently broken adapter chunk now leaves a trace a bug report can carry. Pinned by `still reads the slot when the keychain adapter fails to load first` |
+| 2026-07-27 | **Deviation:** the retry report no longer repeats the remedy or its cost, and the notice control's label branches — `Try removing it again` for `retained`, `Check again` for `unverified` | The report is only ever set while residue is non-null, which is the same condition that renders the notice above it, so both surfaces were guaranteed co-rendered: the user read "clear this site's browser data" twice and the cost sentence twice, a few lines apart. On the primary `handleDelete` flow the adapter's `LEGACY_RETAINED` message made it three times. The report now says only what is new. The shared label had the same problem in miniature — on an `unverified` reading no removal has been attempted, so neither "removing" nor "again" was true, and the report had to walk the label back one line later with "Nothing was removed". Found by the round-three slop lane |
+| 2026-07-27 | **Copy correction:** the status-bar detail says `Open AI settings to deal with it`, not `to remove it`; the notice says `ThreatForge has not been able to delete it`, not `this browser will not delete it` | The indicator renders only on `retained`, which means the erase was already attempted and refused — so the panel it routes to offers a retry that may fail again and the site-data remedy, not removal. It is the first string a user meets, ahead of every careful hedge downstream. The notice's causal clause had the narrower version of the same fault: when `hasKey` rejects, `migrateLegacyKey` never reaches `removeLegacyKey`, so the browser refused nothing |
+| 2026-07-27 | **Test strengthened:** `leaves a standing warning alone when the check did not clear the slot` now seeds the residue store empty and puts `retained` only in the slot | As written it seeded the store with the value it asserted, so it passed with the `checkApiKey` refresh deleted — it pinned only a hypothetical implementation that clears residue unconditionally. Deleting the refresh now fails both chat-store cases rather than one. Found by the round-three slop lane |

--- a/docs/plans/233-persistent-clear-text-key-warning.md
+++ b/docs/plans/233-persistent-clear-text-key-warning.md
@@ -1,0 +1,736 @@
+# Issue 233 — Surface a surviving clear-text API key persistently in AI settings
+
+## Objective
+
+When a browser refuses to erase the pre-#133 clear-text `localStorage` slot, ThreatForge tells
+the user — for as long as the slot is readable, on every mount, in a surface they will actually
+encounter — that a usable API key is still sitting in clear text in this browser, distinguishes
+"definitely still there" from "the check was blocked", and keeps a retry reachable. It never
+again claims "No API key configured" while a readable clear-text copy exists.
+
+## Issue contract
+
+- **Issue:** `#233`
+- **Parent initiative:** `N/A` (related: `#133`, `#231`, `#234`)
+- **Type:** `Bug`
+- **Effort:** `High` (trust boundary and key handling; tier is a floor per `AGENTS.md`)
+- **Priority:** `Urgent` (shipped code misreports secret deletion)
+- **Autonomy:** labelled `AUTO`; **see "Human blockers"** — one owner decision gates step 5, and
+  steps 1–4 are `AUTO` once it is made
+- **Dependencies:** `#133` (merged; introduced the encrypted vault, the erasure read-back, and
+  the `legacy-retained` reason this issue makes persistent)
+- **Non-goals:**
+  - Changing `deleteKey`'s rejection, the migration guards, the retirement markers, or any
+    `browser-key-vault.ts` behavior. #133's fail-closed posture is preserved exactly.
+  - Relaxing the `unverified` answer into "probably absent". Failing closed is the recorded
+    stance (issue comment, round-12 security review).
+  - Overwriting or neutering the clear-text slot in place. See "Follow-up issues".
+  - The adjacent `hasKey === true` / undecryptable-record case, which is `#234`.
+  - Any Rust, IPC, `.thf`, or AI-protocol change.
+
+## Human blockers
+
+1. **The UI surface is an owner decision.** The issue says so ("The right surface is a design
+   decision, not a mechanical one"). Four options are specified below with a recommendation.
+   Steps 1–4 are identical under all four; step 5 exists only for options B, C, and D. An
+   implementer must not pick one. **Nothing in steps 1–4 is blocked by this** — they can be
+   executed and reviewed while the decision is pending, because the store they produce is what
+   every option reads.
+2. **Autonomy label.** `AUTO` is accurate only after (1) is answered. If the owner prefers to
+   answer it inside the PR rather than before, the issue should carry `HITL`. Recording it
+   rather than changing metadata, per the planner contract.
+
+## Current behavior and evidence
+
+Verified against `main` at plan time. Line references are to the files as they stand.
+
+**The vault (`src/lib/adapters/browser-key-vault.ts`).** A browser key is AES-GCM ciphertext in
+the `threatforge-keychain` IndexedDB database under a non-extractable wrapping key.
+`KeyVaultError` carries a closed `KeyVaultErrorReason` union that includes
+`typeof LEGACY_RETAINED`.
+
+**The legacy slot (`src/lib/adapters/browser-keychain-adapter.ts`).** The pre-#133 clear-text
+`localStorage` slot is `tf-api-key-<provider>` (`LEGACY_KEY_PREFIX`, line 18). Three internal
+pieces matter here and already exist:
+
+```ts
+type LegacySlot =
+	| { readonly state: "present"; readonly value: string }
+	| { readonly state: "absent" }
+	| { readonly state: "unreadable" };
+
+function readLegacySlot(provider: AiProvider): LegacySlot
+
+type LegacyErasure = "erased" | "retained" | "unverified";
+function removeLegacyKey(provider: AiProvider): LegacyErasure
+```
+
+`readLegacySlot` returns `unreadable` when `localStorage.getItem` throws — the file's own comment
+says collapsing `absent` and `unreadable` "lets the adapter report a live clear-text credential
+as erased". `removeLegacyKey` decides on the read-back, not on the `removeItem` call.
+
+`deleteKey` erases the slot **first**, then commits `retireAndDeleteSecret(provider)`, then
+throws when `erasure !== "erased"` with one of two authored messages ("would not delete an older
+clear-text copy" for `retained`, "blocked the check for an older clear-text copy" for
+`unverified`). `setKey` calls `removeLegacyKey` and deliberately ignores the result. `hasKey` and
+`getKey` run `migrateLegacyKey`, which — because a `REVOKED` marker makes `importLegacySecret`
+return early and `removeLegacyKey` then runs unconditionally — **already retries the erase on
+every read**. That is why a browser that starts allowing removal heals itself on the next panel
+mount, and why a residue read must be ordered after the `hasKey` calls, not before.
+
+The class docblock records the deferral verbatim: *"Surfacing it persistently in settings is
+#233."*
+
+**The interface (`src/lib/adapters/keychain-adapter.ts`).** Exactly three members, plus a shared
+reason constant:
+
+```ts
+export interface KeychainAdapter {
+	/** Store an API key for a provider. */
+	setKey(provider: AiProvider, key: string): Promise<void>;
+	/** Check if an API key exists for a provider. */
+	hasKey(provider: AiProvider): Promise<boolean>;
+	/** Delete an API key for a provider. */
+	deleteKey(provider: AiProvider): Promise<void>;
+}
+
+export const LEGACY_RETAINED = "legacy-retained";
+```
+
+`getKey` is deliberately **absent** so that asking a desktop adapter for a key is a build
+failure; `keychain-adapter.test.ts` pins that with `@ts-expect-error` plus a runtime `TypeError`
+assertion, and `browser-chat-adapter.ts:330` reaches the browser-only capability by constructing
+`new BrowserKeychainAdapter()` directly from a browser-only module. That precedent is the
+starting point for the contract below — and, as argued there, it does not transfer unchanged.
+
+**The panel (`src/components/panels/ai-settings-content.tsx`).** `keyStatus` is component state,
+`Record<AiProvider, boolean>`. The mount effect settles both providers with
+`Promise.allSettled` and surfaces a rejection through `setMessage` (the swallow the issue body
+cites at lines 61-63 was fixed in #133 preflight round 9; the first issue comment records this).
+`handleDelete` treats a `LEGACY_RETAINED` rejection as a successful removal plus a message. The
+status row renders `keyStatus[provider] ? "API key configured" : "No API key configured"`, and
+the Remove button is gated on `keyStatus[provider]`. `message` is one-shot: `handleSave` and
+`handleDelete` both call `setMessage(null)` on entry, and the panel unmounts when the settings
+dialog closes (`settings-dialog.tsx` renders `AiSettingsContent` under `settingsDialogOpen`).
+
+So the reported state is lost on the next action or the next dialog close, and what remains
+contradicts it. That is the whole bug.
+
+**Escalation surfaces that already exist.** `StatusBar` (`src/components/layout/status-bar.tsx`)
+carries a persistence indicator with an `attention` flag, a `title` detail, and an always-mounted
+`role="status"` `sr-only` live region that announces only attention states. `UpdateBar`
+(`src/components/layout/update-bar.tsx`) is a dismissible full-width bar rendered by `AppLayout`
+directly under `TopMenuBar`. `useSettingsStore` exposes
+`openSettingsDialogAtTab: (tab: SettingsTab) => void` with `"ai"` among its tabs — that is the
+routing action any escalated surface uses.
+
+**Test ground truth.** `src/lib/adapters/test-fixtures/key-vault.ts` exports
+`resetKeyVault(): void`, which replaces `globalThis.indexedDB` with a fresh `IDBFactory`; its
+docblock states that `localStorage.clear()` does not touch IndexedDB, so a suite relying on it
+alone carries a key between cases. `browser-keychain-adapter.test.ts` already has
+`refuseLegacyRemoval()` (a `Storage.prototype.removeItem` no-op spy, ~line 804) and a
+`getItem`-throws spy (~line 927) — the two fakes this issue needs. `ai-settings-content.test.tsx`
+mocks `@/lib/adapters/get-keychain-adapter` and never touches IndexedDB; that stays true.
+
+## The capability contract
+
+### Decision
+
+Add **one optional method and one exported type** to `src/lib/adapters/keychain-adapter.ts`.
+`TauriKeychainAdapter` does not implement it and does not mention it.
+
+```ts
+/**
+ * What a pre-#133 clear-text API key slot currently holds for one provider.
+ *
+ * `null` is an answer, not an absence of one: the slot was checked and nothing is there.
+ * A caller that cannot get an answer at all sees `undefined` from the optional call instead —
+ * see {@link KeychainAdapter.readLegacyResidue}.
+ */
+export type LegacyResidue = "retained" | "unverified" | null;
+
+export interface KeychainAdapter {
+	/** Store an API key for a provider. */
+	setKey(provider: AiProvider, key: string): Promise<void>;
+	/** Check if an API key exists for a provider. */
+	hasKey(provider: AiProvider): Promise<boolean>;
+	/** Delete an API key for a provider. */
+	deleteKey(provider: AiProvider): Promise<void>;
+	/**
+	 * Browser only. Report whether a pre-#133 clear-text copy of this provider's key is still
+	 * readable from `localStorage`, without attempting to erase it and without returning any
+	 * part of the key.
+	 *
+	 * Optional because a platform that never had a clear-text slot has nothing to answer.
+	 * `undefined` from the optional call is "there is no such storage location here"; `null` is
+	 * "there is one, it was checked, and it is empty". Collapsing those two is the same mistake
+	 * `readLegacySlot` refuses to make one level down, and it is what would let a desktop build
+	 * assert an erasure it never performed.
+	 */
+	readLegacyResidue?(provider: AiProvider): Promise<LegacyResidue>;
+}
+```
+
+`browser-keychain-adapter.ts` implements it as a pure read under the existing per-provider lock:
+
+```ts
+async readLegacyResidue(provider: AiProvider): Promise<LegacyResidue> {
+	return withProviderLock(provider, async () => {
+		const slot = readLegacySlot(provider);
+		if (slot.state === "absent") return null;
+		return slot.state === "present" ? "retained" : "unverified";
+	});
+}
+```
+
+### Why this shape
+
+**Why not "required on every adapter, Tauri returns `null`".** `null` is load-bearing: it is the
+exact value every consumer uses to hide the warning. A Tauri implementation returning it would be
+asserting *"I checked this provider's clear-text slot and it is empty"* about a storage location
+that does not exist on desktop, where the key lives in an encrypted file behind `KeyStorage` and
+never enters the webview. That is a false claim with the same structure as the bug this issue
+fixes — a security surface reporting a check it did not perform. It would also be dead
+scaffolding (`AGENTS.md` anti-slop: "impossible defensive branches and dead scaffolding"): a
+method whose body is `return null` forever, that no Rust command backs, that no test can
+meaningfully exercise, and that a future desktop maintainer would reasonably read as an
+obligation to implement. And it hands every future adapter an obligation it cannot fulfil
+honestly.
+
+**Why not "browser-only method off the interface entirely", the `getKey` precedent.** `getKey`
+stays off `KeychainAdapter` because *reaching it must be impossible* — the invariant is that the
+desktop key never enters the webview, so making the request a build failure is the point, and its
+one caller (`browser-chat-adapter.ts`) is itself a browser-only module that can import
+`BrowserKeychainAdapter` directly. Neither condition holds here. The residue read is not
+dangerous — it returns a three-value token, never key material — so there is nothing to forbid.
+And its caller is `ai-settings-content.tsx`, a **shared** component that renders on both
+platforms and holds a `KeychainAdapter` from `getKeychainAdapter()`. Reaching a browser-only
+method from there would mean either a static import of `BrowserKeychainAdapter` — which the
+panel's own comment already rules out, "which would pull IndexedDB code into the desktop bundle"
+— or a runtime `"readLegacyResidue" in adapter` narrowing, which under `strict` narrows the
+member to `unknown` and forces a cast to call it. A cast is exactly the type escape the slop
+guardrails name, and it would erase the platform difference from the type system at the one
+callsite that has to reason about it.
+
+**What the optional method buys.** `adapter.readLegacyResidue?.(provider)` types as
+`Promise<LegacyResidue> | undefined` with no cast, no `any`, and no `in` check. The `?.` is not
+ceremony: it is the callsite acknowledging, visibly and at compile time, that this platform may
+not have a legacy slot at all. The union stays closed, so a typo in a residue value is a build
+error the same way `LEGACY_RETAINED`'s inferred literal type keeps `KeyVaultErrorReason` closed
+(pinned by an existing test in `keychain-adapter.test.ts`). And the desktop adapter genuinely
+does not carry the method, so `"readLegacyResidue" in new TauriKeychainAdapter()` is `false` —
+the same runtime assertion the file already makes about `getKey`.
+
+**Method shorthand, not a property signature.** `readLegacyResidue?(p): Promise<LegacyResidue>`
+matches the three existing members' style. Method shorthand is bivariant under
+`strictFunctionTypes` while a property signature would be contravariant; with a single-parameter,
+single-implementation capability there is no variance hazard to trade for the inconsistency.
+
+**Why `Promise`, when `localStorage` is synchronous.** Because it takes `withProviderLock`.
+`migrateLegacyKey` erases the slot *after* `importLegacySecret` commits, so a synchronous read
+interleaved into that gap reports `retained` for a slot that is about to be erased — a false
+alarm on the ordinary upgrade path, on first mount, for every pre-#133 user. Taking the lock
+makes the answer reflect a settled adapter state. It also matches the interface's uniform async
+shape, so consumers do not branch on call style.
+
+**The one hazard this creates:** `readLegacyResidue` must never be called from inside a
+`withProviderLock` callback — the lock is a promise chain, not reentrant, so a nested call would
+deadlock that provider's queue forever. No planned callsite does this (all callers are the store
+and the panel, outside the adapter). Recorded here and as a code comment.
+
+**What it must never do:** return, log, or store `slot.value`. The residue state is a token. The
+adapter reads the value only to distinguish `present` from `absent`, and discards it in the same
+expression.
+
+**Why not derive it from the thrown `KeyVaultError`.** Acceptance criterion 1 rules it out, and
+for a reason worth restating: an error is produced only by an action. A user who missed the
+banner, or who has residue from a `setKey` that silently failed to erase, never triggers one. A
+capability answers on demand; an exception answers once.
+
+## State flow
+
+**Home: a new Zustand store, `src/stores/key-residue-store.ts`.** Not component state, not
+`chat-store`.
+
+```ts
+interface KeyResidueState {
+	/** Per-provider clear-text residue. `null` also covers "not checked yet" and desktop. */
+	residue: Record<AiProvider, LegacyResidue>;
+	/** Re-read one provider's slot through the keychain adapter. Never throws. */
+	refreshResidue: (provider: AiProvider) => Promise<void>;
+	/** Re-read every provider. */
+	refreshAllResidue: () => Promise<void>;
+}
+
+export const useKeyResidueStore = create<KeyResidueState>()(/* ... */);
+```
+
+- **Not component state**, because the panel unmounts with the settings dialog and every option
+  except A needs a second surface to read the same fact. Under option A alone the store is still
+  the better home — three writers (mount, save, delete) and one reader is already the shape a
+  store exists for — but if the owner picks A, an implementer may collapse it to `useState` in
+  the panel without violating this plan. Every other option requires the store.
+- **Not `chat-store`**, whose `hasApiKey` answers "can I send a request". Residue is the
+  opposite: a key that is *not* usable by the transport and is a storage-hygiene problem.
+  Folding it in would make a conversation store carry a security surface and would tempt a future
+  reader to gate requests on it.
+- **No `persist` middleware, deliberately.** Residue is derived from storage and must be
+  re-derived every session; a persisted copy is a stale claim about a secret. Worse, the
+  persistence target would be `localStorage` — the storage that is, by hypothesis, refusing
+  writes. #133 records the same reasoning for putting the retirement marker in the vault: *"a
+  browser that refuses to erase the clear-text slot cannot be trusted to hold a note saying it
+  was dismissed."* The same applies to any dismissal state an option below introduces: dismissal
+  is in-memory and session-scoped, never persisted.
+- **`refreshResidue` never rejects.** It loads the adapter via `getKeychainAdapter()`, calls
+  `adapter.readLegacyResidue?.(provider)`, and writes the result; when the method is absent it
+  writes `null`. If the adapter *module* fails to load it leaves the previous value untouched and
+  returns — it does not write `null`, because "the bundle did not load" is not evidence the slot
+  is empty. That failure already reaches the user through the panel's `ADAPTER_LOAD_ERROR` path,
+  so nothing is swallowed that is not reported elsewhere.
+
+**When it is read.**
+
+| Trigger | Where | Why |
+|---|---|---|
+| Panel mount, **after** both `hasKey` calls settle | `ai-settings-content.tsx` mount effect | `hasKey` runs `migrateLegacyKey`, which retries the erase; reading first would report a slot that the same tick removed |
+| After `handleSave`, success or failure | `handleSave` `finally` | `setKey` attempts `removeLegacyKey` and ignores the outcome, so a save can both clear residue and (on a refusing browser) leave it |
+| After `handleDelete`, success **and** the `LEGACY_RETAINED` branch **and** any other error | `handleDelete` `finally` | This is the state transition the issue is about; the `finally` also covers a vault error thrown after the slot was already erased |
+| Once at app start, browser only | `AppLayout` effect (options B, C, D only) | The user may never open AI settings — the whole point of escalating |
+
+**How it clears.** Nothing clears it manually. Every refresh recomputes from storage, so the
+warning disappears the moment the slot reads `absent`: after a successful retry, after a mount
+whose `hasKey` migration finally erased it, or after the user clears site data and reloads. There
+is no dismissal that survives a session and none that survives a reload.
+
+**Guard for the mount effect.** The existing `mutated` ref exists so a slow `hasKey` cannot
+overwrite a save or delete the user just performed. Residue does not need it: `refreshResidue`
+reads storage directly and its answer is always the newest one at the moment it resolves, and the
+per-provider lock orders it behind any in-flight adapter operation. Do not extend `mutated` to
+cover it — that would suppress a fresh true answer.
+
+**AC4 in the status row.** The row becomes three-state:
+
+| `keyStatus` | `residue` | Dot | Text |
+|---|---|---|---|
+| `true` | any | green | `API key configured` |
+| `false` | `"retained"` | destructive | `Clear-text API key still in this browser` |
+| `false` | `"unverified"` or `null` | muted | `No API key configured` |
+
+`unverified` keeps "No API key configured" because it *is* the honest summary — nothing is known
+to be readable — and the separate notice carries the uncertainty. AC4 speaks only of a *readable*
+copy.
+
+**AC5, the retry path.** Keep the existing Remove button and widen its gate to
+`keyStatus[provider] || residue[provider] !== null`, relabelling to
+`Try removing the clear-text copy again` when `!keyStatus[provider]`. It calls the unchanged
+`handleDelete`, so the retry is `deleteKey` — which runs `removeLegacyKey` first, then re-commits
+the (idempotent) `REVOKED` marker and a no-op record delete. On a browser that has started
+allowing removal this resolves and the residue refresh clears the warning; on one that has not it
+rejects with the same authored message and the persistent warning stays. Both outcomes are
+honest, and no existing code path changes.
+
+**Considered and rejected as the offered action:** having the app call `localStorage.clear()`. If
+`removeItem` is refused, `clear()` has no reason to succeed, and on the paths where it would it
+destroys unrelated settings and onboarding state to remove one slot. The app genuinely cannot fix
+this itself; the copy says so and points at the browser's own site-data control. Overwriting the
+slot in place is a real alternative and is filed as a follow-up rather than smuggled in here.
+
+## The UI surface — four options for the owner
+
+All four share the same substrate (steps 1–4) and the same copy rules below; they differ in
+placement, persistence, dismissibility, and whether they escalate outside the panel.
+
+### Shared copy (applies to every option)
+
+Fact first, no blame, one concession — per `docs/knowledge/product-voice.md`. The existing
+`deleteKey` messages are **not** changed; this copy is the standing version of them.
+
+*`retained`, provider named:*
+> **A clear-text Anthropic API key is still stored in this browser.**
+> It was saved before ThreatForge encrypted keys, and this browser will not delete it. Anything
+> that can read this site's storage can read the key. Clear this site's browser data to remove
+> it, and revoke the key with Anthropic if it may have been exposed.
+> This copy is not a backup — ThreatForge erases it as soon as the browser allows.
+> `[ Try removing it again ]`
+
+The "not a backup" line is required: it is the round-13 security note folded into this issue's
+scope, and it is what stops a user treating the retained slot as a recovery copy before a
+`getKey` erases it.
+
+*`unverified`, visibly calmer — amber, not destructive:*
+> **ThreatForge could not check for an older clear-text API key.**
+> This browser blocked the check, so an unencrypted copy saved by an older version may or may
+> not still be there. If you used ThreatForge in this browser before keys were encrypted, clear
+> this site's browser data to be sure.
+> `[ Check again ]`
+
+Neither string ever interpolates key material. Provider labels come from the existing `PROVIDERS`
+list.
+
+---
+
+### Option A — In-panel standing notice, nothing outside the panel
+
+The status row becomes the three-state row above, and directly beneath it a permanent bordered
+block renders the copy while `residue[provider] !== null`. Not dismissible. Disappears only when
+the read comes back `null`. `AppLayout`, `StatusBar`, and every non-AI surface are untouched.
+
+- **Persistence:** for the life of the condition, but only inside the AI tab of the settings
+  dialog.
+- **Dismissible:** no.
+- **Escalation:** none.
+- **`retained` vs `unverified`:** colour (destructive vs amber), heading, and button label.
+- **Action:** retry button plus the site-data instruction.
+- **Cost:** one component, one store (or `useState`), zero new app chrome, smallest blast radius,
+  no startup work, no new accessibility surface.
+- **Weakness, and it is the issue's own words:** *"A user who revoked a possibly-compromised key
+  and missed the one banner has no surface anywhere in the app telling them."* A notice inside a
+  dialog they have no reason to reopen is strictly better than a one-shot banner and still leaves
+  that user uninformed. This is the floor, not the answer.
+
+### Option B — Option A plus a persistent status-bar indicator (recommended)
+
+Everything in Option A, plus a `StatusBar` item rendered whenever **any** provider reads
+`"retained"`: `Clear-text API key` in destructive text, with a `title` carrying the detail, as a
+button that calls `openSettingsDialogAtTab("ai")`. It joins the existing always-mounted
+`role="status"` `sr-only` region used for `attention` states, so it is announced once when it
+first appears rather than on every render.
+
+- **Persistence:** every session, every view, until the slot is gone. Survives dialog close,
+  reload, and restart.
+- **Dismissible:** no — and it costs the user nothing to leave standing, because the status bar
+  is 24px of chrome that is already there.
+- **Escalation:** yes, but quiet. `unverified` **does not** escalate: it stays in the panel only.
+  That asymmetry is the design. The status-bar item means "a live credential is definitely
+  readable in this browser"; the round-12 case, where a blocked-storage profile that never had a
+  slot reports `unverified` forever, therefore cannot produce permanent app-wide chrome from a
+  condition that may not exist.
+- **Action:** clicking routes into the panel where the retry and the instructions live.
+- **Cost:** the store becomes mandatory, `AppLayout` gains a browser-only startup refresh (which
+  dynamically imports the keychain adapter chunk at launch instead of at first settings open —
+  small, and worth measuring in step 5), and `StatusBar` gains its first interactive element, so
+  focus order and hit target need checking.
+- **Weakness:** a status bar is easy to not look at. It is a standing fact, not an interruption.
+
+### Option C — Option A plus a non-dismissible global bar
+
+Everything in Option A, plus a `KeyResidueBar` rendered in `AppLayout` beside `UpdateBar`,
+following that component's structure: full-width, destructive rather than primary tinted, naming
+the provider, with `[ Open AI settings ]` and `[ Recheck ]`. No dismiss control while
+`"retained"`. `unverified` renders the same bar in amber **with** a session-scoped in-memory
+dismiss.
+
+- **Persistence:** every session until resolved; unmissable.
+- **Dismissible:** only `unverified`, only for the session.
+- **Escalation:** maximum. Proportionate to the actual severity — the user believes they deleted
+  a possibly-compromised credential and it is readable on disk.
+- **`retained` vs `unverified`:** colour, copy, and the presence of a dismiss control.
+- **Action:** both actions inline.
+- **Cost:** permanent vertical space in a canvas application, for a condition the user may be
+  unable to resolve right now — clearing site data is a deliberate act with its own consequences
+  (it drops the browser workspace). A user who cannot do it today gets an undismissable red bar
+  every session, which is how banner blindness is manufactured, and which risks them clearing
+  site data reflexively and losing work.
+- **When this is right:** if the owner judges that a security tool misreporting secret deletion
+  warrants interrupting every session until fixed, this is the honest expression of that. B→C is
+  a one-component swap later, since both read the same store.
+
+### Option D — Option A plus a once-per-session interruption
+
+Everything in Option A, plus: on the first detection in a session — at app start, or immediately
+after a delete leaves residue — a modal interrupts with the full explanation, `[ Recheck ]`, and
+`[ Continue ]`. Dismissing it lasts for the session only; it returns next launch until resolved.
+`unverified` never opens the modal.
+
+- **Persistence:** returns every session, so it is not one-shot; between appearances the in-panel
+  block is the standing record.
+- **Dismissible:** yes, per session, in memory.
+- **Escalation:** high signal at the moment of detection, zero permanent chrome.
+- **Action:** the explanation and recheck are in the modal; the retry lives in the panel it links
+  to.
+- **Cost:** a startup modal is the most intrusive pattern in this app and would fire on a
+  workflow that has nothing to do with AI. It also collides with the existing first-run overlays
+  (`suppressFirstRunOverlays` in `e2e/fixtures.ts` exists because startup overlays are already a
+  test hazard), and it needs focus-trap and restore handling. And once dismissed for the session,
+  the user is back to a notice inside a dialog — so it does not actually dominate B.
+
+### Recommendation: **Option B**
+
+It is the only option that answers the issue's actual complaint — *the user may never reopen the
+panel* — without either permanently occupying application chrome or interrupting unrelated work.
+It reuses a surface that already exists and is already tested, including its accessibility
+pattern, so the announced-once live region comes for free rather than being reinvented. It gives
+the cleanest place to hold the `retained` / `unverified` line: the escalated surface carries only
+the claim that is certain, which bounds the blast radius of the round-12 false positive to a
+panel a user has to open. And if it proves too quiet in owner validation, C is reachable by
+replacing one component that reads the same store, with no change to steps 1–4.
+
+## Implementation steps
+
+Steps 1–4 are common to all four options. Step 5 is written for Option B and notes the deltas.
+
+### 1. Declare the capability
+
+- **Behavior:** `KeychainAdapter` gains an optional `readLegacyResidue`; `LegacyResidue` is
+  exported. No runtime behavior changes anywhere.
+- **Files:** `src/lib/adapters/keychain-adapter.ts`.
+- **Implementation:** add the type and the optional member exactly as quoted in "The capability
+  contract", including the docblock explaining `undefined` vs `null`. Do not touch
+  `tauri-keychain-adapter.ts`.
+- **Targeted verification:** `npx tsc --noEmit` — `TauriKeychainAdapter` must still satisfy
+  `KeychainAdapter` with no edit, which is the whole point of the optional member.
+- **Intent validation:** the owner reads the docblock and agrees `undefined` and `null` are
+  described as different claims rather than as a nullability convenience.
+
+### 2. Implement it in the browser adapter
+
+- **Behavior:** `BrowserKeychainAdapter.readLegacyResidue(provider)` resolves `"retained"` when
+  the slot reads `present`, `"unverified"` when it reads `unreadable`, `null` when `absent`. It
+  never erases, never writes, never returns key material, and never rejects.
+- **Files:** `src/lib/adapters/browser-keychain-adapter.ts`,
+  `src/lib/adapters/browser-keychain-adapter.test.ts`,
+  `src/lib/adapters/keychain-adapter.test.ts`.
+- **Implementation:** add the method as quoted, under `withProviderLock`. Add a comment stating
+  it must not be called from inside another locked operation. Update the class docblock's #233
+  deferral note to point at this method instead of at a future issue. Leave `readLegacySlot`,
+  `removeLegacyKey`, `LegacyErasure`, `migrateLegacyKey`, `setKey`, `hasKey`, `getKey`, and
+  `deleteKey` byte-identical.
+- **Targeted verification:**
+  `npx vitest run src/lib/adapters/browser-keychain-adapter.test.ts src/lib/adapters/keychain-adapter.test.ts`
+  — see the test plan for the discriminating cases.
+- **Intent validation:** the owner confirms no path can now erase a slot as a side effect of a
+  read that did not already do so, and that the desktop adapter is untouched.
+
+### 3. Add the residue store
+
+- **Behavior:** `useKeyResidueStore` holds `Record<AiProvider, LegacyResidue>` and refresh
+  actions that never reject, write `null` when the adapter has no such capability, and leave the
+  previous value when the adapter module fails to load.
+- **Files:** `src/stores/key-residue-store.ts` (new), `src/stores/key-residue-store.test.ts`
+  (new).
+- **Implementation:** plain `create<KeyResidueState>()`, no middleware, named export, initial
+  `{ anthropic: null, openai: null }`. `refreshAllResidue` fans out over both providers with
+  `Promise.all` (each already non-rejecting).
+- **Targeted verification:** `npx vitest run src/stores/key-residue-store.test.ts`.
+- **Intent validation:** confirm nothing persists and nothing here is reachable by the transport.
+
+### 4. Wire the panel
+
+- **Behavior:** the three-state status row; a persistent warning block while
+  `residue[provider] !== null`; the Remove/retry button gated on
+  `keyStatus[provider] || residue[provider] !== null`; residue refreshed on mount (after both
+  `hasKey` calls settle) and in the `finally` of both `handleSave` and `handleDelete`. The
+  existing one-shot `message` stays exactly as it is.
+- **Files:** `src/components/panels/ai-settings-content.tsx`,
+  `src/components/panels/ai-settings-content.test.tsx`.
+- **Implementation:** render the block with `role="alert"` and the same visual grammar as the
+  existing legacy-model warning (`AlertTriangle`, bordered tinted box) — destructive tint for
+  `retained`, amber for `unverified`. Copy exactly as specified above. Keep the existing security
+  note paragraph.
+- **Targeted verification:** `npx vitest run src/components/panels/ai-settings-content.test.tsx`.
+- **Intent validation:** the owner deletes a key in a browser with `removeItem` stubbed, closes
+  and reopens settings, and reads what the panel says.
+
+### 5. The escalated surface (Option B as written; skip entirely for Option A)
+
+- **Behavior:** while any provider reads `"retained"`, `StatusBar` shows a `Clear-text API key`
+  button that opens settings at the AI tab and is announced through the existing live region.
+  `unverified` and `null` show nothing. Desktop shows nothing, ever.
+- **Files:** `src/components/layout/status-bar.tsx`, `src/components/layout/status-bar.test.tsx`,
+  `src/components/layout/app-layout.tsx`, `src/components/layout/app-layout.test.tsx`.
+- **Implementation:** a browser-only startup effect in `AppLayout` calling
+  `void useKeyResidueStore.getState().refreshAllResidue()`; a derived boolean in `StatusBar`.
+  Measure the startup cost of the dynamic adapter import and, if it is not negligible, defer the
+  call behind `requestIdleCallback` with a `setTimeout` fallback rather than blocking first
+  paint.
+- **Option C delta:** new `src/components/layout/key-residue-bar.tsx` + test, rendered beside
+  `UpdateBar`; no `StatusBar` change. **Option D delta:** a session-scoped `seen` flag in the
+  store and a modal component; no `StatusBar` change.
+- **Targeted verification:** `npx vitest run src/components/layout/`.
+- **Intent validation:** the owner confirms the indicator is noticeable enough to matter and
+  quiet enough to live with, and that it is absent on desktop.
+
+## Test plan
+
+Fixture facts that govern the whole plan: `resetKeyVault()` from
+`src/lib/adapters/test-fixtures/key-vault.ts` is what empties the vault, because
+`localStorage.clear()` does not touch IndexedDB — any adapter-level case here must call it in
+`beforeEach`/`afterEach` as the existing suites do. Panel and store tests stay
+adapter-mocked and must not import `fake-indexeddb`.
+
+| AC | Test | File | Approach |
+|---|---|---|---|
+| 1 — capability reports `retained` | `reports a clear-text copy the browser refused to erase` | `browser-keychain-adapter.test.ts` | `setKey`, `refuseLegacyRemoval()` (existing helper ~line 804), seed `LEGACY_SLOT`, `await deleteKey(...).catch(...)`, then `expect(await adapter.readLegacyResidue("anthropic")).toBe("retained")`. Also asserts the `deleteKey` rejection is still `LEGACY_RETAINED` — the new capability must not replace it |
+| 1 — capability reports `unverified` | `reports storage that would not answer as unverified` | `browser-keychain-adapter.test.ts` | `Storage.prototype.getItem` throwing spy (pattern at ~line 927) → `"unverified"` |
+| 1 — capability reports `null` | `reports no residue when the slot is genuinely absent` | `browser-keychain-adapter.test.ts` | Fresh vault, no slot → `null`; and after an unstubbed `deleteKey` of a migrated key → `null` |
+| 1 — read is not a write | `does not erase the slot it reports on` | `browser-keychain-adapter.test.ts` | Seed the slot, call `readLegacyResidue` twice, assert `localStorage.getItem(LEGACY_SLOT)` is unchanged and `removeItem` was never called for that key |
+| 1 — no key material escapes | `never returns any part of the stored key` | `browser-keychain-adapter.test.ts` | Seed a recognisable secret; assert the resolved value is exactly `"retained"` |
+| 1 — Tauri stays honest | `does not carry a residue check on the desktop adapter` | `keychain-adapter.test.ts` | `expect("readLegacyResidue" in new TauriKeychainAdapter()).toBe(false)`; plus `const shared: KeychainAdapter = new TauriKeychainAdapter(); expect(shared.readLegacyResidue?.("anthropic")).toBeUndefined();` |
+| 1 — the optionality is load-bearing | `makes an unguarded residue call a type error` | `keychain-adapter.test.ts` | `@ts-expect-error` on `shared.readLegacyResidue("anthropic")` (possibly `undefined`), mirroring the file's existing compile assertions — `tsc --noEmit` fails on an unused directive if the member is ever made required |
+| 2 — persistent warning | `keeps warning about a clear-text copy after the message is cleared` | `ai-settings-content.test.tsx` | Fake adapter with `readLegacyResidue: async () => "retained"`; delete, then perform another action that calls `setMessage(null)`; the warning block is still present and names the provider and site data |
+| 2 — **surviving a remount** | `still warns after the settings panel is closed and reopened` | `ai-settings-content.test.tsx` | `const { unmount } = render(...)`; assert warning; `unmount()`; re-`render`; assert the warning is present again without any user action |
+| 3 — the two states differ | `distinguishes a retained copy from a check that was blocked` | `ai-settings-content.test.tsx` | Two cases, `"retained"` vs `"unverified"`; each asserts its own copy is present **and** the other's is absent |
+| 4 — no false "no key" | `does not claim the provider is unconfigured while a clear-text copy is readable` | `ai-settings-content.test.tsx` | `hasKey → false`, residue `"retained"`; `expect(screen.queryByText("No API key configured")).toBeNull()`. The existing test at ~line 162 that asserts `"No API key configured"` after a retained delete **must be updated**, not deleted — it encodes the current wrong behavior and its comment should record why it changed |
+| 5 — retry reachable | `keeps a removal control reachable while a clear-text copy remains` | `ai-settings-content.test.tsx` | `hasKey → false`, residue `"retained"`; the button renders and clicking it calls `deleteKey` again (spy asserts the second call) |
+| 6 — **warning clears** | `stops warning once the slot is actually gone` | `ai-settings-content.test.tsx` | `readLegacyResidue` returns `"retained"`, then `null` after the first `deleteKey`; click retry; the warning and the status-row text are both gone |
+| desktop parity | `shows nothing when the adapter has no residue check` | `ai-settings-content.test.tsx` | Fake adapter object with only `setKey`/`hasKey`/`deleteKey` — the shape `TauriKeychainAdapter` actually has — asserting no warning and no relabelled button |
+| store | `key-residue-store` cases | `src/stores/key-residue-store.test.ts` (new) | Adapter mock via `vi.mock("@/lib/adapters/get-keychain-adapter")`: sets from the capability; writes `null` when the method is absent; **keeps the prior value when the adapter module rejects**; `refreshAllResidue` covers both providers |
+| escalation (B) | `status-bar` cases | `src/components/layout/status-bar.test.tsx` | Seed the store with `useKeyResidueStore.setState(...)`: indicator present for `"retained"`, absent for `"unverified"` and `null`, click calls `openSettingsDialogAtTab("ai")` |
+
+**Regression coverage that must stay green unmodified:** every existing case in
+`browser-keychain-adapter.test.ts` (especially the "keeps the clear-text slot when the wrapping
+key is unusable" family), `src/lib/persistence/no-key-leakage.test.ts` (which enumerates
+`/^tf-api-key-/` and asserts the persistence layer never touches it), and
+`src/lib/adapters/keychain-adapter.test.ts`'s `getKey` compile assertions.
+
+**E2E:** not required for options A or B — the fakes above exercise the real adapter and the real
+panel, and `e2e/fixtures.ts` seeds the legacy slot precisely so the migration path is already
+covered live. If the owner picks C or D, add one Playwright case that seeds the slot, stubs
+`Storage.prototype.removeItem` in an init script, deletes the key, and asserts the global surface
+is present after a reload.
+
+## Cross-cutting requirements
+
+- **Security and privacy:** the residue token never carries key material, and nothing new is
+  logged. No existing validation, guard, marker, or rejection is removed or relaxed — `deleteKey`
+  still fails closed, `readLegacySlot` still separates `absent` from `unreadable`, and
+  `unverified` is still treated as "cannot claim absence". The new capability is read-only. No
+  new permission, no new dependency, no CSP change, no network access.
+- **`.thf` compatibility:** untouched. No schema, no migration, no round-trip surface.
+- **Browser and desktop:** the difference is expressed in the type system as an optional
+  capability the desktop adapter does not implement, and asserted at runtime by a test.
+  `TauriKeychainAdapter`, `src-tauri/`, and the IPC surface get zero edits. The panel's desktop
+  render is unchanged; the escalated surface (step 5) is browser-only. This is a deliberate
+  platform difference, not a fallback.
+- **AI safety:** untouched. No model output, no tool loop, no approval path.
+- **Accessibility and UX:** the warning block uses `role="alert"` like the existing legacy-model
+  warning; the escalated surface reuses `StatusBar`'s always-mounted `role="status"` region so a
+  newly appearing state is announced once rather than on every render; `StatusBar` gains its
+  first focusable control, so tab order, focus ring, and hit target need checking. Colour is not
+  the only carrier of the `retained` / `unverified` distinction — heading text and button label
+  differ too.
+- **Observability and evidence:** the PR carries screenshots of both states in the panel, the
+  escalated surface, and the desktop render showing nothing added.
+
+## Blast radius and risk
+
+**What could break.**
+
+1. **The interface change ripples to every `KeychainAdapter` consumer.** Mitigated by
+   optionality: no existing implementation or caller needs an edit, and `tsc --noEmit` proves it.
+2. **Panel behavior the existing suite pins.** The `mutated` ref, the `Promise.allSettled`
+   independence, the `LEGACY_RETAINED`-as-removal handling, and the adapter-load message are all
+   load-bearing fixes from #133 preflight. None are modified; the mount effect only gains a
+   trailing refresh call, and the residue state deliberately does not participate in `mutated`.
+3. **One existing test asserts the wrong behavior on purpose.** `treats a removal that left a
+   clear-text copy as removed, with the warning` asserts `"No API key configured"` after a
+   retained delete — exactly what AC4 forbids. It must be updated with a comment recording the
+   change, not silently deleted.
+4. **Deadlock hazard.** `readLegacyResidue` takes `withProviderLock`; calling it from inside
+   another locked operation would wedge that provider permanently. No planned callsite does, and
+   a code comment records the constraint.
+5. **A permanent `unverified` notice for blocked-storage profiles** that never had a slot (the
+   round-12 case). Accepted: failing closed is the recorded stance. Contained by calmer copy,
+   distinct colour, and — under the recommended option — by never escalating `unverified` outside
+   the panel.
+6. **Startup cost under options B/C/D:** `getKeychainAdapter()` dynamically imports the browser
+   keychain adapter (and therefore the vault module) at launch rather than at first settings
+   open. Small, but measured in step 5 and deferred behind idle time if it is not.
+7. **A `retained` warning alongside a configured key.** `setKey` also attempts and ignores the
+   erase, so residue can coexist with `keyStatus === true`. The copy is written to be true in
+   both cases; the status row is only overridden in the `false` case.
+
+**What must not regress.**
+
+- The desktop path. No Rust, no IPC, no `TauriKeychainAdapter` edit, nothing rendered on desktop
+  that is not rendered today. The capability is absent there by construction, and a test asserts
+  the absence rather than trusting the omission.
+- `deleteKey` still rejects with `LEGACY_RETAINED` and still erases before it commits. The
+  persistent surface is added *beside* the one-shot message, not instead of it.
+- The migration guards, retirement markers, and the "never write back to the legacy slot" rule.
+- `no-key-leakage.test.ts` and the `tf-api-key-` namespace disjointness proof from #56.
+
+## Decomposition
+
+**This is one coherent change, and it should not be split.** `AGENTS.md` says High effort work is
+decomposed into executable sub-issues; that instruction earns its keep when the pieces are
+independently shippable, and here they are not. The capability without the store and panel is a
+method with no caller — dead scaffolding by the repository's own definition. The panel without
+the capability is a component reading a method that does not exist. The five steps above are each
+XS/S and independently reviewable within one PR, which is the property decomposition exists to
+provide. Manufacturing three sub-issues would produce two that cannot be validated on their own.
+
+The one genuine seam is step 5, and it is a seam in the *decision*, not the work: if the owner
+picks Option A now and wants escalation later, the escalated surface is a clean follow-up against
+the same store. File it only if that happens.
+
+### Follow-up issues to file (not part of this change)
+
+1. **"Neutralize an unerasable clear-text API key slot by overwriting it"** — `M2 • Beta`,
+   `Effort: High`, `area:security`. If `removeItem` is refused but `setItem` is honoured, the app
+   could overwrite the slot and destroy the credential's usefulness even when it cannot delete
+   the entry. Deliberately excluded here: it would break the standing invariant that nothing is
+   ever written back under `LEGACY_KEY_PREFIX`; an overwritten slot still reads as `present` and
+   would be migrated as a key unless the read path learns a sentinel; and it destroys the last
+   copy in the vault-damaged case that #133's tests specifically protect. It needs its own
+   security review, not a rider on a surfacing fix. Acceptance criteria: an overwrite is
+   attempted only after a revocation; the resulting slot can never be imported as a credential;
+   no path can reach the overwrite while the vault cannot produce a replacement key.
+2. `#234` already covers the adjacent `hasKey === true` / undecryptable-record case. No new issue
+   needed.
+
+## Verification gate
+
+```bash
+npx tsc --noEmit
+npx vitest run src/lib/adapters/browser-keychain-adapter.test.ts \
+  src/lib/adapters/keychain-adapter.test.ts \
+  src/stores/key-residue-store.test.ts \
+  src/components/panels/ai-settings-content.test.tsx
+npx vitest run src/lib/persistence/no-key-leakage.test.ts
+# Option B/C/D only:
+npx vitest run src/components/layout/
+```
+
+Then, once:
+
+```bash
+npm run ci:local
+```
+
+E2E only if the owner picks Option C or D (see test plan).
+
+## Owner validation
+
+Green CI cannot decide any of these.
+
+1. **Is the chosen surface actually noticed?** Delete a key in a browser with `removeItem`
+   stubbed, then use the app normally for a few minutes. Did the surface reach you, or did you
+   have to go looking for it?
+2. **Does the `retained` copy read as true and non-alarming-but-serious?** Read it aloud. It
+   claims a credential is readable on disk; check that every clause of that claim is literally
+   true in the state that produced it, including the "not a backup" line.
+3. **Is the `unverified` copy proportionate?** Simulate a profile that never had a clear-text
+   slot in a browser where `getItem` throws. The notice will be permanent for that user. Is what
+   it says worth showing them forever?
+4. **Does the retry feel like a retry?** On a browser that starts allowing removal, does one
+   click clear everything — panel row, warning block, escalated surface — with no reload?
+5. **Desktop shows nothing new.** Open AI settings in the Tauri build with and without a key.
+   Nothing about clear text, nothing about legacy slots, no changed button labels.
+6. **Plausible-but-wrong to check for specifically:** a warning that persists after the slot is
+   gone (stale state rather than a re-read), a warning that appears during a normal pre-#133
+   migration (a residue read that beat `migrateLegacyKey`), and a status row that says "API key
+   configured" while the only copy is the clear-text one.
+
+## Specialist review
+
+- [ ] PR reviewer
+- [ ] Slop auditor
+- [x] Security auditor — required; this is a trust boundary and key-handling change
+- [ ] Threat-model expert — not applicable, no `.thf` or STRIDE surface
+
+## Replan log
+
+| Date | Change | Evidence and reason |
+|------|--------|---------------------|
+| 2026-07-27 | Initial plan | Issue #233 body and its four comments; `browser-keychain-adapter.ts`, `browser-key-vault.ts`, `keychain-adapter.ts`, `tauri-keychain-adapter.ts`, `ai-settings-content.tsx`, `status-bar.tsx`, `update-bar.tsx`, `settings-store.ts`, and the existing adapter/panel test suites, all read on `main` |

--- a/src/components/layout/app-layout.test.tsx
+++ b/src/components/layout/app-layout.test.tsx
@@ -1,7 +1,10 @@
 import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { LegacyResidue } from "@/lib/adapters/keychain-adapter";
 import { useDocumentRegistry } from "@/stores/document-registry";
 import { createDocumentStores, setActiveStores } from "@/stores/document-stores";
+import { useKeyResidueStore } from "@/stores/key-residue-store";
 import type { DocumentId } from "@/types/document";
 import type { ThreatModel } from "@/types/threat-model";
 
@@ -13,9 +16,47 @@ vi.mock("@/components/canvas/canvas", () => ({
 }));
 vi.mock("@/hooks/use-workspace-restore", () => ({ useWorkspaceRestore: () => {} }));
 vi.mock("@/hooks/use-workspace-persistence", () => ({ useWorkspacePersistence: () => {} }));
+// Also a boundary: one case below fakes the Tauri global to prove the launch-time residue check
+// is browser-only, and the real hook would then reach `@tauri-apps/api` for a menu event listener
+// that only a webview can serve.
+vi.mock("@/hooks/use-native-menu", () => ({ useNativeMenu: () => {} }));
 vi.mock("@/stores/update-store", async (importOriginal) => ({
 	...(await importOriginal<typeof import("@/stores/update-store")>()),
 	checkOnLaunch: () => {},
+}));
+
+// The keychain adapter is the one boundary the launch-time residue check crosses. Mocked so
+// this test exercises the wiring rather than IndexedDB, and recording the order of the calls,
+// which is the property that matters: `hasKey` is what migrates and erases a pre-#133 slot.
+let keychainLoads = 0;
+let calls: string[] = [];
+/** How many of the next adapter loads reject, as a failed dynamic import would. */
+let adapterLoadFailures = 0;
+/** The clear-text slot as the real adapter would see it, per provider. */
+let slot: Record<string, LegacyResidue> = { anthropic: null, openai: null };
+/** Whether `hasKey` migrates the slot away, as it does for every upgrading pre-#133 user. */
+let hasKeyMigrates = false;
+vi.mock("@/lib/adapters/get-keychain-adapter", () => ({
+	getKeychainAdapter: async () => {
+		keychainLoads += 1;
+		if (adapterLoadFailures > 0) {
+			adapterLoadFailures -= 1;
+			throw new Error("Failed to fetch dynamically imported module: /assets/x-9f2a1c.js");
+		}
+		return {
+			setKey: async () => undefined,
+			hasKey: async (provider: string) => {
+				calls.push(`hasKey:${provider}`);
+				if (hasKeyMigrates) slot[provider] = null;
+				return false;
+			},
+			deleteKey: async () => undefined,
+			readLegacyResidue: async (provider: string) => {
+				calls.push(`residue:${provider}`);
+				return slot[provider] ?? null;
+			},
+		};
+	},
 }));
 
 import { AppLayout } from "./app-layout";
@@ -43,6 +84,12 @@ function open(title: string): DocumentId {
 beforeEach(() => {
 	useDocumentRegistry.setState({ documents: {}, openDocumentIds: [], activeDocumentId: null });
 	setActiveStores(createDocumentStores());
+	keychainLoads = 0;
+	calls = [];
+	adapterLoadFailures = 0;
+	slot = { anthropic: null, openai: null };
+	hasKeyMigrates = false;
+	useKeyResidueStore.setState({ residue: { anthropic: null, openai: null } });
 });
 
 describe("AppLayout document tabpanel relationship (#54 step 5)", () => {
@@ -78,5 +125,129 @@ describe("AppLayout document tabpanel relationship (#54 step 5)", () => {
 		expect(screen.queryByRole("tabpanel")).toBeNull();
 		expect(screen.getByTestId("btn-new-document")).toBeInTheDocument();
 		expect(screen.getByRole("main")).toBeInTheDocument();
+	});
+});
+
+/**
+ * #233: the whole point of escalating this out of the settings panel is that the user may never
+ * open it. That requires the check to run at launch, in the browser only.
+ */
+describe("AppLayout clear-text key check at launch", () => {
+	afterEach(() => {
+		delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
+		// The adapter-load case spies on `console.warn`; nothing else in this file should
+		// inherit a silenced console.
+		vi.restoreAllMocks();
+	});
+
+	it("reads clear-text residue at startup so the status bar can report it", async () => {
+		slot = { anthropic: "retained", openai: null };
+
+		await act(async () => {
+			render(<AppLayout />);
+		});
+
+		expect(useKeyResidueStore.getState().residue).toEqual({
+			anthropic: "retained",
+			openai: null,
+		});
+		expect(screen.getByTestId("clear-text-key-status")).toBeInTheDocument();
+	});
+
+	it("settles the migration before the reading it acts on", async () => {
+		slot = { anthropic: "retained", openai: "retained" };
+
+		await act(async () => {
+			render(<AppLayout />);
+		});
+
+		// The adapter's per-provider lock orders a read behind any in-flight operation, but at
+		// launch there is none, so a reading taken before the migration would answer "retained"
+		// for a slot the very next `hasKey` erases. Every `hasKey` must precede the reads whose
+		// answers are committed to the store — which is the last read of each provider.
+		let lastMigration = -1;
+		calls.forEach((call, index) => {
+			if (call.startsWith("hasKey:")) lastMigration = index;
+		});
+		expect(lastMigration).toBeGreaterThan(-1);
+		expect([...calls.slice(lastMigration + 1)].sort()).toEqual([
+			"residue:anthropic",
+			"residue:openai",
+		]);
+	});
+
+	it("does not open the key vault when there is no clear-text slot to migrate", async () => {
+		await act(async () => {
+			render(<AppLayout />);
+		});
+
+		// Reading the slot is a `localStorage` read; `hasKey` opens the keychain database. Doing
+		// both unconditionally created that database at launch for every browser profile,
+		// including the majority who never touch AI. Nothing is there to migrate here, so
+		// nothing pays for the vault — and the probe's own answer is never committed, because
+		// the migration it would have to be ordered behind never runs.
+		expect(calls).toEqual([
+			"residue:anthropic",
+			"residue:openai",
+			"residue:anthropic",
+			"residue:openai",
+		]);
+		expect(useKeyResidueStore.getState().residue).toEqual({ anthropic: null, openai: null });
+	});
+
+	it("still reads the slot when the keychain adapter fails to load first", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+		slot = { anthropic: "retained", openai: null };
+		adapterLoadFailures = 1;
+
+		await act(async () => {
+			render(<AppLayout />);
+		});
+
+		// A failed dynamic import must not take the reading down with it. It is reported where
+		// the user can act on it — the settings panel's own adapter-load message — and the store
+		// makes its own attempt, so a transient chunk failure does not silence a standing claim
+		// about a readable credential.
+		expect(useKeyResidueStore.getState().residue.anthropic).toBe("retained");
+		expect(screen.getByTestId("clear-text-key-status")).toBeInTheDocument();
+		// That panel message only reaches a user who opens the panel, which is the one thing
+		// this launch check exists because they may never do. A permanently broken chunk has to
+		// leave a trace a bug report can carry, as `loadAdapter` already logs one.
+		expect(warn).toHaveBeenCalledWith(
+			expect.stringContaining("Clear-text key check could not load key storage"),
+			expect.objectContaining({ message: expect.stringContaining("dynamically imported") }),
+		);
+	});
+
+	it("does not raise a clear-text warning over a slot the launch migration removes", async () => {
+		// The ordinary upgrade path for every pre-#133 user: the slot is there when the app
+		// starts and is gone a moment later, migrated into the encrypted vault. Reading it
+		// first left a standing red status-bar item, all session, over a condition that had
+		// already been resolved — and routed to a panel saying the browser would not delete it.
+		slot = { anthropic: "retained", openai: null };
+		hasKeyMigrates = true;
+
+		await act(async () => {
+			render(<AppLayout />);
+		});
+
+		expect(useKeyResidueStore.getState().residue.anthropic).toBeNull();
+		expect(screen.queryByTestId("clear-text-key-status")).toBeNull();
+	});
+
+	it("does not consult the keychain at startup on the desktop", async () => {
+		(window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {};
+		slot = { anthropic: "retained", openai: "retained" };
+
+		await act(async () => {
+			render(<AppLayout />);
+		});
+
+		// There is no clear-text slot on desktop, so there is nothing to check — and the launch
+		// path does not load the keychain adapter to ask.
+		expect(keychainLoads).toBe(0);
+		expect(calls).toEqual([]);
+		expect(useKeyResidueStore.getState().residue.anthropic).toBeNull();
+		expect(screen.queryByTestId("clear-text-key-status")).toBeNull();
 	});
 });

--- a/src/components/layout/app-layout.tsx
+++ b/src/components/layout/app-layout.tsx
@@ -8,7 +8,10 @@ import { useOnboardingTriggers } from "@/hooks/use-onboarding-triggers";
 import { useWindowTitle } from "@/hooks/use-window-title";
 import { useWorkspacePersistence } from "@/hooks/use-workspace-persistence";
 import { useWorkspaceRestore } from "@/hooks/use-workspace-restore";
+import { getKeychainAdapter } from "@/lib/adapters/get-keychain-adapter";
+import { isTauri } from "@/lib/platform";
 import { useDocumentRegistry } from "@/stores/document-registry";
+import { RESIDUE_PROVIDERS, useKeyResidueStore } from "@/stores/key-residue-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useUiStore } from "@/stores/ui-store";
 import { checkOnLaunch } from "@/stores/update-store";
@@ -50,6 +53,45 @@ export function AppLayout() {
 	// Window/application close guards. Returns the desktop close-summary modal (or null).
 	const closeGuardModal = useCloseGuard();
 	useEffect(() => checkOnLaunch(), []);
+
+	// Browser only: a clear-text API key left by a pre-encryption version is a condition the
+	// user may never open AI settings to find, so the status bar has to be able to report it
+	// from launch (#233). Measured cost and the decision not to defer it behind idle time are
+	// in the plan's replan log (2026-07-27, "Step 5 measurement recorded").
+	useEffect(() => {
+		if (isTauri()) return;
+		void (async () => {
+			try {
+				const adapter = await getKeychainAdapter();
+				// Probe first, and pay for the vault only if there is something to migrate. The
+				// slot read is a `localStorage` read that never opens the keychain database,
+				// while `hasKey` does — so calling `hasKey` unconditionally created that database
+				// at launch for every browser profile, including the ones that never touch AI.
+				// The answer is deliberately not committed to the store: `migrateLegacyKey` may
+				// be about to erase the slot it just reported.
+				const probes = await Promise.allSettled(
+					RESIDUE_PROVIDERS.map((name) => adapter.readLegacyResidue?.(name)),
+				);
+				const anySlot = probes.some((probe) => probe.status === "fulfilled" && probe.value != null);
+				// Settle the migration before the read that *is* committed. `hasKey` is what
+				// moves a pre-#133 key into the vault and erases the slot, and at launch the
+				// adapter's per-provider lock orders a read behind nothing, so a committed read
+				// issued first would answer "retained" for a slot the very next call removes — a
+				// standing red indicator, for every upgrading user, over a resolved condition.
+				// Settled independently so one provider's fault does not skip the other's.
+				if (anySlot) {
+					await Promise.allSettled(RESIDUE_PROVIDERS.map((name) => adapter.hasKey(name)));
+				}
+			} catch (err) {
+				// Logged rather than swallowed: the panel's `ADAPTER_LOAD_ERROR` reaches a user
+				// who opens AI settings, and a permanently broken chunk has to leave a trace for
+				// one who never does. The refresh below leaves the previous value rather than
+				// claiming absence.
+				console.warn("Clear-text key check could not load key storage:", err);
+			}
+			await useKeyResidueStore.getState().refreshAllResidue();
+		})();
+	}, []);
 
 	// Apply font size preference to <html> so rem-based sizes cascade
 	const fontSize = useSettingsStore((s) => s.settings.fontSize);

--- a/src/components/layout/status-bar.test.tsx
+++ b/src/components/layout/status-bar.test.tsx
@@ -1,9 +1,11 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 import type { DocumentPersistenceState } from "@/lib/persistence/types";
 import { useCanvasStore } from "@/stores/canvas-store";
 import { useDocumentRegistry } from "@/stores/document-registry";
 import { createDocumentStores, setActiveStores } from "@/stores/document-stores";
+import { useKeyResidueStore } from "@/stores/key-residue-store";
+import { useSettingsStore } from "@/stores/settings-store";
 import { useWorkspaceStore } from "@/stores/workspace-store";
 import type { ThreatModel } from "@/types/threat-model";
 import { StatusBar } from "./status-bar";
@@ -224,5 +226,64 @@ describe("StatusBar local persistence indicator", () => {
 		render(<StatusBar />);
 
 		expect(screen.getByTestId("local-persistence-status")).toHaveTextContent("Recovery needed");
+	});
+});
+
+/**
+ * #233: a clear-text API key that survived deletion is readable by anything with access to this
+ * site's storage, and the user may never reopen AI settings to find out. The status bar carries
+ * the standing claim — but only the certain one.
+ */
+describe("StatusBar clear-text API key indicator", () => {
+	beforeEach(() => {
+		useKeyResidueStore.setState({ residue: { anthropic: null, openai: null } });
+		useSettingsStore.setState({ settingsDialogOpen: false, settingsDialogInitialTab: null });
+	});
+
+	it("reports a clear-text key that is known to still be readable", () => {
+		useKeyResidueStore.setState({ residue: { anthropic: "retained", openai: null } });
+
+		render(<StatusBar />);
+
+		expect(screen.getByTestId("clear-text-key-status")).toHaveTextContent("Clear-text API key");
+		// Announced once when it first appears, through an always-mounted live region rather
+		// than one that mounts with the state and may be missed.
+		expect(screen.getByTestId("clear-text-key-alert")).toHaveTextContent(
+			"still readable in this browser",
+		);
+	});
+
+	it("stays silent when the check itself was blocked", () => {
+		useKeyResidueStore.setState({ residue: { anthropic: "unverified", openai: "unverified" } });
+
+		render(<StatusBar />);
+
+		// `unverified` may describe a profile that never had a clear-text slot at all — a
+		// blocked-storage browser answers this way forever. That claim is too uncertain to earn
+		// permanent application chrome, so it stays in the AI settings panel.
+		expect(screen.queryByTestId("clear-text-key-status")).toBeNull();
+		expect(screen.getByTestId("clear-text-key-alert")).toBeEmptyDOMElement();
+	});
+
+	it("shows nothing when no provider has residue", () => {
+		render(<StatusBar />);
+
+		// That the desktop keychain adapter carries no residue check, and so can only ever leave
+		// this store holding `null`, is asserted where it is observable: `app-layout.test.tsx`
+		// proves the launch path never asks on that platform.
+		expect(screen.queryByTestId("clear-text-key-status")).toBeNull();
+		expect(screen.getByTestId("clear-text-key-alert")).toBeEmptyDOMElement();
+	});
+
+	it("routes to the AI settings tab, where the retry and the instructions are", () => {
+		useKeyResidueStore.setState({ residue: { anthropic: null, openai: "retained" } });
+
+		render(<StatusBar />);
+		fireEvent.click(screen.getByTestId("clear-text-key-status"));
+
+		// The indicator states the fact; acting on it needs the panel, so it is a real control
+		// rather than inert text.
+		expect(useSettingsStore.getState().settingsDialogOpen).toBe(true);
+		expect(useSettingsStore.getState().settingsDialogInitialTab).toBe("ai");
 	});
 });

--- a/src/components/layout/status-bar.tsx
+++ b/src/components/layout/status-bar.tsx
@@ -2,9 +2,24 @@ import { sanitizeDisplayText } from "@/lib/document-display-title";
 import type { DocumentPersistenceState, WorkspaceUnavailableReason } from "@/lib/persistence/types";
 import { useDocumentRegistry } from "@/stores/document-registry";
 import { useHistoryStore } from "@/stores/history-store";
+import { useKeyResidueStore } from "@/stores/key-residue-store";
 import { useModelStore } from "@/stores/model-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { useWorkspaceStore } from "@/stores/workspace-store";
+
+/**
+ * The clear-text key indicator's detail text (#233).
+ *
+ * Only a `retained` reading reaches this surface. `unverified` means the check itself was
+ * refused, which may describe a profile that never had a clear-text slot at all, and a claim
+ * that uncertain does not earn permanent application chrome — it stays in AI settings.
+ *
+ * It does not promise removal. `retained` means ThreatForge already tried to erase the slot and
+ * the browser refused, so the panel this routes to offers a retry that may fail again and the
+ * site-data remedy — not a button that removes the key.
+ */
+const CLEAR_TEXT_KEY_DETAIL =
+	"An API key saved before ThreatForge encrypted keys is still readable in this browser. Open AI settings to deal with it.";
 
 /**
  * What the local-persistence indicator says. `attention` states are announced to assistive
@@ -96,6 +111,13 @@ export function StatusBar() {
 	const persistenceState = useWorkspaceStore((s) =>
 		activeDocumentId ? s.persistence[activeDocumentId] : undefined,
 	);
+	// True only where a provider's pre-encryption clear-text slot is known to be readable, read
+	// across every provider the store tracks rather than a second list of them. On desktop the
+	// keychain adapter carries no residue check at all, so this is always false.
+	const clearTextKeyRetained = useKeyResidueStore((s) =>
+		Object.values(s.residue).some((residue) => residue === "retained"),
+	);
+	const openSettingsDialogAtTab = useSettingsStore((s) => s.openSettingsDialogAtTab);
 
 	// The file save status and the local persistence status are distinct: one tracks the on-disk
 	// `.thf` file, the other the browser workspace copy.
@@ -154,6 +176,33 @@ export function StatusBar() {
 			    routine "Saving.../Saved locally" transition would talk over the user as they type. */}
 			<span data-testid="local-persistence-alert" role="status" className="sr-only">
 				{localPersistence?.attention ? localPersistence.detail : ""}
+			</span>
+
+			{/* A readable clear-text API key is worth knowing about from anywhere in the app: the
+			    user may have deleted the key, been told once that a copy survived, and never
+			    reopened settings (#233). */}
+			{clearTextKeyRetained && (
+				<>
+					<Separator />
+					<button
+						type="button"
+						data-testid="clear-text-key-status"
+						onClick={() => openSettingsDialogAtTab("ai")}
+						title={CLEAR_TEXT_KEY_DETAIL}
+						className="rounded text-destructive underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-destructive"
+					>
+						Clear-text API key
+					</button>
+				</>
+			)}
+
+			{/* Its live region, mounted whether or not the condition holds, for the same
+			    announce-once reason as the persistence region above. Separate from that one
+			    because the two states are independent: coalescing them would let a save failure
+			    silence a standing claim about a readable credential, or re-announce it on every
+			    persistence transition. */}
+			<span data-testid="clear-text-key-alert" role="status" className="sr-only">
+				{clearTextKeyRetained ? CLEAR_TEXT_KEY_DETAIL : ""}
 			</span>
 
 			{model && displayFilePath && (

--- a/src/components/panels/ai-settings-content.test.tsx
+++ b/src/components/panels/ai-settings-content.test.tsx
@@ -1,10 +1,15 @@
 /** AI settings model picker and persisted legacy-selection behavior. */
 
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { LEGACY_RETAINED } from "@/lib/adapters/keychain-adapter";
+import {
+	CLEARING_SITE_DATA_COST,
+	LEGACY_RETAINED,
+	type LegacyResidue,
+} from "@/lib/adapters/keychain-adapter";
 import { DEFAULT_ANTHROPIC_MODEL, DEFAULT_OPENAI_MODEL } from "@/lib/ai-models";
 import { useChatStore } from "@/stores/chat-store";
+import { useKeyResidueStore } from "@/stores/key-residue-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import { DEFAULT_USER_SETTINGS } from "@/types/settings";
 import { AiSettingsContent } from "./ai-settings-content";
@@ -38,6 +43,7 @@ beforeEach(() => {
 		deleteKey: async () => undefined,
 	});
 	useChatStore.setState({ provider: "anthropic" });
+	useKeyResidueStore.setState({ residue: { anthropic: null, openai: null } });
 	useSettingsStore.setState({ settings: { ...DEFAULT_USER_SETTINGS } });
 });
 
@@ -172,6 +178,9 @@ describe("key storage that cannot answer", () => {
 					"The API key was removed from encrypted storage, but this browser would not delete an older clear-text copy.",
 				);
 			},
+			// The real adapter that throws this rejection also still reads the slot as present —
+			// that is what the rejection means — so the fake has to answer the same way.
+			readLegacyResidue: async () => "retained",
 		});
 
 		await act(async () => {
@@ -185,7 +194,88 @@ describe("key storage that cannot answer", () => {
 		// erase. Leaving the status alone showed "API key configured" directly underneath a
 		// message saying the key had been removed.
 		expect(screen.getByText(/would not delete an older clear-text copy/)).toBeInTheDocument();
-		expect(screen.getByText("No API key configured")).toBeInTheDocument();
+		expect(screen.queryByText("API key configured")).toBeNull();
+		// Changed by #233, deliberately: this assertion used to require "No API key configured"
+		// here. That is the exact claim acceptance criterion 4 forbids — the encrypted record is
+		// gone, but a usable clear-text credential is still readable in this browser, and telling
+		// the user there is no key is how they end up leaving it there.
+		expect(screen.queryByText("No API key configured")).toBeNull();
+		expect(screen.getByText("Clear-text API key still in this browser")).toBeInTheDocument();
+	});
+
+	it("does not report an unreadable vault as an empty one", async () => {
+		hasKey = async () => {
+			throw new Error("Key storage in this browser is damaged.");
+		};
+
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+
+		// A rejected `hasKey` used to collapse to `false`, so a vault nobody can read was
+		// reported as "No API key configured" — reassurance in exactly the wrong direction,
+		// on a surface whose whole job is telling the user where their credential is.
+		expect(screen.queryByText("No API key configured")).toBeNull();
+		expect(screen.getByText("Key storage could not be checked")).toBeInTheDocument();
+		expect(screen.getByText("Key storage in this browser is damaged.")).toBeInTheDocument();
+	});
+
+	it("offers no removal control while it cannot tell whether a key is there", async () => {
+		hasKey = async () => {
+			throw new Error("Key storage in this browser is damaged.");
+		};
+		getAdapter = async () => ({
+			hasKey: (provider: string) => hasKey(provider),
+			setKey: async () => undefined,
+			deleteKey: async () => undefined,
+			readLegacyResidue: async () => "retained",
+		});
+
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+
+		// `deleteKey` commits a permanent revocation marker and can take a record the panel has
+		// never successfully read. An unknown status is not a licence to offer that.
+		expect(screen.queryByRole("button", { name: "Remove API key" })).toBeNull();
+		const control = within(screen.getByTestId("clear-text-key-notice-anthropic")).getByRole(
+			"button",
+		);
+		expect(control).toHaveTextContent("Try removing it again");
+		// A readable clear-text copy outranks an unreadable vault in the status row. Both facts
+		// are true at once here, and "Key storage could not be checked" is the weaker one: it
+		// describes the encrypted record while a usable credential sits in clear text.
+		expect(screen.getByText("Clear-text API key still in this browser")).toBeInTheDocument();
+
+		await act(async () => {
+			fireEvent.click(control);
+		});
+
+		// The retry hit the same fault, and that is what the user must read. The residue re-read
+		// in the same `finally` must not overwrite it with the retry report, which would blame a
+		// removal nobody attempted for a chunk-load or vault failure — and would end in the
+		// destructive clear-site-data instruction over an error a reload might fix.
+		expect(screen.getByText("Key storage in this browser is damaged.")).toBeInTheDocument();
+		expect(screen.queryByText(/still would not delete the older clear-text/)).toBeNull();
+	});
+
+	it("does not claim there is no key before the check has answered", async () => {
+		// The seed value used to be `false`, which the status row reads as "the encrypted record
+		// is known to be gone" — a claim about storage nobody had asked yet. It was visible for
+		// as long as the vault took to open, and unbounded if a cross-tab upgrade blocked it.
+		hasKey = () => new Promise<boolean>(() => undefined);
+
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+
+		expect(
+			screen.queryByText("No API key configured"),
+			"the row must not claim storage answered before it has",
+		).toBeNull();
+		expect(screen.getByText("Checking key storage…")).toBeInTheDocument();
+		// And nothing destructive is offered over a record the panel has not read.
+		expect(screen.queryByRole("button", { name: "Remove API key" })).toBeNull();
 	});
 
 	it("says so when the storage adapter itself will not load", async () => {
@@ -228,6 +318,417 @@ describe("key storage that cannot answer", () => {
 
 		expect(screen.getByText(/Key storage could not be loaded/)).toBeInTheDocument();
 		expect(screen.queryByText(/dynamically imported module/)).not.toBeInTheDocument();
+	});
+});
+
+/**
+ * #233: a `deleteKey` that leaves a readable clear-text copy behind reports it once, and the
+ * panel then used to contradict that report on every later mount — "No API key configured",
+ * with the removal control hidden. These cases pin the standing warning that replaced it.
+ */
+describe("a clear-text API key still readable in this browser", () => {
+	let residue: Record<string, LegacyResidue> = {};
+	let deleteCalls = 0;
+	/**
+	 * Every keychain call the panel makes, in order. One array rather than one per method,
+	 * because the property that matters is how the calls interleave: `hasKey` runs the legacy
+	 * migration, which retries the erase, so a slot read must not be issued before it settles.
+	 */
+	let calls: string[] = [];
+
+	const RETAINED_HEADING = "A clear-text Anthropic API key is still stored in this browser.";
+	// The provider is named here too, which the plan's copy did not do: the notice renders for
+	// whichever provider has residue rather than only the selected one, and two unattributed
+	// amber blocks would leave the user unable to tell which key the browser could not check.
+	const UNVERIFIED_HEADING =
+		"ThreatForge could not check for an older clear-text Anthropic API key.";
+	/** The label the notice's one control carries. It only ever re-reads; see `handleRecheck`. */
+	const CONTROL_LABEL = "Try removing it again";
+	// The blocked reading has never had a removal attempted on it, so neither "removing" nor
+	// "again" would be true there.
+	const BLOCKED_CONTROL_LABEL = "Check again";
+
+	/** The standing notice for one provider, which is not necessarily the selected one. */
+	function notice(provider: string): HTMLElement {
+		return screen.getByTestId(`clear-text-key-notice-${provider}`);
+	}
+
+	/** The one control a notice offers. Scoped, because a second provider may have one too. */
+	function noticeControl(provider: string): HTMLElement {
+		return within(notice(provider)).getByRole("button");
+	}
+
+	/** The providers one kind of call was made for, in order. */
+	function callsFor(marker: string): string[] {
+		return calls
+			.filter((call) => call.startsWith(`${marker}:`))
+			.map((call) => call.slice(marker.length + 1));
+	}
+
+	beforeEach(() => {
+		residue = { anthropic: "retained", openai: null };
+		deleteCalls = 0;
+		calls = [];
+		// The encrypted record is gone — that is what makes this the reported bug rather than a
+		// key that is simply configured.
+		hasKey = async () => false;
+		getAdapter = async () => ({
+			hasKey: async (provider: string) => {
+				calls.push(`hasKey:${provider}`);
+				const answer = await hasKey(provider);
+				// Recorded on the way out as well: the migration erases the slot as it settles,
+				// so "was it called" is a weaker fact than "had it finished".
+				calls.push(`hasKey-settled:${provider}`);
+				return answer;
+			},
+			setKey: async () => undefined,
+			deleteKey: async () => {
+				deleteCalls += 1;
+			},
+			readLegacyResidue: async (provider: string) => {
+				calls.push(`residue:${provider}`);
+				return residue[provider] ?? null;
+			},
+		});
+	});
+
+	it("does not claim the provider is unconfigured while a clear-text copy is readable", async () => {
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+
+		// The observed bug: `hasKey` is false because the encrypted record really was deleted,
+		// so every mount reported "No API key configured" while `localStorage` still served the
+		// credential to anything running on this page.
+		expect(screen.queryByText("No API key configured")).toBeNull();
+		expect(screen.getByText("Clear-text API key still in this browser")).toBeInTheDocument();
+	});
+
+	it("reads the clear-text slot only after the status check that migrates it", async () => {
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+
+		// `hasKey` runs the legacy migration, which retries the erase, so a slot read issued
+		// before it settles describes storage the same mount may be in the middle of clearing —
+		// a standing warning over a resolved condition, for every upgrading user. The adapter's
+		// per-provider lock is the guarantee that survives a mistake here and is pinned at that
+		// level; this pins the panel's own half of the ordering.
+		let lastMigration = -1;
+		calls.forEach((call, index) => {
+			if (call.startsWith("hasKey-settled:")) lastMigration = index;
+		});
+		expect(lastMigration).toBeGreaterThan(-1);
+		expect([...calls.slice(lastMigration + 1)].sort()).toEqual([
+			"residue:anthropic",
+			"residue:openai",
+		]);
+	});
+
+	it("does not warn about a slot the mount's own status check removes", async () => {
+		// The ordinary upgrade path for every pre-#133 user: the slot is there when the panel
+		// mounts and is gone a moment later, migrated into the encrypted vault. The real
+		// migration erases it only after an IndexedDB transaction commits, so the erase lands
+		// after the call rather than during it — a read that did not wait would answer
+		// "retained" for a slot that is already gone.
+		hasKey = async (provider) => {
+			await Promise.resolve();
+			residue[provider] = null;
+			return false;
+		};
+
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+
+		expect(screen.queryByTestId("clear-text-key-notice-anthropic")).toBeNull();
+		expect(screen.getByText("No API key configured")).toBeInTheDocument();
+	});
+
+	it("keeps warning about a clear-text copy after the message is cleared", async () => {
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+		expect(screen.getByText(RETAINED_HEADING)).toBeInTheDocument();
+
+		// Any later action clears the one-shot message. That is what made the original report
+		// disappear; the standing notice must not go with it.
+		await act(async () => {
+			fireEvent.click(noticeControl("anthropic"));
+		});
+
+		expect(screen.getByText(RETAINED_HEADING)).toBeInTheDocument();
+		expect(
+			within(notice("anthropic")).getByText(/Clear this site's browser data to remove it/),
+		).toBeInTheDocument();
+	});
+
+	it("still warns after the settings panel is closed and reopened", async () => {
+		const first = await act(async () => render(<AiSettingsContent />));
+		expect(screen.getByText(RETAINED_HEADING)).toBeInTheDocument();
+
+		// The panel unmounts with the settings dialog, which is why component state could not
+		// hold this. Reopening must not hand the user back the "No API key configured" reading.
+		first.unmount();
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+
+		expect(screen.getByText(RETAINED_HEADING)).toBeInTheDocument();
+		expect(screen.queryByText("No API key configured")).toBeNull();
+		expect(noticeControl("anthropic")).toHaveTextContent(CONTROL_LABEL);
+	});
+
+	it("names the provider, the remedy, and what the remedy costs", async () => {
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+
+		expect(notice("anthropic")).toHaveTextContent(RETAINED_HEADING);
+		expect(notice("anthropic")).toHaveTextContent(
+			"revoke the key with Anthropic if it may have been exposed",
+		);
+		// The only remedy the app can offer is clearing site data, and in this browser that also
+		// takes the user's saved threat models with it (`src/lib/persistence/types.ts`: bodies in
+		// IndexedDB, manifest in `localStorage`). Giving the instruction without the cost is how
+		// someone follows security advice and loses their work.
+		expect(notice("anthropic")).toHaveTextContent(
+			"also removes the threat models saved in this browser, so export anything you need first",
+		);
+		// Without this the retained slot reads as a recovery copy, right up until a read erases it.
+		expect(notice("anthropic")).toHaveTextContent("This copy is not a backup");
+		// The blocked-check wording would overstate nothing here — it would understate it.
+		expect(notice("anthropic")).not.toHaveTextContent(UNVERIFIED_HEADING);
+	});
+
+	it("distinguishes a check that was blocked from a copy known to be there", async () => {
+		residue = { anthropic: "unverified", openai: null };
+
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+
+		expect(notice("anthropic")).toHaveTextContent(UNVERIFIED_HEADING);
+		expect(notice("anthropic")).toHaveTextContent("may or may not still be there");
+		// The same instruction, so the same concession: this notice also tells the user to clear
+		// site data.
+		expect(notice("anthropic")).toHaveTextContent(
+			"also removes the threat models saved in this browser, so export anything you need first",
+		);
+		// Nothing is known to be readable, so the honest summary of the row is unchanged and the
+		// certain-sounding copy must not appear.
+		expect(notice("anthropic")).not.toHaveTextContent(RETAINED_HEADING);
+		expect(screen.getByText("No API key configured")).toBeInTheDocument();
+		expect(screen.queryByText("Clear-text API key still in this browser")).toBeNull();
+	});
+
+	it("offers only a re-read, never an erase, when the check itself was blocked", async () => {
+		// A browser that blocks site data answers `unverified` for a profile that may never have
+		// had a clear-text slot at all. `deleteKey` commits a permanent revocation marker, so
+		// wiring it here would tell a user who never had a key that their erasure failed, and
+		// would destroy a recoverable one for a user who asked only for a read.
+		residue = { anthropic: "unverified", openai: null };
+
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+		const control = noticeControl("anthropic");
+		expect(control).toHaveTextContent(BLOCKED_CONTROL_LABEL);
+		// It must not borrow the retained label: no removal has been attempted on this reading.
+		expect(control).not.toHaveTextContent(CONTROL_LABEL);
+		await act(async () => {
+			fireEvent.click(control);
+		});
+
+		expect(deleteCalls).toBe(0);
+		expect(notice("anthropic")).toHaveTextContent(UNVERIFIED_HEADING);
+	});
+
+	it("never reaches deleteKey from a residue notice, whatever the panel knows", async () => {
+		// The regression this pins: the notice's control was once chosen from a render-time
+		// snapshot of `keyStatus`, and `deleteKey` was one of the choices. The snapshot goes
+		// stale — a key saved in a second tab, or saved before the mount check answered — and
+		// the destructive branch then destroyed a good encrypted key from a control whose copy
+		// spoke only about the clear-text slot. No combination may reach it.
+		const statuses: [string, () => Promise<boolean>][] = [
+			["stored key present", async () => true],
+			["stored key gone", async () => false],
+			[
+				"storage unreadable",
+				async () => {
+					throw new Error("Key storage in this browser is damaged.");
+				},
+			],
+		];
+		const readings: LegacyResidue[] = ["retained", "unverified"];
+
+		for (const [label, answer] of statuses) {
+			for (const reading of readings) {
+				hasKey = answer;
+				residue = { anthropic: reading, openai: reading };
+				const view = await act(async () => render(<AiSettingsContent />));
+
+				for (const provider of ["anthropic", "openai"]) {
+					for (const control of within(notice(provider)).getAllByRole("button")) {
+						await act(async () => {
+							fireEvent.click(control);
+						});
+					}
+				}
+
+				expect(deleteCalls, `${label}, residue "${reading}"`).toBe(0);
+				view.unmount();
+			}
+		}
+	});
+
+	it("keeps a retry reachable while a clear-text copy remains", async () => {
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+
+		// The bug hid the removal control entirely once `hasKey` went false, so a user whose
+		// browser started allowing removal had no way to act from this panel. `hasKey` is what
+		// runs the legacy migration and retries the erase, so the retry is a `hasKey` call.
+		calls = [];
+		await act(async () => {
+			fireEvent.click(noticeControl("anthropic"));
+		});
+		await act(async () => {
+			fireEvent.click(noticeControl("anthropic"));
+		});
+
+		// Two per click, both for the provider the notice names: the retry itself, then the
+		// transport's own check, because this notice happens to be the selected provider's.
+		expect(callsFor("hasKey")).toEqual(["anthropic", "anthropic", "anthropic", "anthropic"]);
+		expect(deleteCalls).toBe(0);
+	});
+
+	it("says so when the retry changed nothing", async () => {
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+
+		await act(async () => {
+			fireEvent.click(noticeControl("anthropic"));
+		});
+
+		// `deleteKey` used to author this report through its own rejection. The retry is a
+		// re-read now, which resolves either way, so a browser that still refuses would leave
+		// the identical notice on screen and no evidence the click did anything.
+		const report = screen.getByText(
+			/This browser still would not delete the older clear-text Anthropic/,
+		);
+		// The report says only what is new. The notice directly above it is still on screen —
+		// the report is only ever set while residue is non-null, which is the same condition
+		// that renders the notice — so repeating the remedy and its cost printed the same two
+		// sentences twice, a few lines apart.
+		expect(report).not.toHaveTextContent(CLEARING_SITE_DATA_COST);
+		expect(notice("anthropic")).toHaveTextContent(CLEARING_SITE_DATA_COST);
+	});
+
+	it("says so when a blocked check is still blocked", async () => {
+		// The permanent case: a blocked-storage profile reads `unverified` forever, so this is
+		// the one state where the control can never change anything. Leaving it silent made the
+		// only action the panel offers do visibly nothing — same notice, no message, no state
+		// change — which is the failure the retained report exists to prevent.
+		residue = { anthropic: "unverified", openai: null };
+
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+
+		await act(async () => {
+			fireEvent.click(noticeControl("anthropic"));
+		});
+
+		const report = screen.getByText(
+			/This browser still blocked the check for an older clear-text Anthropic API key/,
+		);
+		// `migrateLegacyKey` returns before it touches the slot when the read is refused, so
+		// nothing was attempted: the report claims no removal and no absence, only the block.
+		expect(report).toHaveTextContent("Nothing was removed");
+		expect(report).toHaveTextContent("whether a copy is there is still unknown");
+		// Not repeated here: the notice above is still on screen and already carries it.
+		expect(report).not.toHaveTextContent(CLEARING_SITE_DATA_COST);
+		expect(notice("anthropic")).toHaveTextContent(CLEARING_SITE_DATA_COST);
+		// Borrowing the retained wording would assert a removal was refused, which is a claim
+		// about an attempt this state never makes.
+		expect(report).not.toHaveTextContent("would not delete");
+	});
+
+	it("warns about a provider that is not the selected one, and can act on it there", async () => {
+		// The status bar escalates *any* provider's retained slot and routes here. Rendering
+		// only the selected provider's residue made that route a dead end: the panel said "No
+		// API key configured" and offered nothing, which is the contradiction #233 removes.
+		residue = { anthropic: null, openai: "retained" };
+
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+
+		expect(useChatStore.getState().provider).toBe("anthropic");
+		expect(screen.queryByTestId("clear-text-key-notice-anthropic")).toBeNull();
+		expect(notice("openai")).toHaveTextContent(
+			"A clear-text OpenAI API key is still stored in this browser.",
+		);
+
+		calls = [];
+		await act(async () => {
+			fireEvent.click(noticeControl("openai"));
+		});
+
+		// The retry is bound to the provider whose slot it describes, not to the selected one.
+		expect(callsFor("hasKey")).toEqual(["openai"]);
+	});
+
+	it("stops warning once the slot is actually gone", async () => {
+		let browserAllowsRemoval = false;
+		hasKey = async () => {
+			// `hasKey` runs the legacy migration, which retries the erase — so on a browser that
+			// has started allowing removals, the retry is what finally clears the slot.
+			if (browserAllowsRemoval) residue = { anthropic: null, openai: null };
+			return false;
+		};
+
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+		expect(notice("anthropic")).toBeInTheDocument();
+		browserAllowsRemoval = true;
+
+		await act(async () => {
+			fireEvent.click(noticeControl("anthropic"));
+		});
+
+		// Nothing dismisses this warning by hand: it is re-derived from storage, so a resolved
+		// condition clears both the notice and the status row without a reload.
+		expect(screen.queryByTestId("clear-text-key-notice-anthropic")).toBeNull();
+		expect(screen.queryByText("Clear-text API key still in this browser")).toBeNull();
+		expect(screen.getByText("No API key configured")).toBeInTheDocument();
+		// And the retry reports nothing, because it changed something. Deciding that from the
+		// render snapshot rather than the store would tell a user whose problem had just been
+		// resolved to clear their site data — and lose their saved threat models with it.
+		expect(screen.queryByText(/still would not delete the older clear-text/)).toBeNull();
+	});
+
+	it("shows nothing when the adapter has no residue check", async () => {
+		// The shape `TauriKeychainAdapter` actually has. Desktop keys live in an encrypted file
+		// behind Rust and never enter the webview, so there is no clear-text slot to describe —
+		// and this panel is shared, so it has to render the same on both platforms.
+		getAdapter = async () => ({
+			hasKey: async () => true,
+			setKey: async () => undefined,
+			deleteKey: async () => undefined,
+		});
+
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+
+		expect(screen.queryByTestId("clear-text-key-notice-anthropic")).toBeNull();
+		expect(screen.queryByText(/clear-text/i)).toBeNull();
+		expect(screen.getByRole("button", { name: "Remove API key" })).toBeInTheDocument();
 	});
 });
 

--- a/src/components/panels/ai-settings-content.tsx
+++ b/src/components/panels/ai-settings-content.tsx
@@ -1,11 +1,16 @@
-import { AlertTriangle, Eye, EyeOff, Loader2, Trash2 } from "lucide-react";
+import { AlertTriangle, Eye, EyeOff, Loader2, RefreshCw, Trash2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { getKeychainAdapter } from "@/lib/adapters/get-keychain-adapter";
-import { LEGACY_RETAINED } from "@/lib/adapters/keychain-adapter";
+import {
+	CLEARING_SITE_DATA_COST,
+	LEGACY_RETAINED,
+	type LegacyResidue,
+} from "@/lib/adapters/keychain-adapter";
 import { getDefaultModelId, getModelById, getModelsForProvider } from "@/lib/ai-models";
 import { isTauri } from "@/lib/platform";
 import { cn } from "@/lib/utils";
 import { type AiProvider, useChatStore } from "@/stores/chat-store";
+import { useKeyResidueStore } from "@/stores/key-residue-store";
 import { useSettingsStore } from "@/stores/settings-store";
 
 /** Authored so a bundler or network detail never reaches the user as an error message. */
@@ -27,10 +32,71 @@ async function loadAdapter(): Promise<Awaited<ReturnType<typeof getKeychainAdapt
 	}
 }
 
-const PROVIDERS: { value: AiProvider; label: string }[] = [
-	{ value: "anthropic", label: "Anthropic (Claude)" },
-	{ value: "openai", label: "OpenAI (GPT)" },
+/**
+ * The providers this panel offers, and the company each key belongs to.
+ *
+ * `vendor` is deliberately not the selector label: "revoke the key with Anthropic (Claude)"
+ * would name a model family the user cannot revoke anything with. Both live on one entry so
+ * adding a provider is one edit rather than two structures that can drift apart.
+ */
+const PROVIDERS: { value: AiProvider; label: string; vendor: string }[] = [
+	{ value: "anthropic", label: "Anthropic (Claude)", vendor: "Anthropic" },
+	{ value: "openai", label: "OpenAI (GPT)", vendor: "OpenAI" },
 ];
+
+/**
+ * What the panel knows about a provider's stored key.
+ *
+ * Neither non-boolean member is the same as `false`. `"unknown"` is a `hasKey` that rejected —
+ * an unreadable vault, a record that will not decrypt — which used to be collapsed into "no API
+ * key configured", reassurance in exactly the wrong direction. `"unchecked"` is the seed value
+ * before the mount check has answered at all, which used to be `false` for the same reason
+ * `useState` needs something: it made the panel assert that the encrypted record was gone during
+ * every mount, over a vault that may well hold a key.
+ */
+type KeyStatus = boolean | "unknown" | "unchecked";
+
+/**
+ * How the status row reads a provider's storage, in precedence order.
+ *
+ * A readable clear-text copy is never reported as "no API key configured": the encrypted record
+ * is gone, but a usable credential is still in this browser. Neither a check that failed nor one
+ * that has not answered yet is reported that way either — that sentence is a claim about storage
+ * that answered.
+ */
+type StatusTone = "configured" | "retained" | "unknown" | "checking" | "empty";
+
+function statusToneOf(status: KeyStatus, residue: LegacyResidue): StatusTone {
+	if (status === true) return "configured";
+	if (residue === "retained") return "retained";
+	if (status === "unknown") return "unknown";
+	if (status === "unchecked") return "checking";
+	return "empty";
+}
+
+const STATUS_TEXT: Record<StatusTone, string> = {
+	configured: "API key configured",
+	retained: "Clear-text API key still in this browser",
+	unknown: "Key storage could not be checked",
+	checking: "Checking key storage…",
+	empty: "No API key configured",
+};
+
+const STATUS_DOT_CLASS: Record<StatusTone, string> = {
+	configured: "bg-green-500",
+	retained: "bg-destructive",
+	unknown: "bg-amber-500",
+	checking: "bg-muted-foreground/30",
+	empty: "bg-muted-foreground/30",
+};
+
+const STATUS_TEXT_CLASS: Record<StatusTone, string> = {
+	configured: "text-muted-foreground",
+	retained: "text-destructive",
+	unknown: "text-amber-600 dark:text-amber-400",
+	checking: "text-muted-foreground",
+	empty: "text-muted-foreground",
+};
 
 /**
  * Render a keychain failure for display. Adapters throw different shapes — the browser vault
@@ -54,6 +120,121 @@ function isRetainedLegacyCopy(error: unknown): boolean {
 	return error.reason === LEGACY_RETAINED;
 }
 
+/**
+ * What a retry that changed nothing says, once (#233).
+ *
+ * `deleteKey` used to author this: the destructive retry it backed reported through its own
+ * rejection that the browser still would not erase the slot. The retry is a re-read now, which
+ * succeeds either way, so the panel has to make that report itself — otherwise clicking the
+ * control leaves the identical notice on screen and no evidence that anything happened. The
+ * "removed from encrypted storage" clause of the adapter's wording is deliberately dropped: a
+ * re-read removes nothing, and repeating it here would be a claim about a write that never ran.
+ *
+ * Both readings report, because both are outcomes a user just asked for. `unverified` is the
+ * one that is permanent on a blocked-storage profile, so leaving it silent made the only
+ * control the panel offers do visibly nothing, forever. Its wording claims no removal and no
+ * absence: `migrateLegacyKey` returns before it touches the slot when the read is refused, so
+ * nothing was attempted and nothing is known either way.
+ *
+ * Neither reading repeats the remedy or its cost. This report is only ever set while `residue`
+ * is non-null, which is the same condition that renders the notice directly above it — so the
+ * remedy and the site-data cost are already on screen, and saying them again put the same
+ * sentence twice within a few lines.
+ */
+function retryReportText(residue: Exclude<LegacyResidue, null>, vendor: string): string {
+	return residue === "retained"
+		? `This browser still would not delete the older clear-text ${vendor} API key.`
+		: `This browser still blocked the check for an older clear-text ${vendor} API key. Nothing was removed, and whether a copy is there is still unknown.`;
+}
+
+/**
+ * The standing notice for a pre-encryption clear-text key that is still in this browser (#233).
+ *
+ * `deleteKey` already reports the condition once, through `message`, and that report is cleared
+ * by the next action and lost when the dialog closes. This block is the version that stays for
+ * as long as the slot is readable, so a user who revoked a possibly-compromised key and missed
+ * the one-shot banner is still told the credential is sitting in clear text.
+ *
+ * The two states are told apart by heading, wording, and colour rather than colour alone:
+ * `retained` asserts a readable copy exists, `unverified` only says the check was refused.
+ *
+ * It carries its own action, bound to its own provider, because the notice renders for whichever
+ * provider has residue rather than only the selected one — the status bar escalates any
+ * provider's, so routing here has to lead somewhere that can act on it.
+ *
+ * That action only ever re-reads; nothing in this notice can reach `deleteKey`. See
+ * `handleRecheck` for why a destructive retry here was unsafe and bought nothing.
+ */
+function ClearTextKeyNotice({
+	residue,
+	provider,
+	vendor,
+	busy,
+	onRecheck,
+}: {
+	residue: Exclude<LegacyResidue, null>;
+	provider: AiProvider;
+	vendor: string;
+	busy: boolean;
+	onRecheck: () => void;
+}) {
+	return (
+		<div
+			role="alert"
+			data-testid={`clear-text-key-notice-${provider}`}
+			className={cn(
+				"flex items-start gap-1.5 rounded border px-2 py-1.5 text-[10px]",
+				residue === "retained"
+					? "border-destructive/40 bg-destructive/10 text-destructive"
+					: "border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400",
+			)}
+		>
+			<AlertTriangle className="mt-0.5 h-3 w-3 flex-shrink-0" />
+			<div className="space-y-1">
+				{residue === "retained" ? (
+					<>
+						<p className="font-medium">
+							A clear-text {vendor} API key is still stored in this browser.
+						</p>
+						<p>
+							It was saved before ThreatForge encrypted keys, and ThreatForge has not been able to
+							delete it. Anything that can read this site's storage can read the key. Clear this
+							site's browser data to remove it, and revoke the key with {vendor} if it may have been
+							exposed.
+						</p>
+						<p>{CLEARING_SITE_DATA_COST}</p>
+						<p>This copy is not a backup — ThreatForge erases it as soon as the browser allows.</p>
+					</>
+				) : (
+					<>
+						<p className="font-medium">
+							ThreatForge could not check for an older clear-text {vendor} API key.
+						</p>
+						<p>
+							This browser blocked the check, so an unencrypted copy saved by an older version may
+							or may not still be there. If you used ThreatForge in this browser before keys were
+							encrypted, clear this site's browser data to be sure.
+						</p>
+						<p>{CLEARING_SITE_DATA_COST}</p>
+					</>
+				)}
+				<button
+					type="button"
+					onClick={onRecheck}
+					disabled={busy}
+					className="flex items-center gap-1 rounded font-medium underline underline-offset-2 hover:no-underline disabled:no-underline disabled:opacity-60"
+				>
+					{busy ? <Loader2 className="h-3 w-3 animate-spin" /> : <RefreshCw className="h-3 w-3" />}
+					{/* Only the `retained` reading has ever had a removal attempted on it. When the read
+					    itself was refused, `migrateLegacyKey` returns before it touches the slot, so
+					    neither "removing" nor "again" would be true. */}
+					{residue === "retained" ? "Try removing it again" : "Check again"}
+				</button>
+			</div>
+		</div>
+	);
+}
+
 /** AI settings form content — used inside the settings dialog. */
 export function AiSettingsContent() {
 	const provider = useChatStore((s) => s.provider);
@@ -61,6 +242,11 @@ export function AiSettingsContent() {
 	const checkApiKey = useChatStore((s) => s.checkApiKey);
 	const settings = useSettingsStore((s) => s.settings);
 	const updateSetting = useSettingsStore((s) => s.updateSetting);
+	// Residue lives in a store rather than in this component because the panel unmounts with
+	// the settings dialog, and a warning that dies with the dialog is the bug (#233).
+	const residue = useKeyResidueStore((s) => s.residue);
+	const refreshResidue = useKeyResidueStore((s) => s.refreshResidue);
+	const refreshAllResidue = useKeyResidueStore((s) => s.refreshAllResidue);
 
 	// Providers the user has saved or deleted since mount. A status check that started before
 	// one of those lands would report the vault as it was, so its answer is not applied over
@@ -68,11 +254,15 @@ export function AiSettingsContent() {
 	const mutated = useRef(new Set<AiProvider>());
 	const [apiKey, setApiKey] = useState("");
 	const [saving, setSaving] = useState(false);
-	const [deleting, setDeleting] = useState(false);
+	// A set rather than one slot: a residue notice renders for a provider that is not the
+	// selected one and each carries its own control, so two removals or rechecks can genuinely
+	// be in flight at once. With a single slot the first one to finish cleared the flag, which
+	// stopped the other's spinner and re-enabled its button mid-operation.
+	const [busyProviders, setBusyProviders] = useState<ReadonlySet<AiProvider>>(new Set());
 	const [showKey, setShowKey] = useState(false);
-	const [keyStatus, setKeyStatus] = useState<Record<AiProvider, boolean>>({
-		anthropic: false,
-		openai: false,
+	const [keyStatus, setKeyStatus] = useState<Record<AiProvider, KeyStatus>>({
+		anthropic: "unchecked",
+		openai: "unchecked",
 	});
 	const [message, setMessage] = useState<{
 		type: "success" | "error";
@@ -87,6 +277,8 @@ export function AiSettingsContent() {
 	const isLegacyModel = selectedModelId !== "" && selectedModel === undefined;
 	const defaultModelId = getDefaultModelId(provider);
 	const defaultModelLabel = getModelById(defaultModelId)?.label ?? defaultModelId;
+	const providerResidue = residue[provider];
+	const statusTone = statusToneOf(keyStatus[provider], providerResidue);
 
 	useEffect(() => {
 		let current = true;
@@ -103,6 +295,11 @@ export function AiSettingsContent() {
 					adapter.hasKey("anthropic"),
 					adapter.hasKey("openai"),
 				]);
+				// Read after the status checks, never before: `hasKey` runs the legacy migration,
+				// which retries the erase, so a residue read that went first would warn about a
+				// slot this same mount was in the middle of removing. Not gated on `current` —
+				// the answer belongs to a store that outlives this panel.
+				void refreshAllResidue();
 				if (!current) return;
 				const answers: [AiProvider, PromiseSettledResult<boolean>][] = [
 					["anthropic", anthropic],
@@ -112,7 +309,12 @@ export function AiSettingsContent() {
 				setKeyStatus((prev) => {
 					const next = { ...prev };
 					for (const [name, answer] of fresh) {
-						next[name] = answer.status === "fulfilled" && answer.value;
+						// A rejected check is recorded as `"unknown"`, not `false`. "No API key
+						// configured" is a claim about storage that answered, and reporting an
+						// unreadable vault that way points the user at entering a key — the one
+						// action that cannot help — and would let a destructive control render
+						// over a record nobody has read.
+						next[name] = answer.status === "fulfilled" ? answer.value : "unknown";
 					}
 					return next;
 				});
@@ -129,7 +331,16 @@ export function AiSettingsContent() {
 		return () => {
 			current = false;
 		};
-	}, []);
+	}, [refreshAllResidue]);
+
+	function setBusy(target: AiProvider, busy: boolean) {
+		setBusyProviders((prev) => {
+			const next = new Set(prev);
+			if (busy) next.add(target);
+			else next.delete(target);
+			return next;
+		});
+	}
 
 	async function handleSave() {
 		if (!apiKey.trim()) return;
@@ -155,25 +366,35 @@ export function AiSettingsContent() {
 			setMessage({ type: "error", text: errorText(err) });
 		} finally {
 			setSaving(false);
+			// `setKey` attempts the clear-text erase and deliberately ignores the outcome, so a
+			// save can clear residue or — on a browser that refuses removal — leave it standing.
+			// Re-read either way, including after a failure, rather than assuming.
+			await refreshResidue(provider);
 		}
 	}
 
-	async function handleDelete() {
-		setDeleting(true);
+	async function handleDelete(target: AiProvider) {
+		setBusy(target, true);
 		setMessage(null);
 
 		function recordRemoval() {
-			mutated.current.add(provider);
-			setKeyStatus((prev) => ({ ...prev, [provider]: false }));
+			mutated.current.add(target);
+			setKeyStatus((prev) => ({ ...prev, [target]: false }));
+		}
+
+		// The chat transport tracks the *selected* provider's key, so a removal for another
+		// provider — reachable from that provider's residue notice — leaves it untouched.
+		async function syncTransport() {
+			if (target === provider) await checkApiKey(provider);
 		}
 
 		try {
 			const adapter = await loadAdapter();
-			await adapter.deleteKey(provider);
+			await adapter.deleteKey(target);
 			recordRemoval();
 			const successText = isTauri() ? "API key removed." : "API key removed from this browser.";
 			setMessage({ type: "success", text: successText });
-			await checkApiKey(provider);
+			await syncTransport();
 		} catch (err) {
 			// A retained clear-text copy is a warning about residue, not a failed removal: the
 			// stored key is gone. Leaving the status alone would show the provider as configured
@@ -181,11 +402,55 @@ export function AiSettingsContent() {
 			// overwrite it with the answer from before the delete.
 			if (isRetainedLegacyCopy(err)) {
 				recordRemoval();
-				await checkApiKey(provider);
+				await syncTransport();
 			}
 			setMessage({ type: "error", text: errorText(err) });
 		} finally {
-			setDeleting(false);
+			setBusy(target, false);
+			// The state transition this issue is about. Covers the retained rejection, a clean
+			// removal, and a vault error thrown after the slot had already been erased.
+			await refreshResidue(target);
+		}
+	}
+
+	/**
+	 * Re-read a provider's stored key and clear-text slot, and report what is still there.
+	 *
+	 * This is the only thing a residue notice ever does. It must not call `deleteKey`, which
+	 * commits a permanent revocation marker: the notice renders from a snapshot that cannot rule
+	 * out a key saved in another tab, or one saved before the mount check answered. `hasKey` is
+	 * what runs the legacy migration, which retries the erase, so on a browser that has started
+	 * allowing removals this is also what actually clears the slot — and where it has not, the
+	 * retirement marker `deleteKey` already wrote means nothing can re-import the slot either.
+	 *
+	 * Residue is read after `hasKey` for the same reason the mount check reads it last, and a
+	 * reading that survives is reported here because `deleteKey` used to be what said it.
+	 */
+	async function handleRecheck(target: AiProvider, vendor: string) {
+		setBusy(target, true);
+		setMessage(null);
+		let reported = false;
+		try {
+			const adapter = await loadAdapter();
+			const present = await adapter.hasKey(target);
+			// This answer is newer than any mount check still in flight, so it outranks it.
+			mutated.current.add(target);
+			setKeyStatus((prev) => ({ ...prev, [target]: present }));
+			if (target === provider) await checkApiKey(provider);
+		} catch (err) {
+			setKeyStatus((prev) => ({ ...prev, [target]: "unknown" }));
+			setMessage({ type: "error", text: errorText(err) });
+			reported = true;
+		} finally {
+			setBusy(target, false);
+			await refreshResidue(target);
+			// Read from the store rather than the render snapshot, which predates the refresh.
+			// A retry that changed nothing has to say so: the standing notice looks identical
+			// before and after, so without this the click has no outcome the user can see.
+			const reading = useKeyResidueStore.getState().residue[target];
+			if (!reported && reading !== null) {
+				setMessage({ type: "error", text: retryReportText(reading, vendor) });
+			}
 		}
 	}
 
@@ -261,22 +526,37 @@ export function AiSettingsContent() {
 			</div>
 
 			{/* Key status */}
-			<div className="flex items-center gap-2">
-				<div
-					className={cn(
-						"h-2 w-2 rounded-full",
-						keyStatus[provider] ? "bg-green-500" : "bg-muted-foreground/30",
-					)}
-				/>
-				<span className="text-xs text-muted-foreground">
-					{keyStatus[provider] ? "API key configured" : "No API key configured"}
-				</span>
+			<div className="space-y-1.5">
+				<div className="flex items-center gap-2">
+					<div className={cn("h-2 w-2 rounded-full", STATUS_DOT_CLASS[statusTone])} />
+					<span className={cn("text-xs", STATUS_TEXT_CLASS[statusTone])}>
+						{STATUS_TEXT[statusTone]}
+					</span>
+				</div>
+
+				{/* Every provider with residue, not only the selected one: the status bar escalates
+				    any provider's retained slot, and routing a user here to a panel that shows
+				    nothing would restore the contradiction this issue exists to remove. */}
+				{PROVIDERS.map(({ value, vendor }) => {
+					const noticeResidue = residue[value];
+					if (noticeResidue === null) return null;
+					return (
+						<ClearTextKeyNotice
+							key={value}
+							residue={noticeResidue}
+							provider={value}
+							vendor={vendor}
+							busy={busyProviders.has(value)}
+							onRecheck={() => void handleRecheck(value, vendor)}
+						/>
+					);
+				})}
 			</div>
 
 			{/* API key input */}
 			<div>
 				<span className="mb-1 block text-[10px] font-medium text-muted-foreground">
-					{keyStatus[provider] ? "Replace API Key" : "API Key"}
+					{keyStatus[provider] === true ? "Replace API Key" : "API Key"}
 				</span>
 				<div className="flex gap-2">
 					<div className="relative flex-1">
@@ -316,15 +596,21 @@ export function AiSettingsContent() {
 				</div>
 			</div>
 
-			{/* Delete button */}
-			{keyStatus[provider] && (
+			{/* Removal. Rendered only where a stored key is known to be there: `deleteKey` commits
+			    a permanent revocation marker, so it must never be what a user reaches for when
+			    the panel could not read storage, or has not read it yet. */}
+			{keyStatus[provider] === true && (
 				<button
 					type="button"
-					onClick={() => void handleDelete()}
-					disabled={deleting}
+					onClick={() => void handleDelete(provider)}
+					disabled={busyProviders.has(provider)}
 					className="flex items-center gap-1 rounded px-2 py-1 text-xs text-destructive hover:bg-destructive/10 transition-colors"
 				>
-					{deleting ? <Loader2 className="h-3 w-3 animate-spin" /> : <Trash2 className="h-3 w-3" />}
+					{busyProviders.has(provider) ? (
+						<Loader2 className="h-3 w-3 animate-spin" />
+					) : (
+						<Trash2 className="h-3 w-3" />
+					)}
 					Remove API key
 				</button>
 			)}

--- a/src/lib/adapters/browser-keychain-adapter.test.ts
+++ b/src/lib/adapters/browser-keychain-adapter.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } fr
 import "fake-indexeddb/auto";
 import { KEY_VAULT_DB_NAME, KEY_VAULT_DB_VERSION, KeyVaultError } from "./browser-key-vault";
 import { BrowserKeychainAdapter } from "./browser-keychain-adapter";
-import { LEGACY_RETAINED } from "./keychain-adapter";
+import { CLEARING_SITE_DATA_COST, LEGACY_RETAINED } from "./keychain-adapter";
 import { yieldHostTask } from "./test-fixtures/host-task";
 import { resetKeyVault } from "./test-fixtures/key-vault";
 
@@ -16,6 +16,33 @@ import { resetKeyVault } from "./test-fixtures/key-vault";
 
 const SECRET = "sk-ant-test-0123456789abcdef";
 const LEGACY_SLOT = "tf-api-key-anthropic";
+
+/** Make `localStorage.removeItem` a no-op, as a browser refusing the removal would. */
+function refuseLegacyRemoval(): MockInstance<Storage["removeItem"]> {
+	return vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => undefined);
+}
+
+/**
+ * Collect every promise the adapter parks in its module-scoped per-provider queue.
+ *
+ * That map is private to `browser-keychain-adapter.ts`, and exporting it to observe what it
+ * holds would put a test seam in production code for a property about what production code
+ * retains. Spying on `Map.prototype.set` reads the same fact from outside, filtered to the
+ * promises stored under a provider key — which is the only thing that shape describes.
+ */
+function captureQueuedPromises(provider: string): Promise<unknown>[] {
+	const captured: Promise<unknown>[] = [];
+	const original = Map.prototype.set;
+	vi.spyOn(Map.prototype, "set").mockImplementation(function (
+		this: Map<unknown, unknown>,
+		key: unknown,
+		value: unknown,
+	) {
+		if (key === provider && value instanceof Promise) captured.push(value);
+		return original.call(this, key, value);
+	});
+	return captured;
+}
 
 /** Read every value held in the vault database, as one string, for substring scanning. */
 async function dumpVault(): Promise<string> {
@@ -800,11 +827,6 @@ describe("storage that never responds", () => {
 });
 
 describe("a clear-text slot that will not erase", () => {
-	/** Make `localStorage.removeItem` a no-op, as a browser refusing the removal would. */
-	function refuseLegacyRemoval(): MockInstance<Storage["removeItem"]> {
-		return vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => undefined);
-	}
-
 	it("does not reinstate a replaced key when the vault is started over", async () => {
 		refuseLegacyRemoval();
 		localStorage.setItem(LEGACY_SLOT, "sk-ant-old");
@@ -900,6 +922,11 @@ describe("a clear-text slot that will not erase", () => {
 		expect((error as KeyVaultError).reason).toBe(LEGACY_RETAINED);
 		// The encrypted copy is still removed; only the claim of completeness is withheld.
 		expect(localStorage.getItem(LEGACY_SLOT)).toBe("sk-ant-old-cleartext");
+		// The message ends in the only instruction the app can give, so it carries what that
+		// instruction costs — clearing site data takes the user's saved threat models with it.
+		// Asserted against the shared constant rather than a copy of its words, because the
+		// point of sharing it is that every surface giving the instruction states the cost.
+		expect((error as KeyVaultError).message).toContain(CLEARING_SITE_DATA_COST);
 	});
 	it("does not let a dismissed clear-text slot come back after a delete", async () => {
 		localStorage.setItem(LEGACY_SLOT, "sk-ant-compromised");
@@ -939,6 +966,8 @@ describe("a clear-text slot that will not erase", () => {
 		// either wording is caught. Only the message distinguishes "a copy is definitely still
 		// there" from "a copy could not be checked", and they call for different advice.
 		expect((error as KeyVaultError).message).toContain("blocked the check");
+		// Both branches give the same instruction, so both state the same cost.
+		expect((error as KeyVaultError).message).toContain(CLEARING_SITE_DATA_COST);
 	});
 
 	it("keeps the stored key when the tombstone cannot be written", async () => {
@@ -1064,6 +1093,128 @@ describe("a clear-text slot that will not erase", () => {
 		// they are in — and only one of them justifies asserting a copy exists.
 		expect((retained as KeyVaultError).message).toContain("would not delete");
 		expect((retained as KeyVaultError).message).not.toContain("blocked the check");
+	});
+});
+
+/**
+ * #233: `deleteKey`'s rejection reports a surviving clear-text copy exactly once, at the moment
+ * of the action. `readLegacyResidue` is the standing answer the settings panel and the status
+ * bar read instead, so a user who missed that message is still told a usable credential is
+ * readable in this browser.
+ */
+describe("reporting a surviving clear-text copy", () => {
+	it("reports a clear-text copy the browser refused to erase", async () => {
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-old-cleartext");
+		refuseLegacyRemoval();
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+
+		const error = await adapter.deleteKey("anthropic").catch((caught: unknown) => caught);
+
+		// The one-shot rejection is not replaced by the standing answer: a delete that leaves a
+		// live credential behind must still fail closed at the moment it is attempted.
+		expect((error as KeyVaultError).reason).toBe(LEGACY_RETAINED);
+		expect(await adapter.readLegacyResidue("anthropic")).toBe("retained");
+	});
+
+	it("reports storage that would not answer as unverified", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		// A browser that blocks site data throws on read while the value stays on disk. Absence
+		// cannot be claimed from that, so it is reported as its own state rather than as `null`.
+		vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+			throw new DOMException("blocked", "SecurityError");
+		});
+
+		expect(await adapter.readLegacyResidue("anthropic")).toBe("unverified");
+	});
+
+	it("reports no residue when the slot is genuinely absent", async () => {
+		const adapter = new BrowserKeychainAdapter();
+
+		// A profile created after #133 never had a slot.
+		expect(await adapter.readLegacyResidue("anthropic")).toBeNull();
+
+		// And a browser that allows the removal leaves nothing behind, so the warning the panel
+		// draws from this has to go away rather than persisting as stale state.
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-old-cleartext");
+		await adapter.setKey("anthropic", SECRET);
+		await adapter.deleteKey("anthropic");
+
+		expect(await adapter.readLegacyResidue("anthropic")).toBeNull();
+	});
+
+	it("does not erase the slot it reports on", async () => {
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-old-cleartext");
+		const removal = vi.spyOn(Storage.prototype, "removeItem");
+		const adapter = new BrowserKeychainAdapter();
+
+		expect(await adapter.readLegacyResidue("anthropic")).toBe("retained");
+		expect(await adapter.readLegacyResidue("anthropic")).toBe("retained");
+
+		// A read that erased would make the warning disappear on the first render that showed
+		// it, and would destroy a copy the vault may not be able to replace.
+		expect(localStorage.getItem(LEGACY_SLOT)).toBe("sk-ant-old-cleartext");
+		expect(removal).not.toHaveBeenCalledWith(LEGACY_SLOT);
+	});
+
+	it("answers with a fixed token rather than anything read from the slot", async () => {
+		localStorage.setItem(LEGACY_SLOT, SECRET);
+		const adapter = new BrowserKeychainAdapter();
+
+		// The slot's value is read only to tell `present` from `absent`, and every consumer of
+		// this renders the result somewhere a user can see. Seeding a recognisable secret and
+		// asserting the answer is exactly `"retained"` is what pins that.
+		expect(await adapter.readLegacyResidue("anthropic")).toBe("retained");
+	});
+
+	it("does not open the key vault to answer", async () => {
+		localStorage.setItem(LEGACY_SLOT, SECRET);
+		const adapter = new BrowserKeychainAdapter();
+
+		expect(await adapter.readLegacyResidue("anthropic")).toBe("retained");
+
+		// The launch-time check reads the slot before it decides whether to run the migration,
+		// precisely so a profile with nothing to migrate never materialises the keychain
+		// database. That only holds while this stays a `localStorage` read.
+		expect(await indexedDB.databases()).toEqual([]);
+		expect(await adapter.hasKey("anthropic")).toBe(true);
+		expect((await indexedDB.databases()).map((db) => db.name)).toContain("threatforge-keychain");
+	});
+
+	it("does not park the plaintext key in the provider queue", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		const queued = captureQueuedPromises("anthropic");
+
+		expect(await adapter.getKey("anthropic")).toBe(SECRET);
+
+		// `withProviderLock` parks a promise per provider so the next operation can chain off
+		// it. That promise must not forward the operation's value: for `getKey` the value is the
+		// plaintext key, which would then sit in a module-scoped map until the provider's next
+		// call replaced it — a copy of the credential nobody asked for and nothing clears.
+		// Asserted over every promise parked under this provider, not just the last: a lock that
+		// parked a second promise per provider could otherwise hide the leak behind the
+		// sanitized one.
+		expect(queued.length).toBeGreaterThan(0);
+		for (const parked of queued) {
+			expect(await parked).toBeUndefined();
+		}
+	});
+
+	it("waits for an in-flight migration instead of warning about a slot it is erasing", async () => {
+		localStorage.setItem(LEGACY_SLOT, "sk-ant-old-cleartext");
+		const adapter = new BrowserKeychainAdapter();
+
+		// `migrateLegacyKey` erases the slot only after the import has committed. A read that
+		// landed in that gap would report `retained` on the ordinary pre-#133 upgrade path — a
+		// permanent-looking security warning for a user whose key was migrated correctly. The
+		// per-provider lock is what closes it, so the read is issued without awaiting the
+		// migration it must queue behind.
+		const migrated = adapter.hasKey("anthropic");
+		const residue = await adapter.readLegacyResidue("anthropic");
+
+		expect(await migrated).toBe(true);
+		expect(residue).toBeNull();
 	});
 });
 

--- a/src/lib/adapters/browser-keychain-adapter.ts
+++ b/src/lib/adapters/browser-keychain-adapter.ts
@@ -8,7 +8,12 @@ import {
 	putSecret,
 	retireAndDeleteSecret,
 } from "./browser-key-vault";
-import { type KeychainAdapter, LEGACY_RETAINED } from "./keychain-adapter";
+import {
+	CLEARING_SITE_DATA_COST,
+	type KeychainAdapter,
+	LEGACY_RETAINED,
+	type LegacyResidue,
+} from "./keychain-adapter";
 
 /**
  * Prefix of the clear-text `localStorage` slot this adapter used before #133. Retained only
@@ -113,7 +118,7 @@ function removeLegacyKey(provider: AiProvider): LegacyErasure {
  * A slot that refuses to be erased here is not reported. Only `deleteKey` makes a claim about
  * a credential being gone, so only it must fail when one survives; a read reporting an error
  * would break every AI request over a residue the user cannot act on from that surface.
- * Surfacing it persistently in settings is #233.
+ * {@link BrowserKeychainAdapter.readLegacyResidue} is what surfaces it persistently instead.
  */
 async function migrateLegacyKey(provider: AiProvider): Promise<void> {
 	const slot = readLegacySlot(provider);
@@ -142,10 +147,16 @@ const providerOperations = new Map<AiProvider, Promise<unknown>>();
 
 function withProviderLock<T>(provider: AiProvider, operation: () => Promise<T>): Promise<T> {
 	const pending = (providerOperations.get(provider) ?? Promise.resolve()).then(operation);
-	// The stored link never rejects, so one failed operation cannot poison the queue.
+	// The stored link never rejects, so one failed operation cannot poison the queue — and it
+	// resolves to `undefined` rather than forwarding the operation's value, which for `getKey`
+	// is the plaintext API key and would otherwise sit in this module-scoped map until the
+	// provider's next call replaced it.
 	providerOperations.set(
 		provider,
-		pending.catch(() => undefined),
+		pending.then(
+			() => undefined,
+			() => undefined,
+		),
 	);
 	return pending;
 }
@@ -233,10 +244,30 @@ export class BrowserKeychainAdapter implements KeychainAdapter {
 				throw new KeyVaultError(
 					LEGACY_RETAINED,
 					erasure === "retained"
-						? "The API key was removed from encrypted storage, but this browser would not delete an older clear-text copy. Clear this site's browser data to remove it."
-						: "The API key was removed from encrypted storage, but this browser blocked the check for an older clear-text copy. Clear this site's browser data to be sure it is gone.",
+						? `The API key was removed from encrypted storage, but this browser would not delete an older clear-text copy. Clear this site's browser data to remove it. ${CLEARING_SITE_DATA_COST}`
+						: `The API key was removed from encrypted storage, but this browser blocked the check for an older clear-text copy. Clear this site's browser data to be sure it is gone. ${CLEARING_SITE_DATA_COST}`,
 				);
 			}
+		});
+	}
+
+	/**
+	 * Browser-only: report whether a pre-#133 clear-text slot is still readable (#233).
+	 *
+	 * A pure read. It never erases, never writes, and never returns key material.
+	 *
+	 * It takes the provider lock because {@link migrateLegacyKey} erases the slot only after
+	 * {@link importLegacySecret} commits: an unlocked read landing in that gap would report
+	 * `retained` for a slot the same operation is about to erase, which is a false alarm on the
+	 * ordinary upgrade path for every pre-#133 user. Because the lock is a promise chain and is
+	 * not reentrant, this must never be called from inside another locked operation — a nested
+	 * call would wedge that provider's queue permanently.
+	 */
+	async readLegacyResidue(provider: AiProvider): Promise<LegacyResidue> {
+		return withProviderLock(provider, async () => {
+			const slot = readLegacySlot(provider);
+			if (slot.state === "absent") return null;
+			return slot.state === "present" ? "retained" : "unverified";
 		});
 	}
 }

--- a/src/lib/adapters/keychain-adapter.test.ts
+++ b/src/lib/adapters/keychain-adapter.test.ts
@@ -63,6 +63,38 @@ describe("the shared keychain interface", () => {
 		expect("getKey" in new TauriKeychainAdapter()).toBe(false);
 	});
 
+	it("does not carry a residue check on the desktop adapter", () => {
+		// The clear-text `localStorage` slot is a browser artefact, and a desktop implementation
+		// returning `null` would report a check it never performed. See `LegacyResidue` for why
+		// `undefined` and `null` are kept as different claims.
+		expect("readLegacyResidue" in new TauriKeychainAdapter()).toBe(false);
+
+		const shared: KeychainAdapter = new TauriKeychainAdapter();
+		expect(shared.readLegacyResidue?.("anthropic")).toBeUndefined();
+	});
+
+	it("makes an unguarded residue call a type error", () => {
+		const shared: KeychainAdapter = new TauriKeychainAdapter();
+
+		// The compile assertion. `tsc --noEmit` fails with "unused '@ts-expect-error'
+		// directive" the moment `readLegacyResidue` stops being optional — which is what would
+		// let a caller assume every platform can answer, and hand the desktop build an
+		// obligation it cannot fulfil honestly.
+		// @ts-expect-error `readLegacyResidue` is optional: this platform may not have a slot.
+		const callWithoutGuarding = (): unknown => shared.readLegacyResidue("anthropic");
+
+		expect(callWithoutGuarding).toThrowError(TypeError);
+	});
+
+	it("answers the residue check through the shared interface in the browser", async () => {
+		localStorage.setItem("tf-api-key-anthropic", "sk-ant-pre-encryption");
+		const shared: KeychainAdapter = new BrowserKeychainAdapter();
+
+		// The optional call is not decoration: where the capability exists it resolves to a
+		// closed union with no cast, no `in` check, and no key material.
+		await expect(shared.readLegacyResidue?.("anthropic")).resolves.toBe("retained");
+	});
+
 	it("still lets the desktop adapter report whether a key exists", () => {
 		const desktop: KeychainAdapter = new TauriKeychainAdapter();
 		expect(desktop.hasKey).toBeTypeOf("function");

--- a/src/lib/adapters/keychain-adapter.ts
+++ b/src/lib/adapters/keychain-adapter.ts
@@ -22,7 +22,43 @@ export interface KeychainAdapter {
 	hasKey(provider: AiProvider): Promise<boolean>;
 	/** Delete an API key for a provider. */
 	deleteKey(provider: AiProvider): Promise<void>;
+	/**
+	 * Browser only. Report whether a pre-#133 clear-text copy of this provider's key is still
+	 * readable from `localStorage`, without attempting to erase it and without returning any
+	 * part of the key.
+	 *
+	 * Optional because a platform that never had a clear-text slot has nothing to answer — see
+	 * {@link LegacyResidue} for why `undefined` and `null` are different claims.
+	 */
+	readLegacyResidue?(provider: AiProvider): Promise<LegacyResidue>;
 }
+
+/**
+ * What a pre-#133 clear-text API key slot currently holds for one provider.
+ *
+ * `null` is an answer, not an absence of one: the slot was checked and nothing is there. A
+ * caller that cannot get an answer at all sees `undefined` from the optional
+ * {@link KeychainAdapter.readLegacyResidue} call instead, meaning "there is no such storage
+ * location on this platform". Collapsing those two is the same mistake the browser adapter's
+ * `readLegacySlot` refuses to make one level down, and it is what would let a desktop build
+ * assert an erasure it never performed.
+ */
+export type LegacyResidue = "retained" | "unverified" | null;
+
+/**
+ * The cost of the one instruction that actually removes a clear-text slot (#233).
+ *
+ * "Clear this site's browser data" is the only remedy the app can offer for a slot the browser
+ * refuses to erase — and in this browser it also destroys the user's saved threat models, which
+ * live in IndexedDB with their manifest in `localStorage` (`src/lib/persistence/types.ts`).
+ * Shipping the instruction without the cost is how a user follows security advice and loses
+ * their work, so every surface that gives the instruction states it, from one string.
+ *
+ * Declared beside {@link LEGACY_RETAINED} for the same reason: the browser adapter and the
+ * settings panel both need it, and the panel must not import IndexedDB code to get it.
+ */
+export const CLEARING_SITE_DATA_COST =
+	"Clearing this site's browser data also removes the threat models saved in this browser, so export anything you need first.";
 
 /**
  * Reason code for a removal that succeeded but left a readable clear-text copy behind.

--- a/src/stores/chat-store.test.ts
+++ b/src/stores/chat-store.test.ts
@@ -8,9 +8,11 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { LegacyResidue } from "@/lib/adapters/keychain-adapter";
 import type { StreamConversationHandlers } from "@/lib/ai/protocol/client";
 import { flattenText } from "@/lib/ai/protocol/messages";
 import { type ChatMessage, useChatStore } from "@/stores/chat-store";
+import { useKeyResidueStore } from "@/stores/key-residue-store";
 import type { ThreatModel } from "@/types/threat-model";
 
 const streamConversationMock = vi.hoisted(() => vi.fn());
@@ -21,6 +23,30 @@ vi.mock("@/lib/ai/protocol/client", () => ({
 
 vi.mock("@/lib/adapters/get-chat-transport", () => ({
 	getChatTransport: () => Promise.resolve({ open: vi.fn() }),
+}));
+
+// `checkApiKey` crosses the keychain boundary twice: `hasKey`, which also migrates and erases a
+// pre-#133 clear-text slot, and the residue re-read that follows it. Mocked so both the order of
+// those calls and the slot's fate are observable without IndexedDB.
+let keychainCalls: string[] = [];
+/** The clear-text slot as the real adapter would see it, per provider. */
+let slot: Record<string, LegacyResidue> = { anthropic: null, openai: null };
+/** Whether `hasKey` migrates the slot away, as it does for every upgrading pre-#133 user. */
+let hasKeyMigrates = false;
+vi.mock("@/lib/adapters/get-keychain-adapter", () => ({
+	getKeychainAdapter: async () => ({
+		setKey: async () => undefined,
+		hasKey: async (provider: string) => {
+			keychainCalls.push(`hasKey:${provider}`);
+			if (hasKeyMigrates) slot[provider] = null;
+			return false;
+		},
+		deleteKey: async () => undefined,
+		readLegacyResidue: async (provider: string) => {
+			keychainCalls.push(`residue:${provider}`);
+			return slot[provider] ?? null;
+		},
+	}),
 }));
 
 function emptyModel(): ThreatModel {
@@ -65,6 +91,10 @@ function lastMessage(): ChatMessage {
 beforeEach(() => {
 	vi.clearAllMocks();
 	localStorage.clear();
+	keychainCalls = [];
+	slot = { anthropic: null, openai: null };
+	hasKeyMigrates = false;
+	useKeyResidueStore.setState({ residue: { anthropic: null, openai: null } });
 	seedSession();
 });
 
@@ -258,5 +288,40 @@ describe("chat store persistence", () => {
 			{ role: "user", content: [{ type: "text", text: "remember this" }] },
 			{ role: "assistant", content: [{ type: "text", text: "remembered answer" }] },
 		]);
+	});
+});
+
+/**
+ * #233: `checkApiKey` is the third path that runs the legacy migration, and the only one that
+ * runs outside both the launch effect and the settings panel — `ai-chat-tab.tsx` calls it on
+ * mount. Without a residue re-read here, opening the AI chat tab can erase the clear-text slot
+ * while the status bar keeps claiming one is there for the rest of the session.
+ */
+describe("chat store clear-text key residue", () => {
+	it("re-reads the clear-text slot after the key check that can erase it", async () => {
+		useKeyResidueStore.setState({ residue: { anthropic: "retained", openai: null } });
+		slot = { anthropic: "retained", openai: null };
+		hasKeyMigrates = true;
+
+		await useChatStore.getState().checkApiKey("anthropic");
+
+		expect(useKeyResidueStore.getState().residue.anthropic).toBeNull();
+		// Ordered, not merely present: `hasKey` is what migrates the slot, so a read taken
+		// before it would answer "retained" for storage this same call just cleaned up. Only
+		// the checked provider is re-read — the other's slot was not touched.
+		expect(keychainCalls).toEqual(["hasKey:anthropic", "residue:anthropic"]);
+	});
+
+	it("leaves a standing warning alone when the check did not clear the slot", async () => {
+		// Seeded empty, not `retained`: if the store already held the value the assertion looks
+		// for, it would pass with the refresh deleted. The warning has to arrive from the slot.
+		useKeyResidueStore.setState({ residue: { anthropic: null, openai: null } });
+		slot = { anthropic: "retained", openai: null };
+
+		await useChatStore.getState().checkApiKey("anthropic");
+
+		// The re-read is a re-derivation, not a dismissal: a browser that still refuses the
+		// erase keeps its warning.
+		expect(useKeyResidueStore.getState().residue.anthropic).toBe("retained");
 	});
 });

--- a/src/stores/chat-store.ts
+++ b/src/stores/chat-store.ts
@@ -14,6 +14,7 @@ import {
 } from "@/lib/ai/protocol/messages";
 import { getDefaultModelId } from "@/lib/ai-models";
 import { buildSystemPrompt } from "@/lib/ai-prompt";
+import { useKeyResidueStore } from "@/stores/key-residue-store";
 import { useSettingsStore } from "@/stores/settings-store";
 import {
 	type ChatSession,
@@ -524,6 +525,11 @@ export const useChatStore = create<ChatState>((set, get) => ({
 		} catch {
 			set({ hasApiKey: false });
 		}
+		// `hasKey` is also what migrates a pre-#133 clear-text key into the vault and erases the
+		// slot, so a slot that was there when the session started may be gone now. Re-read it
+		// rather than leaving a standing "clear-text API key" warning (#233) about storage this
+		// call just cleaned up. Never rejects, and never gates a request on the answer.
+		await useKeyResidueStore.getState().refreshResidue(provider);
 	},
 
 	clearError: () => set({ error: null }),

--- a/src/stores/key-residue-store.test.ts
+++ b/src/stores/key-residue-store.test.ts
@@ -1,0 +1,144 @@
+/**
+ * The residue store is the standing record of a clear-text API key that survived deletion
+ * (#233). Its contract is narrow and load-bearing: it never rejects, it never persists, and it
+ * never writes `null` — the value that hides the warning — on evidence it does not have.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { LegacyResidue } from "@/lib/adapters/keychain-adapter";
+import { useKeyResidueStore } from "./key-residue-store";
+
+let getAdapter: () => Promise<unknown> = async () => ({});
+
+vi.mock("@/lib/adapters/get-keychain-adapter", () => ({
+	getKeychainAdapter: () => getAdapter(),
+}));
+
+/** An adapter with the browser capability, answering whatever the case sets up. */
+function browserAdapter(answers: Record<string, LegacyResidue>) {
+	return {
+		setKey: async () => undefined,
+		hasKey: async () => false,
+		deleteKey: async () => undefined,
+		readLegacyResidue: async (provider: string) => answers[provider] ?? null,
+	};
+}
+
+beforeEach(() => {
+	localStorage.clear();
+	useKeyResidueStore.setState({ residue: { anthropic: null, openai: null } });
+	getAdapter = async () => browserAdapter({});
+});
+
+describe("the clear-text key residue store", () => {
+	it("records what the keychain capability reports for a provider", async () => {
+		getAdapter = async () => browserAdapter({ anthropic: "retained", openai: "unverified" });
+
+		await useKeyResidueStore.getState().refreshResidue("anthropic");
+
+		expect(useKeyResidueStore.getState().residue.anthropic).toBe("retained");
+		// One refresh answers for one provider; the other is not guessed at.
+		expect(useKeyResidueStore.getState().residue.openai).toBeNull();
+	});
+
+	it("covers every provider when refreshing them all", async () => {
+		getAdapter = async () => browserAdapter({ anthropic: "retained", openai: "unverified" });
+
+		await useKeyResidueStore.getState().refreshAllResidue();
+
+		expect(useKeyResidueStore.getState().residue).toEqual({
+			anthropic: "retained",
+			openai: "unverified",
+		});
+	});
+
+	it("reports nothing when the platform has no clear-text slot to check", async () => {
+		// The shape `TauriKeychainAdapter` actually has: the answer comes from the absence of
+		// the method, not from a desktop implementation claiming it performed a check. See
+		// `LegacyResidue` for why that distinction is kept.
+		getAdapter = async () => ({
+			setKey: async () => undefined,
+			hasKey: async () => false,
+			deleteKey: async () => undefined,
+		});
+		useKeyResidueStore.setState({ residue: { anthropic: "retained", openai: null } });
+
+		await useKeyResidueStore.getState().refreshResidue("anthropic");
+
+		expect(useKeyResidueStore.getState().residue.anthropic).toBeNull();
+	});
+
+	it("clears a provider's warning once the slot reads empty", async () => {
+		useKeyResidueStore.setState({ residue: { anthropic: "retained", openai: null } });
+		getAdapter = async () => browserAdapter({ anthropic: null });
+
+		await useKeyResidueStore.getState().refreshResidue("anthropic");
+
+		// Every refresh recomputes from storage, so nothing has to clear the warning by hand.
+		expect(useKeyResidueStore.getState().residue.anthropic).toBeNull();
+	});
+
+	it("keeps the previous answer when the adapter module will not load", async () => {
+		useKeyResidueStore.setState({ residue: { anthropic: "retained", openai: null } });
+		getAdapter = async () => {
+			throw new Error("Failed to fetch dynamically imported module: /assets/x-9f2a1c.js");
+		};
+
+		await expect(
+			useKeyResidueStore.getState().refreshResidue("anthropic"),
+		).resolves.toBeUndefined();
+
+		// "The bundle did not load" is not evidence the slot is empty. Writing `null` here would
+		// retract a warning about a live credential on the strength of a chunk-load failure.
+		expect(useKeyResidueStore.getState().residue.anthropic).toBe("retained");
+	});
+
+	it("keeps the previous answer when the read itself rejects", async () => {
+		useKeyResidueStore.setState({ residue: { anthropic: "retained", openai: null } });
+		getAdapter = async () => ({
+			setKey: async () => undefined,
+			hasKey: async () => false,
+			deleteKey: async () => undefined,
+			readLegacyResidue: async () => {
+				throw new DOMException("blocked", "SecurityError");
+			},
+		});
+
+		// Both panel callers await this inside a `finally`, so a rejection escaping here would
+		// surface as an unhandled rejection and mask the error the `catch` had just rendered.
+		await expect(
+			useKeyResidueStore.getState().refreshResidue("anthropic"),
+		).resolves.toBeUndefined();
+
+		// A failed read is not evidence of an empty slot, for the same reason a failed module
+		// load is not: `null` here would retract a warning about a live credential.
+		expect(useKeyResidueStore.getState().residue.anthropic).toBe("retained");
+	});
+
+	it("keeps nothing in web storage, because the storage it describes is the one refusing", () => {
+		useKeyResidueStore.setState({ residue: { anthropic: "retained", openai: "unverified" } });
+
+		// A persisted copy would be a stale claim about a secret, written to the storage that is
+		// by hypothesis misbehaving. The state is re-derived every session instead.
+		const stored = Object.keys(localStorage).map((key) => localStorage.getItem(key) ?? "");
+		expect(stored.join("|")).not.toContain("retained");
+	});
+
+	it("has no persistence middleware to write anywhere else either", () => {
+		// The scan above only proves `localStorage` is clean; `persist` can be pointed at
+		// `sessionStorage` or IndexedDB and would pass it. Read the module as raw text at test
+		// time and assert the middleware is absent at the source, in the spirit of
+		// `src/lib/persistence/no-key-leakage.test.ts`.
+		const sources = import.meta.glob("./key-residue-store.ts", {
+			query: "?raw",
+			import: "default",
+			eager: true,
+		}) as Record<string, string>;
+		const [[path, contents]] = Object.entries(sources);
+		expect(path).toContain("key-residue-store.ts");
+		// Matched as code rather than as a word, so the module's own prose about not persisting
+		// does not satisfy the check it is describing.
+		expect(contents).not.toMatch(/from ["']zustand\/middleware["']/);
+		expect(contents).not.toMatch(/\bpersist\s*\(/);
+	});
+});

--- a/src/stores/key-residue-store.ts
+++ b/src/stores/key-residue-store.ts
@@ -1,0 +1,78 @@
+import { create } from "zustand";
+import { getKeychainAdapter } from "@/lib/adapters/get-keychain-adapter";
+import type { LegacyResidue } from "@/lib/adapters/keychain-adapter";
+import type { AiProvider } from "@/stores/chat-store";
+
+/**
+ * Assert at compile time that `list` names every `AiProvider`.
+ *
+ * A bare `readonly AiProvider[]` annotation only rejects a *wrong* provider; a third provider
+ * added to the union would leave this list silently short, and the slot it never refreshes is
+ * one nothing would ever warn about. The intersection resolves to `never` — so the call fails
+ * to compile — unless every member of the union appears in the tuple. `Object.keys(...) as
+ * AiProvider[]` would answer the same question at runtime and is forbidden by `AGENTS.md`.
+ */
+function everyProvider<T extends readonly AiProvider[]>(
+	list: T & (AiProvider extends T[number] ? unknown : never),
+): T {
+	return list;
+}
+
+/**
+ * Every provider whose clear-text slot is worth asking about.
+ *
+ * Exported because the launch effect in `app-layout.tsx` has to walk the same list to settle
+ * each provider's migration before the committed read, and a second hand-written list there is
+ * one a third provider would be silently missing from.
+ *
+ * The guard covers this list only. The settings panel hand-writes its own provider set, so
+ * adding a provider still means auditing that file — this buys the launch path, not the repo.
+ */
+export const RESIDUE_PROVIDERS = everyProvider(["anthropic", "openai"] as const);
+
+/**
+ * Whether a pre-#133 clear-text API key is still readable in this browser (#233).
+ *
+ * Kept out of `chat-store` deliberately: `hasApiKey` there answers "can I send a request",
+ * while residue is the opposite — a key the transport does not use and a storage-hygiene
+ * problem the user has to act on. Folding the two together would invite a future reader to
+ * gate requests on it.
+ *
+ * Deliberately not persisted. Residue is derived from storage and has to be re-derived every
+ * session; a stored copy would be a stale claim about a secret, and the store it would be
+ * written to is `localStorage` — by hypothesis the storage that is refusing to cooperate.
+ */
+interface KeyResidueState {
+	/** Per-provider clear-text residue. `null` also covers "not checked yet" and desktop. */
+	residue: Record<AiProvider, LegacyResidue>;
+	/** Re-read one provider's slot through the keychain adapter. Never throws. */
+	refreshResidue: (provider: AiProvider) => Promise<void>;
+	/** Re-read every provider. */
+	refreshAllResidue: () => Promise<void>;
+}
+
+export const useKeyResidueStore = create<KeyResidueState>((set, get) => ({
+	residue: { anthropic: null, openai: null },
+
+	refreshResidue: async (provider) => {
+		try {
+			const adapter = await getKeychainAdapter();
+			// `?.` rather than a runtime `in` check: `undefined` from the optional call means
+			// there is no such storage location on this platform, which — like a checked-and-empty
+			// slot — is nothing to warn about. See `LegacyResidue`.
+			const answer = (await adapter.readLegacyResidue?.(provider)) ?? null;
+			set((state) => ({ residue: { ...state.residue, [provider]: answer } }));
+		} catch {
+			// The previous value stands, for either failure. Neither "the bundle did not load"
+			// nor "the read threw" is evidence the slot is empty, and writing `null` here would
+			// retract a warning about a live credential on the strength of one. A module-load
+			// failure reaches the user through the settings panel's own adapter-load message,
+			// so nothing is swallowed silently.
+		}
+	},
+
+	refreshAllResidue: async () => {
+		// Each refresh already resolves rather than rejecting, so no settling wrapper is needed.
+		await Promise.all(RESIDUE_PROVIDERS.map((provider) => get().refreshResidue(provider)));
+	},
+}));


### PR DESCRIPTION
Closes #233.

## The bug

A key saved before ThreatForge encrypted keys lives in `localStorage`. On a browser that refuses
`removeItem`, `deleteKey` erased the encrypted record, failed to erase the clear-text copy, and
the panel then reported **"No API key configured"** — a readable credential sitting in storage
the app had just told the user was empty. The only mention of it was a one-shot message, gone by
the next action and never coming back.

## The shape of the fix

Residue is derived state, re-read from storage on every transition that can change it and never
persisted — a persisted copy is a stale claim about a secret, and the persistence target would be
the storage that is, by hypothesis, refusing writes.

- **`readLegacyResidue`** on the keychain adapter reports `retained` / `unverified` / `null` per
  provider. A pure read inside the provider lock: never writes, never returns key material.
  Absent on desktop, which is the distinct claim `undefined` makes against `null`.
- **`key-residue-store`** holds the reading. `refreshResidue` never rejects, and on a failed read
  leaves the previous value rather than claiming absence.
- **The settings panel** renders a notice for every provider holding residue, not only the
  selected one — the status bar escalates any provider's, so routing there had to lead somewhere
  that could act on it.
- **The status bar** carries a standing indicator for a `retained` slot, so a user who never
  opens AI settings still learns about it.
- **`keyStatus`** distinguishes "not checked yet", "checked and empty", and "the check itself
  failed". Reporting an unreadable vault as "no key configured" points the user at entering a
  key, the one action that cannot help.

## What review changed

Three rounds, four lanes, and the two most important changes were both **deletions**.

**A destructive retry was drafted and removed.** It decided from a render-time snapshot that the
handler never re-verified. The security lane reproduced the consequence end-to-end against the
real IndexedDB vault: the panel settles honestly at `hasKey=false, residue="retained"`, the user
saves a fresh key in a second tab, and clicking a control whose copy speaks only about the
clear-text slot irreversibly destroys the new encrypted key — behind a message that reads like
the ordinary warning. The PR reviewer found the same gate stale for ~26 ms on every mount,
unbounded behind a cross-tab IndexedDB `blocked` upgrade. Both lanes then proved the control
bought nothing: a retirement marker already stands in that state, so `hasKey` cannot re-import,
and `migrateLegacyKey` runs `removeLegacyKey` unconditionally anyway. Recheck-only measured
`hasKey=false residue=null slot=null` once the browser allowed removal.

**The launch read was inverted.** It originally ran `hasKey` for both providers at startup, which
opened the keychain IndexedDB database for every browser profile — including the majority that
never touch AI, where it previously appeared only on first AI use. It now probes the
`localStorage` slot first (pinned in both directions by asserting `indexedDB.databases()`) and
opens the vault only when there is something to migrate.

Two copy defects worth naming, because tests could not have caught either:

- The notice told users to **clear this site's browser data** without saying that also deletes
  every threat model saved in this browser. The plan named that cost when it rejected another
  option, then shipped the instruction without it.
- The status-bar detail said *"Open AI settings to remove it"*. The indicator only renders once
  the erase has already been attempted and refused, so the panel offers a retry that may fail
  again and the site-data remedy — not removal.

## Verification

`bash scripts/ci-local.sh --e2e` — all checks passed, Playwright `110 passed`. Full suite 2165+
tests. `tsc --noEmit` and Biome clean. No `any`, double casts, or non-null assertions in
production code.

Every security-relevant assertion was **mutation-tested**: the production line was reverted, the
test confirmed red with a meaningful message, then restored. That caught a test which seeded the
residue store with the value it later asserted — it passed with the behavior under test deleted,
and now fails.

The security lane ran a two-canary runtime probe across the launch path, status bar, panel, save,
recheck and delete. Neither canary appears in the DOM, any attribute, `sessionStorage`,
IndexedDB, or any store. It also confirmed `deleteKey`'s fail-closed `LEGACY_RETAINED` rejection
is structurally unchanged and that desktop is untouched.

## For owner validation

Things a reviewer could not verify, called out rather than buried:

- **Desktop divergence, deliberate:** a rejecting desktop `hasKey` now renders "Key storage could
  not be checked" instead of "No API key configured". An honest improvement, under failure only.
- **`ai-chat-tab.tsx` still renders "No API key configured"** while a readable clear-text copy
  exists. All three lanes judged this honest — it is a claim about the *transport*, and after the
  retirement marker the app genuinely cannot use that key. The always-mounted status-bar
  indicator covers that screen. The one edge it does not cover is `retained` with no vault record
  **and** no marker, which is #234-adjacent.
- **Adapter-load failure at launch** commits a reading that was not ordered behind a migration,
  so a transient chunk failure can show `retained` until the next panel mount clears it —
  self-healing, and it now logs a `console.warn`.
- **#233 moved an existing hazard earlier.** `migrateLegacyKey` erases the slot after a declined
  import even when the stored record is unreadable; running `hasKey` at launch means that now
  happens at app start rather than on first AI use. Impact is a re-issuable credential, not user
  data. Recorded on #234, where the fix belongs.

Follow-ups filed: #265 (same site-data copy defect in two other messages), #264 (the preflight
process bug this run exposed).