### PR TITLE
docs(process): isolate review lanes by working tree, not just context

### DIFF
--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -38,3 +38,20 @@ Report only high-confidence findings:
 
 For each finding include `path:line`, the failing behavior, evidence, and the smallest correct
 fix. State explicitly when no findings remain.
+
+## Tree hygiene
+
+You share a checkout with other review lanes, and one of them may be editing it.
+
+- Record `git rev-parse HEAD` and `git status --porcelain` before you touch anything, and open
+  your report with both.
+- Report every command result as observed under a stated tree state. If a build, suite or
+  linter result surprises you, re-read `git status --porcelain` before believing it — a result
+  produced while another lane was mid-edit arrives with a reproduction count, a line number and
+  a working fix, and is indistinguishable from a real one.
+- Restore every mutation you make, then **confirm** the restore by re-running
+  `git status --porcelain` and comparing it to what you recorded. Confirmed, not assumed.
+- Write scratch files outside every glob in `vitest.config.ts`'s `include`, and delete them
+  before reporting.
+
+Mutate freely to prove a test discriminates the behavior it claims to.

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -39,19 +39,24 @@ Report only high-confidence findings:
 For each finding include `path:line`, the failing behavior, evidence, and the smallest correct
 fix. State explicitly when no findings remain.
 
+Your invocation states whether you may write to the working tree. When it says `MUTATING`,
+you hold the tree alone: revert a line freely to prove a test discriminates the behavior it
+claims to. Otherwise you are read-only — other lanes are reading this checkout right now, and
+anything you write becomes their evidence.
+
 ## Tree hygiene
 
-You share a checkout with other review lanes, and one of them may be editing it.
+You share one checkout with the other review lanes.
 
-- Record `git rev-parse HEAD` and `git status --porcelain` before you touch anything, and open
-  your report with both.
+- Open your report with `git rev-parse HEAD`, `git status --porcelain`, and
+  `git diff HEAD | shasum`. Close it with the same three.
 - Report every command result as observed under a stated tree state. If a build, suite or
-  linter result surprises you, re-read `git status --porcelain` before believing it — a result
-  produced while another lane was mid-edit arrives with a reproduction count, a line number and
-  a working fix, and is indistinguishable from a real one.
-- Restore every mutation you make, then **confirm** the restore by re-running
-  `git status --porcelain` and comparing it to what you recorded. Confirmed, not assumed.
+  linter result surprises you, re-read that state before believing it — a result produced while
+  another lane was mid-edit arrives with a reproduction count, a line number and a working fix,
+  and is indistinguishable from a real one.
+- You are only ever cleared to mutate a tree that started clean at a known commit, so restoring
+  means all three readings match what you recorded. **Confirm** that they do. Do not assume the
+  revert took: `git status --porcelain` reports paths and status, not contents, and on its own
+  it cannot tell a restored file from a differently-broken one.
 - Write scratch files outside every glob in `vitest.config.ts`'s `include`, and delete them
   before reporting.
-
-Mutate freely to prove a test discriminates the behavior it claims to.

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -22,19 +22,24 @@ Report `CRITICAL`, `HIGH`, `MEDIUM`, or `LOW` findings with `path:line`, exploit
 confidence, and a specific remediation. Do not report theoretical noise without a plausible
 boundary or impact.
 
+Your invocation states whether you may write to the working tree. When it says `MUTATING`,
+you hold the tree alone: probe and mutate freely to establish that a boundary is really
+enforced. Otherwise you are read-only — other lanes are reading this checkout right now, and
+anything you write becomes their evidence.
+
 ## Tree hygiene
 
-You share a checkout with other review lanes, and one of them may be editing it.
+You share one checkout with the other review lanes.
 
-- Record `git rev-parse HEAD` and `git status --porcelain` before you touch anything, and open
-  your report with both.
+- Open your report with `git rev-parse HEAD`, `git status --porcelain`, and
+  `git diff HEAD | shasum`. Close it with the same three.
 - Report every command result as observed under a stated tree state. If a build, suite or
-  linter result surprises you, re-read `git status --porcelain` before believing it — a result
-  produced while another lane was mid-edit arrives with a reproduction count, a line number and
-  a working fix, and is indistinguishable from a real one.
-- Restore every mutation you make, then **confirm** the restore by re-running
-  `git status --porcelain` and comparing it to what you recorded. Confirmed, not assumed.
+  linter result surprises you, re-read that state before believing it — a result produced while
+  another lane was mid-edit arrives with a reproduction count, a line number and a working fix,
+  and is indistinguishable from a real one.
+- You are only ever cleared to mutate a tree that started clean at a known commit, so restoring
+  means all three readings match what you recorded. **Confirm** that they do. Do not assume the
+  revert took: `git status --porcelain` reports paths and status, not contents, and on its own
+  it cannot tell a restored file from a differently-broken one.
 - Write scratch files outside every glob in `vitest.config.ts`'s `include`, and delete them
   before reporting.
