### PR TITLE
docs(process): one place says when an issue moves to In progress

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -12,15 +12,16 @@ argument-hint: "[issue-number]"
    - XS/S: execute the issue body
    - M/L: require `docs/plans/<issue>-<slug>.md`
    - XL: stop and decompose
-4. If an M/L plan is absent or stale, invoke `issue-planner` and stop after the plan is written.
+4. Move the issue to `In progress` before doing anything else, including planning. A claim you
+   have not recorded is not a claim, and planning is work another agent can duplicate.
+5. If an M/L plan is absent or stale, invoke `issue-planner` and stop after the plan is written.
    Planning and execution must happen in separate passes, and implementation begins only after the
    plan is committed.
-5. Move active work to `In progress`, then invoke `feature-implementer` with the settled issue or
-   committed plan.
-6. Add out-of-scope discoveries as linked follow-up work rather than expanding silently.
-7. Invoke `anti-slop-review`, then `build-test`.
-8. Invoke `pr-preflight` and resolve its must-fix and should-fix findings to convergence.
-9. Prepare a handoff with changed behavior, evidence, remaining owner validation, and applicable
-   specialist lanes. Stop at verification-complete `In progress`.
+6. Invoke `feature-implementer` with the settled issue or committed plan.
+7. Add out-of-scope discoveries as linked follow-up work rather than expanding silently.
+8. Invoke `anti-slop-review`, then `build-test`.
+9. Invoke `pr-preflight` and resolve its must-fix and should-fix findings to convergence.
+10. Prepare a handoff with changed behavior, evidence, remaining owner validation, and applicable
+    specialist lanes. Stop at verification-complete `In progress`.
 
 Do not commit, push, create a PR, or merge without separate explicit authorization.

--- a/.claude/skills/pr-cycle/SKILL.md
+++ b/.claude/skills/pr-cycle/SKILL.md
@@ -15,7 +15,7 @@ class: commit, push, PR creation, approval, merge, or release.
 4. If authorized, create a Conventional Commit linked to the issue.
 5. If authorized, push and create/update a draft PR with the repository template.
 6. Wait for required CI; repair failures without bypassing checks.
-7. Move to `In progress` when verification and preflight are complete.
+7. Confirm the issue is still `In progress`, and repair it if an earlier step was skipped.
 8. Present owner validation steps and unresolved decisions.
 9. Only an authorized owner may approve and squash-merge after validation.
 10. Confirm Project 2 reaches `Done`; repair metadata drift if automation misses it.

--- a/.claude/skills/pr-preflight/SKILL.md
+++ b/.claude/skills/pr-preflight/SKILL.md
@@ -5,8 +5,8 @@ description: Run convergent independent review lanes before ThreatForge owner va
 
 # PR preflight
 
-Run on a complete local diff or, after explicit PR-creation authorization, a draft PR before
-moving its issue to `In progress`.
+Run on a complete local diff or, after explicit PR-creation authorization, a draft PR. The issue
+has been `In progress` since it was claimed, and preflight does not move it.
 
 1. Confirm issue linkage, acceptance criteria, required plan, and verification evidence.
 2. Decide, per lane, whether it may write to the working tree, and **state that mode in the
@@ -32,8 +32,7 @@ moving its issue to `In progress`.
 8. Re-run affected verification.
 9. Post or preserve a preflight record with each lane, findings, revisions, and final state.
 
-Only then mark the issue `In progress`. Preflight is not owner validation and cannot approve or
-merge the PR.
+Preflight changes no board state. It is not owner validation and cannot approve or merge the PR.
 
 ## Working-tree isolation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,8 +136,10 @@ may pull an `M3` item forward into `M2` at any time; agents may not.
 - **Validation:** owner judgment that the change solves the right problem and avoids
   plausible-but-wrong behavior.
 
-Green CI never means `Done`. `In progress` means verification is complete and only owner
-validation and merge remain.
+Green CI never means `Done`. `In progress` covers the whole of implementation and the whole PR
+cycle, so the status never signals that verification is finished — the handoff record does that.
+Verification-complete work waits in `In progress` for owner validation. There is no state
+between them.
 
 ## Authorization boundaries
 
@@ -192,16 +194,21 @@ budget, not a free resource. A saturated machine is an outage for the owner.
 ## Engineering workflow
 
 1. **Triage:** shape the issue and populate Project 2 metadata. Do not code.
-2. **Plan:** for M/L work, an independent planner writes the committed plan. XL work is
+2. **Claim:** move the issue to `In progress` before doing anything else. Parallel agents rely
+   on the board to avoid starting the same work twice, and a claim you have not recorded is not
+   a claim. It stays there until merge.
+3. **Plan:** for M/L work, an independent planner writes the committed plan. XL work is
    decomposed first.