-
-Probe and mutate freely to establish that a boundary is really enforced.

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -21,3 +21,20 @@ Focus on:
 Report `CRITICAL`, `HIGH`, `MEDIUM`, or `LOW` findings with `path:line`, exploit scenario,
 confidence, and a specific remediation. Do not report theoretical noise without a plausible
 boundary or impact.
+
+## Tree hygiene
+
+You share a checkout with other review lanes, and one of them may be editing it.
+
+- Record `git rev-parse HEAD` and `git status --porcelain` before you touch anything, and open
+  your report with both.
+- Report every command result as observed under a stated tree state. If a build, suite or
+  linter result surprises you, re-read `git status --porcelain` before believing it — a result
+  produced while another lane was mid-edit arrives with a reproduction count, a line number and
+  a working fix, and is indistinguishable from a real one.
+- Restore every mutation you make, then **confirm** the restore by re-running
+  `git status --porcelain` and comparing it to what you recorded. Confirmed, not assumed.
+- Write scratch files outside every glob in `vitest.config.ts`'s `include`, and delete them
+  before reporting.
+
+Probe and mutate freely to establish that a boundary is really enforced.

--- a/.claude/agents/slop-auditor.md
+++ b/.claude/agents/slop-auditor.md
@@ -32,19 +32,24 @@ Output each finding as:
 Conclude `clean`, `minor`, or `needs-work`. Propose a new doctrine pattern only when supported
 by concrete evidence not already covered.
 
+Your invocation states whether you may write to the working tree. When it says `MUTATING`,
+you hold the tree alone: delete a line freely to prove an assertion would fail without the code
+under it. Otherwise you are read-only — other lanes are reading this checkout right now, and
+anything you write becomes their evidence.
+
 ## Tree hygiene
 
-You share a checkout with other review lanes, and one of them may be editing it.
+You share one checkout with the other review lanes.
 
-- Record `git rev-parse HEAD` and `git status --porcelain` before you touch anything, and open
-  your report with both.
+- Open your report with `git rev-parse HEAD`, `git status --porcelain`, and
+  `git diff HEAD | shasum`. Close it with the same three.
 - Report every command result as observed under a stated tree state. If a build, suite or
-  linter result surprises you, re-read `git status --porcelain` before believing it — a result
-  produced while another lane was mid-edit arrives with a reproduction count, a line number and
-  a working fix, and is indistinguishable from a real one.
-- Restore every mutation you make, then **confirm** the restore by re-running
-  `git status --porcelain` and comparing it to what you recorded. Confirmed, not assumed.
+  linter result surprises you, re-read that state before believing it — a result produced while
+  another lane was mid-edit arrives with a reproduction count, a line number and a working fix,
+  and is indistinguishable from a real one.
+- You are only ever cleared to mutate a tree that started clean at a known commit, so restoring
+  means all three readings match what you recorded. **Confirm** that they do. Do not assume the
+  revert took: `git status --porcelain` reports paths and status, not contents, and on its own
+  it cannot tell a restored file from a differently-broken one.
 - Write scratch files outside every glob in `vitest.config.ts`'s `include`, and delete them
   before reporting.
-
-Mutate freely to prove an assertion would fail without the code under it.

--- a/.claude/agents/slop-auditor.md
+++ b/.claude/agents/slop-auditor.md
@@ -31,3 +31,20 @@ Output each finding as:
 
 Conclude `clean`, `minor`, or `needs-work`. Propose a new doctrine pattern only when supported
 by concrete evidence not already covered.
+
+## Tree hygiene
+
+You share a checkout with other review lanes, and one of them may be editing it.
+
+- Record `git rev-parse HEAD` and `git status --porcelain` before you touch anything, and open
+  your report with both.
+- Report every command result as observed under a stated tree state. If a build, suite or
+  linter result surprises you, re-read `git status --porcelain` before believing it — a result
+  produced while another lane was mid-edit arrives with a reproduction count, a line number and
+  a working fix, and is indistinguishable from a real one.
+- Restore every mutation you make, then **confirm** the restore by re-running
+  `git status --porcelain` and comparing it to what you recorded. Confirmed, not assumed.
+- Write scratch files outside every glob in `vitest.config.ts`'s `include`, and delete them
+  before reporting.
+
+Mutate freely to prove an assertion would fail without the code under it.

--- a/.claude/agents/threat-model-expert.md
+++ b/.claude/agents/threat-model-expert.md
@@ -20,5 +20,6 @@ Use `docs/knowledge/file-format.md` and `docs/knowledge/glossary.md` as canonica
 Distinguish verified facts from assumptions. Preserve backward compatibility and require a
 migration path for breaking changes.
 
-Open your report with the commit you read, so a finding taken from a stale checkout is
-detectable. You have no shell, so the tree is whatever the orchestrator left there.
+You have no shell, so you cannot read the state of the tree you are reviewing and are not asked
+to attest it. The orchestrator gives you the commit; report it back, so a finding taken from a
+stale checkout is detectable.

--- a/.claude/agents/threat-model-expert.md
+++ b/.claude/agents/threat-model-expert.md
@@ -19,3 +19,6 @@ Review:
 Use `docs/knowledge/file-format.md` and `docs/knowledge/glossary.md` as canonical references.
 Distinguish verified facts from assumptions. Preserve backward compatibility and require a
 migration path for breaking changes.
+
+Open your report with the commit you read, so a finding taken from a stale checkout is
+detectable. You have no shell, so the tree is whatever the orchestrator left there.

--- a/.claude/skills/pr-preflight/SKILL.md
+++ b/.claude/skills/pr-preflight/SKILL.md
@@ -9,16 +9,43 @@ Run on a complete local diff or, after explicit PR-creation authorization, a dra
 moving its issue to `In progress`.
 
 1. Confirm issue linkage, acceptance criteria, required plan, and verification evidence.
-2. Run in independent contexts:
+2. Decide, per lane, whether it may mutate the working tree, and schedule on that decision:
+   - lanes you keep read-only run in parallel
+   - **a lane permitted to mutate runs alone** — nothing else runs while it holds the tree
+3. Run in independent contexts:
    - always: `pr-reviewer`
    - always: `slop-auditor`
    - conditional: `security-auditor` for security/trust-boundary lanes
    - conditional: `threat-model-expert` for `.thf`, STRIDE, or threat-quality lanes
-3. Keep reviewer ownership separate; do not collapse all checklists into one pass.
-4. Fix must-fix and should-fix findings or record the explicit owner decision.
-5. Re-run the same reviewer lanes after revisions until they converge.
-6. Re-run affected verification.
-7. Post or preserve a preflight record with each lane, findings, revisions, and final state.
+4. Keep reviewer ownership separate; do not collapse all checklists into one pass.
+5. Reject any lane report that does not attest its tree state, and re-run that lane.
+6. Fix must-fix and should-fix findings or record the explicit owner decision.
+7. Re-run the same reviewer lanes after revisions until they converge.
+8. Re-run affected verification.
+9. Post or preserve a preflight record with each lane, findings, revisions, and final state.
 
 Only then mark the issue `In progress`. Preflight is not owner validation and cannot approve or
 merge the PR.
+
+## Working-tree isolation
+
+Lanes share one checkout. A lane that reverts a line to prove a test catches it is doing the
+right thing, but a second lane running the suite in that window sees the first lane's breakage
+and reports it as a defect — with a line number, a mechanism and a fix, all fabricated. The
+inverse is worse: a half-applied mutation can make a suite look green to another lane, and a
+false clearance is not visibly wrong. This happened on #233; see the recognition log in
+`docs/quality/agentic-slop.md`.
+
+Serialization is the mechanism, because a `git worktree` per lane starts with no `node_modules`
+and nothing here runs `vitest` without one — an `npm ci` per lane per round, or a shared store
+that recouples the lanes. Build that only if lane wall-clock ever dominates.
+
+`pr-reviewer`, `slop-auditor` and `security-auditor` each carry a `## Tree hygiene` section
+stating what they owe you. The three are byte-identical on purpose, so drift between them is
+greppable. Enforcing it is your job, not theirs:
+
+- A report without an entry and exit tree state is not a result. Re-run the lane.
+- When a lane's exit state differs from its entry state, or its report contradicts the tree it
+  claims to have observed, restore the tree yourself and re-run it. Discard what it got from
+  running something; what it found by reading the diff still stands. Do not reconcile a
+  contradicted result by reasoning about which half was true.

--- a/.claude/skills/pr-preflight/SKILL.md
+++ b/.claude/skills/pr-preflight/SKILL.md
@@ -15,6 +15,9 @@ moving its issue to `In progress`.
    - **a lane you invoke `MUTATING` runs alone.** Nothing else runs while it holds the tree,
      including you, and it may only be dispatched against a clean tree at a known commit
    - a shell lane invoked without a stated mode is read-only
+   - **you are a writer too.** Do not start fixing an early report while another lane, or a
+     command it launched, is still reading. Wait for the cohort. An edit you make and revert
+     inside a lane's window is invisible to both of its snapshots and is exactly the #233 shape
 3. Run in independent contexts:
    - always: `pr-reviewer`
    - always: `slop-auditor`
@@ -54,8 +57,16 @@ purpose, so drift between them is greppable. Enforcing them is your job, not the
   what makes its restoration checkable: `git status --porcelain` reports paths and status, not
   contents, so it can only confirm a restore when the state it is confirming a return to is
   *empty*. On a tree that was already dirty it cannot tell a restored file from a differently
-  broken one — and restoring blind would destroy work that was never yours. Commit first.
+  broken one. Committing first is the way there, and committing needs authorization you may not
+  have — **when you cannot commit, every lane is read-only.** That costs mutation proofs for one
+  round. It costs nothing you can lose.
 - When a lane's exit state differs from its entry state, or its report contradicts the tree it