-3. **Implement:** execute settled criteria without silently rescoping. Add tests with the
+4. **Implement:** execute settled criteria without silently rescoping. Add tests with the
    behavior.
-4. **Self-review:** run `anti-slop-review` and fix behavior-preserving findings.
-5. **Preflight:** run the general PR reviewer and independent slop auditor, plus security
+5. **Self-review:** run `anti-slop-review` and fix behavior-preserving findings.
+6. **Preflight:** run the general PR reviewer and independent slop auditor, plus security
    and threat-model specialists when their lanes apply. Repeat the same lanes until
    must-fix and should-fix findings are resolved.
-6. **Handoff:** move the issue to `In progress` only after verification and preflight.
-7. **Validate and merge:** an owner performs intent validation and the final merge.
+7. **Handoff:** record the changed behavior, the verification evidence, and the owner
+   validation still outstanding. No status changes — the issue has been `In progress` since
+   step 2.
+8. **Validate and merge:** an owner performs intent validation and the final merge.
 
 Newly discovered work becomes a linked issue or sub-issue. Do not expand scope silently.
 Replans append a dated change log rather than rewriting history.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,8 +77,9 @@ Verification is deterministic evidence that the written contract was implemented
 lint, tests, builds, security checks, and artifacts. Validation is an owner decision that the
 change solves the right problem and avoids plausible-but-wrong outcomes.
 
-Green CI does not mean a change is done. Move work to `In progress` only after verification and
-agent preflight; owners perform final validation and merge.
+Green CI does not mean a change is done. Work moves to `In progress` when you claim it, before
+you start, and stays there through verification and preflight; owners perform final validation
+and merge.
 
 ### Branch Naming
 

--- a/docs/runbooks/adding-a-feature.md
+++ b/docs/runbooks/adding-a-feature.md
@@ -22,7 +22,11 @@ Use the size as a capability contract:
 - M/L: run the issue planner and commit `docs/plans/<issue>-<slug>.md` before code.
 - XL: keep it as a parent initiative and decompose it into sub-issues.
 
-## 2. Create a Branch
+## 2. Claim It and Create a Branch
+
+Move the project item to `In progress` first. Another agent may be scanning the board for
+work right now, and the status field is the only thing that stops two of you starting the
+same issue.
 
 ```bash
 git checkout main
@@ -31,7 +35,6 @@ git checkout -b feat/short-description
 ```
 
 Use Conventional Commits prefixes: `feat/`, `fix/`, `refactor/`, `chore/`, or `docs/`.
-Move the project item to `In progress`.
 
 ## 3. Understand Existing Code
 
@@ -93,7 +96,8 @@ Fix must-fix and should-fix findings and rerun the same lanes until they converg
 - Link the M/L plan or state `N/A — XS/S`.
 - Separate verification evidence from owner validation steps.
 - Include before/after screenshots for UI changes.
-- Move the project item to `In progress`.
+- Leave the project item where it is. It went to `In progress` back in *Claim It and Create a
+  Branch* and stays there until merge.
 
 Only `Shreyasdbz` and `exitzerolabs-admin` may merge or update `main`.
 Commit, push, PR creation, approval, and merge each require explicit authorization. Owners

--- a/docs/runbooks/configuring-release-signing.md
+++ b/docs/runbooks/configuring-release-signing.md
@@ -552,7 +552,8 @@ When the rehearsal passes:
 - Attach or link the retained evidence to issues #49, #50, #51, and #52.
 - Confirm the PR reviewer, slop auditor, and security auditor have no unresolved must-fix or
   should-fix findings.
-- Move each completed child issue to `In progress`.
+- Confirm each child issue is still `In progress`; they reach `Done` only after the owner
+  validates and the PR merges.
 - Have an owner validate intended publisher presentation, install behavior, and update
   behavior.
 - Squash-merge only after owner validation and separate merge authorization.

--- a/docs/runbooks/responding-to-issues.md
+++ b/docs/runbooks/responding-to-issues.md
@@ -69,16 +69,18 @@ For a red CI check rather than a reported bug, start from
 [Diagnosing CI Failures](diagnosing-ci-failures.md) — it distinguishes a runner
 infrastructure fault from a real break.
 