-  claims to have observed, reset to the known commit and re-run it. Discard what it got from
-  running something; what it found by reading the diff still stands. Do not reconcile a
-  contradicted result by reasoning about which half was true.
+  claims to have observed, discard what it got from running something; what it found by reading
+  the diff still stands. Do not reconcile a contradicted result by reasoning about which half
+  was true.
+- Recover only from a state you know how to recover from. A `MUTATING` lane entered on a clean
+  commit, so `git checkout -- . && git clean -fd` returns it there — including the untracked
+  scratch a bare reset would leave behind to fail the next lane's precondition. Confirm
+  `git status --porcelain` is empty before re-dispatching. A read-only lane that dirtied the
+  tree anyway is a different problem: it may have written over uncommitted work that was never
+  yours, so stop and look rather than resetting.

--- a/.claude/skills/pr-preflight/SKILL.md
+++ b/.claude/skills/pr-preflight/SKILL.md
@@ -9,16 +9,21 @@ Run on a complete local diff or, after explicit PR-creation authorization, a dra
 moving its issue to `In progress`.
 
 1. Confirm issue linkage, acceptance criteria, required plan, and verification evidence.
-2. Decide, per lane, whether it may mutate the working tree, and schedule on that decision:
-   - lanes you keep read-only run in parallel
-   - **a lane permitted to mutate runs alone** — nothing else runs while it holds the tree
+2. Decide, per lane, whether it may write to the working tree, and **state that mode in the
+   invocation** — a lane cannot infer it:
+   - lanes you invoke read-only run in parallel
+   - **a lane you invoke `MUTATING` runs alone.** Nothing else runs while it holds the tree,
+     including you, and it may only be dispatched against a clean tree at a known commit
+   - a shell lane invoked without a stated mode is read-only
 3. Run in independent contexts:
    - always: `pr-reviewer`
    - always: `slop-auditor`
    - conditional: `security-auditor` for security/trust-boundary lanes
    - conditional: `threat-model-expert` for `.thf`, STRIDE, or threat-quality lanes
 4. Keep reviewer ownership separate; do not collapse all checklists into one pass.
-5. Reject any lane report that does not attest its tree state, and re-run that lane.
+5. Reject any shell lane's report that does not attest its tree state, and re-run that lane.
+   `threat-model-expert` has no shell, so give it the commit yourself and expect that back —
+   a lane cannot attest a state it has no way to read.
 6. Fix must-fix and should-fix findings or record the explicit owner decision.
 7. Re-run the same reviewer lanes after revisions until they converge.
 8. Re-run affected verification.
@@ -41,11 +46,16 @@ and nothing here runs `vitest` without one — an `npm ci` per lane per round, o
 that recouples the lanes. Build that only if lane wall-clock ever dominates.
 
 `pr-reviewer`, `slop-auditor` and `security-auditor` each carry a `## Tree hygiene` section
-stating what they owe you. The three are byte-identical on purpose, so drift between them is
-greppable. Enforcing it is your job, not theirs:
+stating what they owe you. Those sections are byte-identical from the heading to end of file, on
+purpose, so drift between them is greppable. Enforcing them is your job, not theirs:
 
-- A report without an entry and exit tree state is not a result. Re-run the lane.
+- A shell lane's report without an entry and exit tree state is not a result. Re-run the lane.
+- Dispatch a `MUTATING` lane only against a clean tree at a known commit. That precondition is
+  what makes its restoration checkable: `git status --porcelain` reports paths and status, not
+  contents, so it can only confirm a restore when the state it is confirming a return to is
+  *empty*. On a tree that was already dirty it cannot tell a restored file from a differently
+  broken one — and restoring blind would destroy work that was never yours. Commit first.
 - When a lane's exit state differs from its entry state, or its report contradicts the tree it
-  claims to have observed, restore the tree yourself and re-run it. Discard what it got from
+  claims to have observed, reset to the known commit and re-run it. Discard what it got from
   running something; what it found by reading the diff still stands. Do not reconcile a
   contradicted result by reasoning about which half was true.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,8 +224,8 @@ Use fresh reviewer context for non-trivial changes. Do not manufacture findings.
 Lanes must be isolated in **working-tree state** as well as in context. Proving a test fails
 before trusting it is correct technique, so lanes do mutate the tree — and two lanes mutating
 one checkout produce findings about each other's edits that read exactly like real defects.
-**A lane permitted to mutate the tree runs alone; read-only lanes stay parallel.** Every lane
-report opens with the tree state it observed — the commit, plus `git status --porcelain` for
+**A lane permitted to mutate the tree runs alone, against a clean tree at a known commit;
+read-only lanes stay parallel.** Every lane report opens with the tree state it observed — the commit, plus `git status --porcelain` for
 the lanes that have a shell — so a result taken from a tree someone else was editing is
 detectable rather than persuasive.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,6 +221,14 @@ Keep review contexts independent and non-overlapping:
 Use fresh reviewer context for non-trivial changes. Do not manufacture findings. Report
 `must-fix`, `should-fix`, and `consider` separately.
 
+Lanes must be isolated in **working-tree state** as well as in context. Proving a test fails
+before trusting it is correct technique, so lanes do mutate the tree — and two lanes mutating
+one checkout produce findings about each other's edits that read exactly like real defects.
+**A lane permitted to mutate the tree runs alone; read-only lanes stay parallel.** Every lane
+report opens with the tree state it observed — the commit, plus `git status --porcelain` for
+the lanes that have a shell — so a result taken from a tree someone else was editing is
+detectable rather than persuasive.
+
 ## Anti-slop guardrails
 
 Functionality is sacred. Never remove behavior, validation, edge handling, accessibility,

--- a/docs/plans/264-preflight-lane-isolation.md
+++ b/docs/plans/264-preflight-lane-isolation.md
@@ -1,0 +1,97 @@
+# 264 — Preflight review lanes share one working tree
+
+## The failure this fixes
+
+Round-two preflight on #233 ran `pr-reviewer`, `slop-auditor` and `security-auditor`
+concurrently against a single checkout, with two of them instructed to mutate it. The
+`slop-auditor` ran the test suite during the `pr-reviewer`'s revert-and-observe cycle, saw the
+reviewer's deliberate breakage, and reported it as a flaky-suite `must-fix` — with a
+reproduction count, a line number, a plausible mechanism and a verified fix. All fabricated.
+The full account is on #264.
+
+Acting on it would have meant editing a healthy suite to chase a defect that never existed. The
+inverse is worse: a mutating lane can make a suite look **green** to a concurrent lane, and a
+"all tests pass" report on someone else's half-applied mutation is a false clearance.
+
+## Root cause
+
+`.claude/skills/pr-preflight/SKILL.md` says to run the lanes "in independent contexts" and means
+*conversational* context — which worked, the lanes did converge independently on a real defect.
+It says nothing about the **working tree**, which they share. Separately, `pr-reviewer` and
+`security-auditor` are told to prove a test fails before trusting it, which is correct technique
+and requires mutation. The skill instructs mutation and parallelism without reconciling them.
+
+## Decision: serialize mutating lanes, keep read-only lanes parallel
+
+The issue offered three options. Choosing (2), with (1) rejected on measured cost:
+
+- **(1) A worktree per mutating lane** preserves parallelism and removes interference entirely,
+  but a `git worktree` starts with no `node_modules`, and nothing here runs `vitest` without one.
+  That means a per-lane `npm ci` each round, or a shared store that couples the lanes back
+  together on the one axis the worktree was meant to separate. Neither has been built or
+  measured, and writing down a mechanism whose cost I have not paid is the speculative doctrine
+  the anti-slop rules forbid. Recorded as an option with its cost named, not mandated.
+- **(3) Hoisting mutation into a phase after convergence** loses the property that the lane which
+  found a defect is the one that proves it. Round three of #233 yielded exactly one class of
+  finding — correct code that no test pins — and every one of them was established by the finding
+  lane reverting a line and watching the suite stay green. That coupling is worth keeping.
+- **(2) Serializing mutating lanes** costs wall-clock time and nothing else. It is what round
+  three actually did, and round three produced no fabricated findings.
+
+Read-only lanes keep running in parallel, because the interference is caused by writes, not by
+concurrency.
+
+## The rules, and where each one lives
+
+`AGENTS.md` already owns a "Review lanes" section describing context independence. Tree
+isolation is the same idea applied to a different resource, so it belongs there rather than in a
+new document. The operational procedure belongs in the preflight skill. The four lane
+definitions carry only what must hold when the lane is invoked *outside* preflight.
+
+| Rule | Home |
+|------|------|
+| Lanes are isolated in tree state as well as context; mutating lanes serialize | `AGENTS.md` § Review lanes |
+| Declare mutation up front; the orchestrator serializes on that declaration | `.claude/skills/pr-preflight/SKILL.md` |
+| Attest the observed tree state in every report | each lane + skill |
+| Restore and **confirm** restoration before reporting | each lane + skill |
+| Scratch files must not land where a test runner collects them | each lane + skill |
+| The fabricated-finding failure as a recognition pattern | `docs/quality/agentic-slop.md` |
+
+## Acceptance criteria mapping
+
+- [ ] Skill states the isolation model and what a lane may do to the tree — `SKILL.md`
+- [ ] Mechanism written down, not implied — serialization is named, with the declaration that
+      drives it and the worktree alternative and its cost
+- [ ] Every report states the tree state observed — `HEAD` sha plus `git status --porcelain`,
+      required by the skill and by each lane with `Bash`
+- [ ] Restoration confirmed, not attempted — `git status --porcelain` compared against the
+      state recorded at entry, with the comparison in the report
+- [ ] Scratch files kept outside every glob in `vitest.config.ts`'s `include` — the issue named
+      only `src/**/*.test.{ts,tsx}`, but `worker/` and `scripts/` are collected too, so the rule
+      points at the config rather than restating a list that will drift
+- [ ] Recognition pattern added to `docs/quality/agentic-slop.md`
+
+## Scope boundary
+
+`threat-model-expert` has no `Bash` tool, so it cannot mutate and cannot run a suite. It gets no
+tree-hygiene rules; adding them would be defense against an impossible state. It does get the
+attestation line, because its report still cites file contents and needs to say which commit.
+
+This is a process change. There is no product behavior to test; verification is that the
+documents say what they claim, the referenced globs and paths resolve, and the markdown gate
+passes.
+
+## Change log
+
+- 2026-07-27 — written after #233 preflight; option (1) rejected on the `node_modules` cost
+  above rather than on preference.
+- 2026-07-27 — self-review corrected five things in the first draft, all of them the same
+  species the issue is about. The skill told the orchestrator to *ask* each lane whether it
+  would mutate, which is not something you can do before launching one; it now decides and
+  schedules. "Every lane report states `git status --porcelain`" was false for
+  `threat-model-expert`, which has no shell. A rule discarding a whole report over a leftover
+  scratch file would have thrown away real findings; only results obtained by *running*
+  something are discarded now. The scratch-file rule named one `vitest` include glob when there
+  are three, so it points at the config instead of restating it. And the three lane blocks were
+  three prose variations of the same rules — now byte-identical, with one lane-specific line
+  each, so drift is greppable. The skill no longer restates them at all.