-1. **Reproduce** the bug locally
-2. **Create a branch**: `git checkout -b fix/issue-description`
-3. **Write a failing test** that captures the bug
-4. **Fix the bug** — minimal change, don't refactor surrounding code
-5. **Verify the test passes**
-6. **Run anti-slop review and preflight**
-7. **Run full verification**: `npm run ci:local`
-8. **Open a PR** referencing the issue: `Fixes #42`
-9. **Stay `In progress`** through review — there is no `In review` state
-10. **Close the issue** when PR is merged (GitHub auto-closes with `Fixes #N`)
+1. **Claim it**: move the issue to `In progress` before starting, so a parallel agent does not
+   pick up the same bug
+2. **Reproduce** the bug locally
+3. **Create a branch**: `git checkout -b fix/issue-description`
+4. **Write a failing test** that captures the bug
+5. **Fix the bug** — minimal change, don't refactor surrounding code
+6. **Verify the test passes**
+7. **Run anti-slop review and preflight**
+8. **Run full verification**: `npm run ci:local`
+9. **Open a PR** referencing the issue: `Fixes #42`
+10. **Stay `In progress`** through review — there is no `In review` state
+11. **Close the issue** when PR is merged (GitHub auto-closes with `Fixes #N`)
 
 ## Security Issues
 


### PR DESCRIPTION
Closes #268.

`AGENTS.md`'s status table says an issue moves to `In progress` when you claim it, before work starts, because parallel agents read the board to avoid picking up the same issue. Seven documents said otherwise — three lines of `AGENTS.md` itself among them.

Six of those seven are the deleted `In review` handoff with the destination renamed to the state the work is already in. When doctrine v1 collapsed to four states, the transitions pointing at `In review` were left behind pointing at `In progress`, and each file stayed individually coherent, so nothing caught the drift.

The failure this causes is narrow but expensive. An agent following the stale wording leaves the issue unclaimed until verification is complete — precisely the window where a collision costs most: two agents, two branches, one issue, both nearly done.

Two more documents are a different shape. `implement-issue` claimed after planning, and planning is exactly the work a second agent can duplicate. The bug runbook never claimed at all. So did the workflow list in `AGENTS.md`, whose only mention of claiming lived inside the step that had it wrong; it gains a Claim step at position 2.

`AGENTS.md` also *defined* `In progress` as "verification is complete and only owner validation and merge remain" — the old `In review` definition wearing the new name. That is now the handoff record's job, not the state's.

## Changed

| File | Change |
|------|--------|
| `AGENTS.md` | `In progress` no longer defined as verification-complete; workflow gains **Claim** at step 2, renumbered to 8; step 7 Handoff no longer moves status |
| `CONTRIBUTING.md` | Verification/validation section no longer instructs a post-preflight move |
| `.claude/skills/implement-issue/SKILL.md` | Claim moved **before** planning; renumbered to 10 |
| `.claude/skills/pr-preflight/SKILL.md` | Preflight changes no board state |
| `.claude/skills/pr-cycle/SKILL.md` | Step 7 confirms and repairs rather than moves |
| `docs/runbooks/adding-a-feature.md` | §2 renamed *Claim It and Create a Branch*; claim moved above the git commands |
| `docs/runbooks/configuring-release-signing.md` | Child issues are confirmed still `In progress`, not moved there |
| `docs/runbooks/responding-to-issues.md` | Gained a Claim step; renumbered to 11 |

## Verification

- `npm run ci:local` green.
- Repository-wide sweep for remaining late-transition instructions, excluding `docs/archive/`, run independently by me and by both review lanes. Nothing left.
- `.e0l/first-principles/planning.md` verified correct and unchanged — the drift is local to this repo, so no upstream amendment is owed.

## Preflight

Three rounds, `pr-reviewer` and `slop-auditor`, read-only and parallel under the working-tree isolation rules that #264 just landed. Converged clean.

Both lanes independently found the same eighth site, `CONTRIBUTING.md`, that neither the issue nor I had found — the sweep, not the fix, was the weak part of this change. Round 2's findings were both about the commit message rather than the diff: the reviewer caught a miscount, and the slop auditor caught a fabricated provenance claim by checking the actual commit dates (`4d21b2f` 2026-07-25 vs `facf172` 2026-07-26) and showing `implement-issue` was written *after* the migration, so it inherited the delay rather than being stranded by it. Both were corrected.

## Owner validation

Nothing here changes product behavior; the risk is that a rule reads correct and still leaves an agent ambiguous about when to claim. The thing to check is `AGENTS.md` § Engineering workflow and `implement-issue` — whether the claim now sits early enough to actually prevent a collision, and whether step 7's handoff still reads as a real action now that it no longer moves anything.

One residue is deliberately **not** fixed here: nine files still route planning decisions on the deleted `Size` field, including `implement-issue` step 3, three lines above an edit in this PR. That needs the effort contract re-derived rather than a rename, so it is #270. Both lanes were asked to judge the split and both agreed with it.