--- a/docs/plans/264-preflight-lane-isolation.md
+++ b/docs/plans/264-preflight-lane-isolation.md
@@ -23,18 +23,22 @@ and requires mutation. The skill instructs mutation and parallelism without reco
 
 ## Decision: serialize mutating lanes, keep read-only lanes parallel
 
-The issue offered three options. Choosing (2), with (1) rejected on measured cost:
+The issue offered three options. Choosing (2):
 
 - **(1) A worktree per mutating lane** preserves parallelism and removes interference entirely,
   but a `git worktree` starts with no `node_modules`, and nothing here runs `vitest` without one.
   That means a per-lane `npm ci` each round, or a shared store that couples the lanes back
-  together on the one axis the worktree was meant to separate. Neither has been built or
-  measured, and writing down a mechanism whose cost I have not paid is the speculative doctrine
-  the anti-slop rules forbid. Recorded as an option with its cost named, not mandated.
-- **(3) Hoisting mutation into a phase after convergence** loses the property that the lane which
-  found a defect is the one that proves it. Round three of #233 yielded exactly one class of
-  finding — correct code that no test pins — and every one of them was established by the finding
-  lane reverting a line and watching the suite stay green. That coupling is worth keeping.
+  together on the one axis the worktree was meant to separate. The dependency-setup cost is
+  certain; its size is not, because neither variant has been built or timed here. Recorded as an
+  option with its cost named rather than mandated on a number I have not measured.
+- **(3) Hoisting mutation into a phase after convergence** separates the lane that finds a defect
+  from the act of proving it. Not necessarily into different lanes — the same lane can be
+  relaunched for the mutation phase — but into different contexts, which means re-establishing
+  why the line mattered, or carrying a lane's context across a phase boundary for the whole
+  round. Round three of #233 yielded exactly one class of finding, correct code that no test
+  pins, and every one was established by the finding lane reverting a line and watching the
+  suite stay green, in the same breath as noticing it. That immediacy is cheap to keep and
+  awkward to reconstruct.
 - **(2) Serializing mutating lanes** costs wall-clock time and nothing else. It is what round
   three actually did, and round three produced no fabricated findings.
 
@@ -95,3 +99,20 @@ passes.
   are three, so it points at the config instead of restating it. And the three lane blocks were
   three prose variations of the same rules — now byte-identical, with one lane-specific line
   each, so drift is greppable. The skill no longer restates them at all.
+- 2026-07-27 — preflight ran two read-only lanes in parallel under the new rules; both attested
+  the same clean tree at `2813aaf`. They converged on two defects and the reviewer found two
+  more, all four of which were the change failing its own standard. The plan said option (1) was
+  "rejected on measured cost" and then said nothing had been measured. The skill rejected any
+  report without a tree attestation while `threat-model-expert`, which has no shell, was told to
+  produce one — an infinite reject-and-rerun loop for every `.thf` review. The lane files said
+  "mutate freely" unconditionally, so a lane the orchestrator considered read-only had nothing
+  telling it so, which is the #233 path still open; mutation is now gated on a `MUTATING` mode
+  stated in the invocation, and an unstated mode means read-only. And `git status --porcelain`
+  cannot confirm a *restore*: it reports paths and status, not contents, so a lane that put back
+  the wrong bytes on an already-dirty tree exits looking identical to one that put back the right
+  ones. Rather than fingerprinting contents, a mutating lane now requires a clean tree at a known
+  commit — which makes the confirmation sound by construction and removes the earlier instruction
+  to "restore the tree yourself", which could have destroyed uncommitted work that was never the
+  lane's. The claim that the three hygiene blocks were byte-identical was also false as written:
+  each ended with a different lane-specific sentence. That sentence moved above the heading, so
+  the sections now really are identical to end of file, and the claim is checkable.

--- a/docs/plans/264-preflight-lane-isolation.md
+++ b/docs/plans/264-preflight-lane-isolation.md
@@ -100,8 +100,8 @@ passes.
   three prose variations of the same rules — now byte-identical, with one lane-specific line
   each, so drift is greppable. The skill no longer restates them at all.
 - 2026-07-27 — preflight ran two read-only lanes in parallel under the new rules; both attested
-  the same clean tree at `2813aaf`. They converged on two defects and the reviewer found two
-  more, all four of which were the change failing its own standard. The plan said option (1) was
+  the same clean tree at `2813aaf`. Five defects between them — two both lanes found, three only
+  the reviewer did — and every one was the change failing its own standard. The plan said option (1) was
   "rejected on measured cost" and then said nothing had been measured. The skill rejected any
   report without a tree attestation while `threat-model-expert`, which has no shell, was told to
   produce one — an infinite reject-and-rerun loop for every `.thf` review. The lane files said
@@ -116,3 +116,19 @@ passes.
   lane's. The claim that the three hygiene blocks were byte-identical was also false as written:
   each ended with a different lane-specific sentence. That sentence moved above the heading, so
   the sections now really are identical to end of file, and the claim is checkable.
+- 2026-07-27 — round two, both lanes read-only and parallel, both attesting `db141be` clean with
+  the same empty-diff hash. Two findings, both real, both about the fix rather than the problem.
+  The rule serialized *lanes* and forgot that **the orchestrator is a writer too**: nothing
+  stopped it starting on an early report while another lane was still reading, and an edit made
+  and reverted inside a lane's window is invisible to both of that lane's snapshots. That is the
+  #233 shape with the roles swapped, and it was still wide open. Second, recovery said "reset to
+  the known commit", which leaves untracked scratch behind to fail the next lane's clean-tree
+  precondition, and applied to read-only lanes too — where the tree may hold uncommitted work
+  that was never the lane's, and resetting destroys it. Recovery is now scoped to the case whose
+  entry state is known, and a read-only lane that dirtied the tree is something to stop and look
+  at rather than reset. The clean-tree precondition also implied "commit first", which needs an
+  authorization preflight may not hold: when it cannot commit, every lane is read-only. That
+  buys the isolation without the authority. Two smaller corrections: the recognition-log entry
+  still said "every lane" must report `git status --porcelain` after the no-shell exemption had
+  been written everywhere else, and this log undercounted round one as four defects when it was
+  five.

--- a/docs/quality/agentic-slop.md
+++ b/docs/quality/agentic-slop.md
@@ -40,6 +40,8 @@ slop when they protect a real invariant. A review that manufactures findings is 
 - Assertions are weakened, timing is inflated, or failures are skipped to make CI green.
 - Large snapshots are updated without inspecting the behavioral difference.
 - E2E failures lose screenshots, traces, console errors, or reproducible fixture state.
+- A test result is reported without stating which tree state produced it, so a red or green
+  observed during someone else's edit is indistinguishable from a real one.
 
 ### Documentation and operations
 
@@ -103,3 +105,22 @@ host and no Cloudflare project existed.
 
 **Fix:** treat source, deployed service, custom domains, DNS, headers, analytics, privacy text,
 verification, and rollback as one migration contract.
+
+### 2026-07-27 — A concurrent review lane fabricated a finding out of another lane's mutation
+
+**Tell:** a `must-fix` arrived with everything a true finding has — a reproduction count, a named
+line, a plausible mechanism, and a verified minimal fix — and none of it existed. Three review
+lanes ran in parallel against one checkout; one had reverted a production fix to prove a test
+caught it, and another ran the suite in that window and diagnosed the breakage as a flaky test.
+The reported failure was byte-identical to the mutation the first lane said it had applied. A
+quiet tree was green 8 runs out of 8.
+
+The general shape: **a finding is only as trustworthy as the tree state it was observed on, and
+a report that omits that state cannot be checked.** The dangerous direction is not the false red
+— that one gets caught by re-running. It is the false **green**, where a half-applied mutation
+makes a suite pass for a lane that then clears the change.
+
+**Fix:** serialize any lane that mutates the working tree, keep read-only lanes parallel, and
+require every lane to open its report with the commit and `git status --porcelain` it observed
+and to confirm — not assume — that it restored what it changed. See #264 and
+`.claude/skills/pr-preflight/SKILL.md`.

--- a/docs/quality/agentic-slop.md
+++ b/docs/quality/agentic-slop.md
@@ -121,6 +121,6 @@ a report that omits that state cannot be checked.** The dangerous direction is n
 makes a suite pass for a lane that then clears the change.
 
 **Fix:** serialize any lane that mutates the working tree, keep read-only lanes parallel, and
-require every lane to open its report with the commit and `git status --porcelain` it observed
-and to confirm — not assume — that it restored what it changed. See #264 and
-`.claude/skills/pr-preflight/SKILL.md`.
+require every lane that has a shell to open its report with the tree state it observed and to
+confirm — not assume — that it restored what it changed. A lane with no shell cannot read that
+state and is given its commit instead. See #264 and `.claude/skills/pr-preflight/SKILL.md`.


### PR DESCRIPTION
Closes #264.

## The failure

Preflight on #233 ran three review lanes in parallel against one working tree and told two of
them to mutate it — revert a production fix, confirm the test goes red, restore. The
`slop-auditor` ran the suite inside the `pr-reviewer`'s mutation window, saw the deliberate
breakage, and reported it as a `must-fix`: a flaky panel suite, 4 runs in 5, with a named line, a
genuinely plausible mechanism and a verified minimal fix.

None of it existed. The reported failure string was byte-identical to the mutation the reviewer
said it had applied. A quiet tree was green 8 runs out of 8.

The false finding was more convincing than a true one, and acting on it would have meant editing
a healthy suite — with a change that would have masked real races later. The inverse is worse: a
half-applied mutation can make a suite look **green** to a concurrent lane, and a false clearance
does not look wrong.

## Root cause

`.claude/skills/pr-preflight/SKILL.md` said to run lanes "in independent contexts" and meant
*conversational* context. That part worked — the lanes converged independently on a real defect
in the same round. It said nothing about the working tree they share, while separately telling
lanes to prove a test fails before trusting it. The skill instructed mutation and parallelism and
never reconciled them.

## The fix

- **A lane permitted to mutate runs alone**, against a clean tree at a known commit. Read-only
  lanes stay parallel, because the hazard is writes, not concurrency.
- **Mutation is gated on a `MUTATING` mode stated in the invocation.** A shell lane invoked
  without a stated mode is read-only. A lane cannot infer what the orchestrator decided.
- **The orchestrator is a writer too** and may not start on an early report while another lane,
  or a command it launched, is still reading.
- **Every shell lane attests** `git rev-parse HEAD`, `git status --porcelain` and
  `git diff HEAD | shasum` on entry and exit. `threat-model-expert` has no shell, cannot read
  that state, and is exempt — it is given its commit and reports it back.
- **Recovery is scoped to states we know how to recover from.** A `MUTATING` lane entered clean,
  so `git checkout -- . && git clean -fd` returns it there, scratch included, confirmed by an
  empty status. A read-only lane that dirtied the tree may have written over uncommitted work
  that was never its own — that is something to stop and look at, not reset.
- **When preflight cannot commit, every lane is read-only.** The clean-tree precondition implies
  committing first, and committing needs authorization preflight may not hold.

A worktree per lane would have kept the parallelism and is recorded with its cost — it starts
with no `node_modules` and nothing here runs `vitest` without one — rather than mandated on a
number I have not measured.

## Verification

Three preflight rounds under the new rules, both lanes read-only and parallel, each attesting
entry and exit state.

| Round | Commit | `pr-reviewer` | `slop-auditor` |
|-------|--------|---------------|----------------|
| 1 | `2813aaf` | 3 must-fix, 2 should-fix | `needs-work` — 1 must-fix, 1 should-fix |
| 2 | `db141be` | 2 must-fix, 2 should-fix | `minor` — 1 should-fix |
| 3 | `4ba771f` | 1 must-fix (pre-existing, filed as #268) | **`clean`** |

Every round-one and round-two finding was **this change failing its own standard**, which is the
strongest evidence I have that the lanes were working:

- the plan called the worktree option "rejected on measured cost" two paragraphs before saying
  nothing had been measured
- the skill rejected any report without a tree attestation while `threat-model-expert`, which has
  no shell, was told to produce one — an infinite reject-and-rerun loop on every `.thf` review
- the lane files said "mutate freely" unconditionally, so a lane the orchestrator was treating as
  read-only had nothing telling it so. That is the #233 path, still open
- `git status --porcelain` reports paths and status, not contents, so it cannot confirm a
  *restore* on an already-dirty tree — a lane that put back the wrong bytes exits looking exactly
  like one that put back the right ones
- the claim that the three hygiene blocks were byte-identical was false as written; each ended
  with a different lane-specific sentence
- serialization covered lanes and forgot the orchestrator
- "reset to the known commit" left untracked scratch behind to fail the next lane's precondition,
  and applied to read-only lanes where it would destroy work that was never theirs

The three `## Tree hygiene` sections now hash identically from heading to EOF
(`fa5ed27f39f98dbcb90ea36e9b170d4f9547d2ee`), verified independently by both lanes, which is what
makes the drift claim checkable rather than aspirational.

`npm run ci:local` green. Both round-three lanes reported the same `HEAD`, the same empty status
and the same empty-diff hash — the attestation mechanism demonstrating itself.

## What a reviewer cannot verify from the diff

That this actually prevents recurrence. The rules govern agent behavior, and the only real proof
is the next several preflight runs not producing a contradicted finding. The three rounds here
are encouraging but they are also the rules reviewing themselves.

## Raised, not fixed here

`pr-reviewer` round three found one `must-fix` that **predates this branch**: `AGENTS.md`
contradicts itself on when an issue moves to `In progress`, and `pr-preflight` and `pr-cycle`
still carry the transition that belonged to the deleted `In review` state. Real, and worth
fixing — filed as #268 rather than folded in, since that is board lifecycle and this is
working-tree isolation, and they share only a file.

Two further recognition patterns from #233 are filed as #267.

## Milestone

`M2 • Beta`.