### PR TITLE
docs(process): route planning on Effort, not the deleted Size field

### DIFF
--- a/.claude/agents/feature-implementer.md
+++ b/.claude/agents/feature-implementer.md
@@ -6,10 +6,11 @@ tools: Read, Glob, Grep, Bash, Edit, Write
 
 # Feature implementer
 
-Implement an XS/S issue specification or a committed M/L plan.
+Implement a `Low` issue specification, or a committed plan for `Medium` or `High` work.
 
 - Read `AGENTS.md`, the issue, plan if required, and all path-matched instructions.
-- Do not plan M/L work, execute XL work, or silently broaden acceptance criteria.
+- Do not plan `Medium` or `High` work, implement a `High` parent instead of its sub-issues, or
+  silently broaden acceptance criteria.
 - Work from a failing or discriminating test when behavior changes.
 - Reuse existing contracts and helpers before adding abstractions.
 - Validate Rust/IPC boundaries and preserve `.thf` compatibility.

--- a/.claude/agents/issue-planner.md
+++ b/.claude/agents/issue-planner.md
@@ -1,22 +1,25 @@
 ---
 name: issue-planner
-description: Plans M/L ThreatForge issues without implementing them
+description: Plans Medium and High ThreatForge issues without implementing them
 tools: Read, Glob, Grep, Bash, Edit, Write
 ---
 
 # Issue planner
 
-Plan settled M/L issues into executable, reviewable steps. Do not implement production code,
-commit, push, or mutate GitHub metadata.
+Plan settled `Medium` and `High` issues into executable, reviewable steps. Do not implement
+production code, commit, push, or mutate GitHub metadata.
 
 1. Read `AGENTS.md`, the issue, parent initiative, dependencies, linked PRs, Project 2
    metadata, relevant source, tests, and knowledge docs.
-2. Reject `Backlog`, ambiguous, blocked, or XL work. XL initiatives must be decomposed.
+2. Reject `Backlog`, ambiguous, or blocked work. A `Low` issue needs no plan; say so and stop
+   rather than writing one.
 3. Resolve assumptions from repository evidence. Record remaining human blockers instead of
    guessing.
 4. Write only `docs/plans/<issue>-<slug>.md` using `docs/plans/0000-template.md`.
-5. Break work into XS/S-equivalent steps with exact surfaces, behavior, targeted verification,
-   intent validation, security/file-format implications, and dependencies.
+5. Break work into steps that are each `Low` on their own — exact surfaces, behavior, targeted
+   verification, intent validation, security/file-format implications, and dependencies. For a
+   `High` issue those steps are the decomposition: name the sub-issues to file and what each
+   one owns.
 6. Keep out-of-scope ideas separate. Append future replans; never erase prior decisions.
 
 The plan is complete only when a separate implementer can execute it without rediscovery.

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -13,4 +13,4 @@ Follow `../implement-issue/SKILL.md` with bug-specific emphasis:
 - fix the root cause with the smallest complete change
 - avoid unrelated refactoring
 
-The same size, plan, anti-slop, verification, and authorization boundaries apply.
+The same effort, plan, anti-slop, verification, and authorization boundaries apply.

--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -7,21 +7,32 @@ argument-hint: "[issue-number]"
 # Implement issue
 
 1. Read `AGENTS.md`, the issue, parent, dependencies, linked PRs, and live Project 2 metadata.
-2. Require a selected `Ready` issue or an explicit user override. Never select a sprint or batch.
-3. Enforce the size contract:
-   - XS/S: execute the issue body
-   - M/L: require `docs/plans/<issue>-<slug>.md`
-   - XL: stop and decompose
+2. Require a selected `Ready` issue, an `In progress` issue you are continuing, or an explicit
+   user override. Never select a sprint or batch.
+3. Establish what the effort contract requires before anything can be implemented:
+   - `Low`: nothing; the issue body is the specification
+   - `Medium`: a committed `docs/plans/<issue>-<slug>.md`
+   - `High`: that plan, and the sub-issues it decomposes into — those are what get implemented,
+     never the parent
+
+   Treat anything touching cryptography, the IPC boundary, the `.thf` schema, or a trust
+   boundary as `High` whatever the field says, and say so rather than proceeding quietly.
 4. Move the issue to `In progress` before doing anything else, including planning. A claim you
    have not recorded is not a claim, and planning is work another agent can duplicate.
-5. If an M/L plan is absent or stale, invoke `issue-planner` and stop after the plan is written.
-   Planning and execution must happen in separate passes, and implementation begins only after the
-   plan is committed.
-6. Invoke `feature-implementer` with the settled issue or committed plan.
-7. Add out-of-scope discoveries as linked follow-up work rather than expanding silently.
-8. Invoke `anti-slop-review`, then `build-test`.
-9. Invoke `pr-preflight` and resolve its must-fix and should-fix findings to convergence.
-10. Prepare a handoff with changed behavior, evidence, remaining owner validation, and applicable
+5. If a required plan is absent or stale, invoke `issue-planner`, then stop. Planning and
+   execution happen in separate passes, so this run ends when the plan is committed; a later run
+   picks the issue up from `In progress`.
+6. For a `High` issue with a committed plan, reconcile the sub-issues that plan names against
+   what is already linked to the parent: shape any that exist but are not executable, file the
+   rest shaped and linked, then stop. Every child must be selectable on its own, or a later run
+   will reject it. The planner writes them down and cannot file them; if you do not, nobody
+   does.
+7. Invoke `feature-implementer` with the settled issue or committed plan. A `High` parent never
+   reaches this step; its sub-issues do.
+8. Add out-of-scope discoveries as linked follow-up work rather than expanding silently.
+9. Invoke `anti-slop-review`, then `build-test`.
+10. Invoke `pr-preflight` and resolve its must-fix and should-fix findings to convergence.
+11. Prepare a handoff with changed behavior, evidence, remaining owner validation, and applicable
     specialist lanes. Stop at verification-complete `In progress`.
 
 Do not commit, push, create a PR, or merge without separate explicit authorization.

--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "[issue-number]"
 
 # Issue triage
 
-Triage one issue. Do not plan M/L work or edit production code.
+Triage one issue. Do not plan `Medium` or `High` work, and do not edit production code.
 
 1. Read `AGENTS.md`, the full issue/comments, related issues/PRs, roadmap context, and relevant
    repository evidence.
@@ -22,7 +22,9 @@ Triage one issue. Do not plan M/L work or edit production code.
    - relevant domain labels
    - `Priority`: `Urgent`/`High`/`Medium`/`Low`, answering how soon *within* the milestone.
      `Urgent` and `High` require a comment naming what specifically goes wrong if this waits.
-   - `Effort`: High/Medium/Low, with the matching `model/opus|sonnet|haiku` label
+   - `Effort`: the reasoning class the work needs, not how long it takes — `High`/`Medium`/`Low`
+     with the matching `model/opus|sonnet|haiku` label. It is a floor: cryptography, the IPC
+     boundary, the `.thf` schema, and trust boundaries are `High` however small the diff looks.
    - exactly one autonomy label: `AUTO` or `HITL`
    - parent, dependencies, and acceptance criteria
    - `Ready` only when executable; otherwise `Backlog`

--- a/.claude/skills/issues-clarify/SKILL.md
+++ b/.claude/skills/issues-clarify/SKILL.md
@@ -11,9 +11,13 @@ Run as an explicit maintainer-requested board maintenance pass.
 2. Discover Project 2 fields/options dynamically.
 3. Review every non-Done issue against current code, merged work, open PRs, parent initiatives,
    dependencies, and roadmap direction.
-4. Identify obsolete, duplicate, compound, blocked, mis-sized, or incorrectly prioritized work.
+4. Identify obsolete, duplicate, compound, blocked, or wrongly prioritized work, and work whose
+   `Effort` no longer matches the reasoning it actually needs. Raise an understated `Effort`
+   before acting on the issue: cryptography, the IPC boundary, the `.thf` schema, and trust
+   boundaries are `High` however small the diff looks.
 5. Preserve `Backlog` for genuinely unshaped reports.
-6. Split compound executable work into native sub-issues; XL remains a parent.
+6. Split compound executable work into native sub-issues; a `High` issue stays the parent of the
+   sub-issues it decomposes into.
 7. Ensure exactly one autonomy label and explicit acceptance/dependency state.
 8. Mutate one item at a time, read it back, and leave a concise reason for material changes.
 9. Report the snapshot, changes, unresolved decisions, and remaining drift.

--- a/.claude/skills/issues-report/SKILL.md
+++ b/.claude/skills/issues-report/SKILL.md
@@ -19,4 +19,5 @@ Produce a read-only, reproducible briefing. Do not mutate GitHub or repository f
 6. Use asymmetric depth: more detail for high-impact or ambiguous items, less for settled work.
 7. Save any long artifact outside the repository or in a gitignored session artifact directory.
 
-Never infer readiness from labels alone; confirm criteria, dependencies, size, and plan state.
+Never infer readiness from labels alone; confirm criteria, dependencies, `Effort`, and plan
+state.

--- a/.github/ISSUE_TEMPLATE/roadmap-initiative.yml
+++ b/.github/ISSUE_TEMPLATE/roadmap-initiative.yml
@@ -64,7 +64,7 @@ body:
     id: decomposition
     attributes:
       label: Proposed Decomposition
-      description: List independently verifiable sub-outcomes. Initiatives are XL parents and are not implemented directly.
+      description: List independently verifiable sub-outcomes. An initiative is a `High` parent — it is decomposed into sub-issues and those are what get implemented.
 
   - type: textarea
     id: verification

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 
 - Closes #
 - Parent initiative:
-- Plan: <!-- docs/plans/<issue>-<slug>.md or N/A — XS/S -->
+- Plan: <!-- docs/plans/<issue>-<slug>.md or N/A — Effort: Low -->
 
 ## Acceptance Criteria
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,8 +197,8 @@ budget, not a free resource. A saturated machine is an outage for the owner.
 2. **Claim:** move the issue to `In progress` before doing anything else. Parallel agents rely
    on the board to avoid starting the same work twice, and a claim you have not recorded is not
    a claim. It stays there until merge.
-3. **Plan:** for M/L work, an independent planner writes the committed plan. XL work is
-   decomposed first.
+3. **Plan:** for `Medium` and `High` work, an independent planner writes the committed plan.
+   `High` work is decomposed into executable sub-issues, and those are what get implemented.
 4. **Implement:** execute settled criteria without silently rescoping. Add tests with the
    behavior.
 5. **Self-review:** run `anti-slop-review` and fix behavior-preserving findings.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,7 @@ Examples:
    [docs/runbooks/running-agent-e2e-scenarios.md](docs/runbooks/running-agent-e2e-scenarios.md)
    (`npm run test:e2e:agent -- <scenario>`) and inspect its evidence before handoff.
 4. Run the author anti-slop pass and independent PR preflight.
-5. Link the issue with `Closes #N` and the M/L plan when required.
+5. Link the issue with `Closes #N`, and the plan when one is required.
 6. Include before/after screenshots or traces for visible UI changes.
 7. List owner validation steps separately from automated verification.
 

--- a/docs/knowledge/documentation-architecture.md
+++ b/docs/knowledge/documentation-architecture.md
@@ -215,7 +215,7 @@ Existing transitional exceptions are named below. This is the anti-duplication r
 
 | Fact class | Single canonical source | Owner |
 |------------|-------------------------|-------|
-| Live task status, priority, size, ownership, dependencies | GitHub Project 2 (never in docs) | Maintainers |
+| Live task status, priority, effort, ownership, dependencies | GitHub Project 2 (never in docs) | Maintainers |
 | Product direction and sequencing | `docs/plans/roadmap.md` | Maintainers |
 | Architecture contract | `docs/knowledge/architecture.md` | Maintainers |
 | `.thf` schema and format contract | `docs/knowledge/file-format.md` | Maintainers |

--- a/docs/plans/0000-template.md
+++ b/docs/plans/0000-template.md
@@ -22,7 +22,7 @@ docs instead of copying mutable specifications.
 
 ## Implementation steps
 
-Each step should be independently executable and no larger than XS/S.
+Each step should be independently executable and `Low` on its own.
 
 ### 1. Step title
 

--- a/docs/plans/270-effort-contract.md
+++ b/docs/plans/270-effort-contract.md
@@ -1,0 +1,158 @@
+# Issue 270 — Route planning on `Effort`, not the deleted `Size` field
+
+## Objective
+
+Every governance file that decides *plan or don't plan* and *decompose or don't* routes on
+`Effort`, the field the board actually has, using the contract `AGENTS.md` defines. No file
+routes on `XS`, `S`, `M`, `L`, or `XL`.
+
+## Issue contract
+
+- **Issue:** `#270`
+- **Parent initiative:** `N/A`
+- **Type:** `Bug`
+- **Effort:** `Medium`
+- **Priority:** `High`
+- **Autonomy:** `AUTO`
+- **Dependencies:** `#268` (the sibling residue, merged as `7b1fd64`)
+- **Non-goals:** changing what `Effort` means, changing any issue's `Effort` value, editing
+  `.e0l/`, rewriting historical narration about the migration itself, or rewriting committed
+  plans for closed issues
+
+## Behavior before this change
+
+`AGENTS.md:106` records the migration: `Effort` replaced `Size` in doctrine v1, and the
+`size/XS`–`size/XL` labels were deleted across 92 issues in the #243 sweep. The field and the
+labels are gone. The vocabulary is not.
+
+Sixteen files still route on it. `implement-issue` step 3 was titled *Enforce the size
+contract* and branched on `XS/S`, `M/L`, `XL`. `issue-planner` rejected `XL` work.
+`feature-implementer` refused to execute `XL`. Two runbooks told a triager to set a `Size`
+field that no longer exists on the board. The pull request template asked contributors to
+write `N/A — XS/S`.
+
+The observable cost is not tidiness. An agent reading `implement-issue` must invent a mapping
+before it can act, and the mapping it will invent is the duration reading — the exact
+misconception `Effort` was introduced to replace. That produces skipped plans on work that
+needed one, and `High` security work executed as though it were small.
+
+## What a committed plan is, and why most of them keep the old words
+
+A sweep turns up `Size` vocabulary in roughly twenty committed plans under `docs/plans/`. Almost
+all of it stays.
+
+A plan for a **closed** issue is a record of what was decided and what the board said at the
+time. `- **Size:** `M`` in `docs/plans/111-ci-reliability.md` is not an instruction to anyone;
+it is what that field held on that date. Rewriting it would make the record assert something
+that was never true, and the repository forbids rewriting plan history for exactly that reason.
+Seventeen of the nineteen plans carrying the vocabulary are for closed issues.
+
+A plan for an **open** issue is a live instruction, and its granularity sentence tells an
+implementer how finely to cut the work. `#58` is the only open issue whose plan states that in
+`Size` terms, so it is translated and the translation is recorded in that plan's replan log
+rather than applied silently.
+
+`#64` is open and is described as `XL` inside two plans — but both of those plans belong to
+closed issues (`#62`, `#203`) and are describing `#64` as it stood then. Its own `Effort` lives
+on the board, which is where that fact belongs.
+
+## Implementation record
+
+This plan was written while the change was underway rather than before it, so what follows is a
+record of the three pieces of work and the judgment behind each, not a forecast of them. The
+replan log says when and why.
+
+### 1. Re-derive the three-tier contract from `AGENTS.md`
+
+- **Behavior:** the routing files state `Low` / `Medium` / `High` as `AGENTS.md:92-110`
+  defines them, including that `High` implies decomposition.
+- **Files:** `.claude/skills/{implement-issue,issue-triage,issues-clarify,issues-report,fix-issue}/SKILL.md`,
+  `.claude/agents/{issue-planner,feature-implementer}.md`, `AGENTS.md`, `CONTRIBUTING.md`,
+  `.github/PULL_REQUEST_TEMPLATE.md`, `.github/ISSUE_TEMPLATE/roadmap-initiative.yml`,
+  `docs/runbooks/{adding-a-feature,responding-to-issues}.md`,
+  `docs/knowledge/documentation-architecture.md`, `docs/plans/{README,roadmap,0000-template}.md`,
+  and `docs/plans/58-panel-information-architecture.md` — the one open issue whose plan states
+  step granularity in `Size` terms, translated with a replan-log row in that plan
+- **Implementation:** translate each decision point by re-deriving it, not by substitution.
+  See *The mapping is not one-to-one* below.
+- **Targeted verification:** a repository sweep for `XS`, `S`, `M`, `L`, `XL`, `M/L` and bare
+  `Size`-field vocabulary returns only historical narration.
+- **Intent validation:** an agent can execute each routing decision without inventing a mapping.
+
+### 2. Carry the floor rule to the files that decide
+
+- **Behavior:** the "floor, not a ceiling" override reaches the surfaces where `Effort` is
+  assigned and where it is acted on.
+- **Files:** `.claude/skills/{issue-triage,issues-clarify,implement-issue}/SKILL.md`,
+  `docs/runbooks/{adding-a-feature,responding-to-issues}.md`
+- **Implementation:** state that cryptography, the IPC boundary, the `.thf` schema, and trust
+  boundaries are `High` however small the diff looks.
+- **Targeted verification:** each of the five files names the rule.
+- **Intent validation:** a triager assigning `Effort` and an implementer acting on it both see
+  the override without having to remember `AGENTS.md`.
+
+### 3. Give `High` sub-issue creation an owner
+
+- **Behavior:** exactly one step files the sub-issues a `High` plan names.
+- **Files:** `.claude/skills/implement-issue/SKILL.md`, `.claude/agents/issue-planner.md`
+- **Implementation:** the planner names the sub-issues in the plan and does not file them — it
+  is forbidden from mutating GitHub. `implement-issue` files them and stops.
+- **Targeted verification:** no step requires sub-issues that no step creates.
+- **Intent validation:** a `High` issue does not stall after planning with nobody owning the
+  next move.
+
+## The mapping is not one-to-one
+
+This is the judgment the change turns on, and it is why substitution would have been wrong.
+
+- `XS/S` → `Low`. Close enough; the issue body stays the executable specification.
+- `M/L` → `Medium` mostly holds, but the meaning shifted. `Size` said how big; `Effort` says
+  what reasoning the work needs. A large mechanical change is `Low`.
+- `XL` → **nothing.** Decomposition is not a fourth tier, it is part of what `High` already
+  means. So every "reject `XL`" and "never execute `XL` directly" became a statement about
+  `High` needing both a plan and sub-issues, rather than a renamed rejection.
+
+## Cross-cutting requirements
+
+- **Security and privacy:** the floor rule is the security-relevant part. Understating `Effort`
+  on cryptography, IPC, `.thf`, or a trust boundary routes that work to a weaker reasoning tier
+  and skips the plan gate.
+- **No runtime surface:** the change is documentation only, so `.thf` compatibility, browser and
+  desktop parity, AI safety, and accessibility are untouched.
+- **Observability and evidence:** the sweep pattern is recorded here because `git grep -E` does
+  not support `\b`, which produced a false clean result during this work. Use POSIX character
+  classes: `(^|[^[:alnum:]_])(XS|XL|M/L|XS/S)([^[:alnum:]_]|$)`.
+
+## Verification gate
+
+```bash
+npm run ci:local
+```
+
+## Owner validation
+
+Deterministic checks cannot decide any of this. What to read:
+
+- Is `XL` → `High`-with-decomposition the right call, or should an undecomposed parent still be
+  a distinct thing the board can express?
+- Does `implement-issue` step 6 put sub-issue creation in the right place, or does filing
+  issues belong to triage rather than to the implementation orchestrator?
+- Is repeating the floor rule in five files the right trade against it drifting out of sync?
+
+## Specialist review
+
+- [x] PR reviewer
+- [x] Slop auditor
+- [ ] Security auditor — not applicable; no code, boundary, or dependency surface changes
+- [ ] Threat-model expert — not applicable; no schema, STRIDE, or threat-quality surface
+
+## Replan log
+
+Append changes; do not rewrite prior decisions.
+
+| Date | Change | Evidence and reason |
+|------|--------|---------------------|
+| 2026-07-27 | Initial plan, written after implementation began | `#270` is `Effort: Medium`, so a committed plan was required before code and there was none. The change read as vocabulary substitution until the `XL`-has-no-successor problem surfaced mid-edit, by which point it was underway; the PR reviewer raised the omission as a must-fix. The plan is committed because the mapping judgment above should be reviewable in one place. The sequencing guarantee it was meant to provide is lost for this issue and cannot be reconstructed. |
+| 2026-07-27 | Scope grew from the eight files the issue named to sixteen routing surfaces | The issue's table names eight files; its title says nine and does not enumerate the ninth. My own sweep found thirteen. Both preflight lanes then found three more my exclusions had hidden — I had excluded `docs/plans/` wholesale as historical and searched only `*.md`, which concealed `.github/ISSUE_TEMPLATE/roadmap-initiative.yml`, `docs/plans/0000-template.md` and `docs/plans/README.md` — and the reviewer added `docs/plans/roadmap.md` and the open `#58` plan. Sixteen files route a decision. Two more, `docs/plans/roadmap.md` and `docs/knowledge/documentation-architecture.md`, only name the field in prose and were corrected alongside. With this plan the diff touches nineteen. Recorded because the exclusion, not the pattern, was the defect both times. |
+| 2026-07-27 | `implement-issue`'s `High` path made resumable and idempotent | The second review round found the loop I had just written could not complete: planning left the parent `In progress` while step 2 admitted only `Ready`, step 3 demanded sub-issues that step 6 had not yet created, and step 6 would refile ones already linked. Step 2 now admits a continuation, step 3 states prerequisites rather than checking them, step 6 skips already-linked sub-issues, and step 7 says outright that a `High` parent never reaches it. |
+| 2026-07-27 | Step 6 restored the requirement that children be executable | The third review round found that adding the already-linked skip had silently dropped "each shaped and linked" from the previous wording, so an existing placeholder child would be skipped rather than shaped and a later run would reject it at step 2. Step 6 now reconciles: shape what exists, file what is missing, and every child must be selectable on its own. |

--- a/docs/plans/58-panel-information-architecture.md
+++ b/docs/plans/58-panel-information-architecture.md
@@ -449,7 +449,7 @@ panel element rather than a viewport media query.
 
 ## Implementation steps
 
-Each step is independently executable, no larger than XS/S, and leaves the tree green.
+Each step is independently executable, `Low` on its own, and leaves the tree green.
 
 ### 1. Add the palette catalog and icon seam
 
@@ -1033,3 +1033,4 @@ Append changes; do not rewrite prior decisions.
 |------|--------|---------------------|
 | 2026-07-21 | Initial plan | Issue `#58`, parent `#47`, sibling issues `#54`/`#56`/`#59`/`#60`, and repository evidence at `7b2e025`: `src/components/palette/component-palette.tsx`, `src/components/panels/{right-panel,properties-tab,threats-tab,ai-chat-tab}.tsx`, `src/components/layout/{app-layout,top-menu-bar}.tsx`, `src/components/canvas/{dfd-canvas,canvas-context-menu}.tsx`, `src/components/canvas/nodes/dfd-element-node.tsx`, `src/lib/{component-library,service-icons,command-registry,thf-validation,thf-yaml}.ts`, `src/lib/ai/schemas/actions.ts`, `src/stores/{ui-store,model-store-factory,canvas-store-factory,document-registry,document-stores,workspace-store,settings-store}.ts`, `src/lib/persistence/types.ts`, `src/types/threat-model.ts`, `src/hooks/use-keyboard-shortcuts.ts`, `e2e/*`, `package.json`, `vitest.config.ts`. Catalog counts (45 components, 9 categories, 16 subtypes) and the absence of any virtualization dependency, any ARIA attribute in the four affected files, and any merged `isThreatAnalysisEnabled` helper were measured directly rather than assumed. |
 | 2026-07-24 | `#59` registry seam supersedes the initial adapter plan | `#59` deletes `src/lib/component-library.ts` and `src/lib/service-icons.ts`; the typed component/icon source of truth is now `src/lib/registry/registry.ts`, and `IconRenderer` owns rendering. The assumptions in *Two icon sources exist today*, *Assumed `#59` interface*, and the `#59` row of *Concurrent work seams* are historical and must not be implemented. `#58` must consume the registry query API directly, must not restore the deleted modules, and should add a palette adapter only if its panel-specific row model proves a real second abstraction is needed. Recalculate catalog counts and revise the affected implementation steps before promoting `#58` to Ready. |
+| 2026-07-27 | Step granularity restated in `Effort` vocabulary | The `Size` field this plan was written against was replaced by `Effort` in the doctrine v1 migration and its labels deleted in the #243 sweep, so *Implementation steps* now says each step is `Low` on its own rather than "no larger than XS/S". Granularity is unchanged; only the vocabulary an implementer can look up has. No decision in this plan is superseded (`#270`). |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,7 +1,7 @@
 # Planning
 
 The [Threat Forge GitHub Project](https://github.com/orgs/exit-zero-labs/projects/2) is
-the sole source of truth for work status, priority, size, ownership, and dependencies.
+the sole source of truth for work status, priority, effort, ownership, and dependencies.
 
 - [Roadmap](./roadmap.md) — stable product direction and phase gates
 - [GitHub Issues](https://github.com/exit-zero-labs/threat-forge/issues) — requirements
@@ -9,7 +9,7 @@ the sole source of truth for work status, priority, size, ownership, and depende
 - [GitHub Project](https://github.com/orgs/exit-zero-labs/projects/2) — live execution
   status
 - [`0000-template.md`](./0000-template.md) — committed implementation plan contract for
-  M/L issues
+  `Medium` and `High` issues
 
 Historical execution records are isolated under [`docs/archive/plans`](../archive/plans/).
 They are read-only and are not active planning inputs.

--- a/docs/plans/roadmap.md
+++ b/docs/plans/roadmap.md
@@ -1,7 +1,7 @@
 # ThreatForge Roadmap
 
 This document defines product direction, sequencing, and completion gates. Live status,
-priority, sizing, and ownership belong in the
+priority, effort, and ownership belong in the
 [Threat Forge GitHub Project](https://github.com/orgs/exit-zero-labs/projects/2).
 
 ## Product Direction

--- a/docs/runbooks/adding-a-feature.md
+++ b/docs/runbooks/adding-a-feature.md
@@ -7,7 +7,7 @@ Use this workflow for non-trivial ThreatForge features.
 1. Find or create the GitHub issue.
 2. Add it to the
    [Threat Forge project](https://github.com/orgs/exit-zero-labs/projects/2).
-3. Set `Status`, `Priority`, and `Size`.
+3. Set `Status`, `Priority`, and `Effort`.
 4. Link the parent initiative and any blocking issues.
 5. Write measurable acceptance criteria in the issue.
 6. Apply exactly one autonomy label:
@@ -16,11 +16,15 @@ Use this workflow for non-trivial ThreatForge features.
 
 GitHub is the only execution tracker. Do not create a second backlog in Markdown.
 
-Use the size as a capability contract:
+`Effort` is the reasoning class the work needs, not how long it takes, and it decides what you
+have to do before writing code:
 
-- XS/S: the issue body is executable.
-- M/L: run the issue planner and commit `docs/plans/<issue>-<slug>.md` before code.
-- XL: keep it as a parent initiative and decompose it into sub-issues.
+- `Low`: the issue body is executable.
+- `Medium`: run the issue planner and commit `docs/plans/<issue>-<slug>.md` before code.
+- `High`: the same plan, plus a decomposition into sub-issues that get implemented in its place.
+
+It is a floor. Cryptography, the IPC boundary, the `.thf` schema, and trust boundaries are
+`High` however small the diff looks.
 
 ## 2. Claim It and Create a Branch
 
@@ -50,12 +54,13 @@ Read the relevant knowledge docs and source before editing.
 | Rust models | `src-tauri/src/models/` |
 | Tauri config | `src-tauri/tauri.conf.json` |
 
-## 4. Plan M/L Work
+## 4. Plan Medium and High Work
 
 Use the `issue-planner` agent and `docs/plans/0000-template.md`. The planner may write only
 the plan. Implementation happens in a separate context after the plan is reviewable.
 
-Skip this step for settled XS/S issues. Never execute an XL issue directly.
+A `Low` issue skips this step; its body is the specification. A `High` issue needs the plan
+*and* the sub-issues that plan decomposes it into, and the sub-issues are what you implement.
 
 ## 5. Implement and Test
 
@@ -93,7 +98,7 @@ Fix must-fix and should-fix findings and rerun the same lanes until they converg
 ## 8. Open the Pull Request
 
 - Link it with `Closes #N`.
-- Link the M/L plan or state `N/A — XS/S`.
+- Link the plan, or state `N/A — Effort: Low`.
 - Separate verification evidence from owner validation steps.
 - Include before/after screenshots for UI changes.
 - Leave the project item where it is. It went to `In progress` back in *Claim It and Create a

--- a/docs/runbooks/responding-to-issues.md
+++ b/docs/runbooks/responding-to-issues.md
@@ -32,7 +32,7 @@ When a new issue arrives:
 | `browser` | Browser workspace, persistence, or web-only behavior |
 | `e2e` | End-to-end, visual, or agent-driven quality coverage |
 
-After labeling, add the issue to Project 2 and set `Status`, `Priority`, and `Size`.
+After labeling, add the issue to Project 2 and set `Status`, `Priority`, and `Effort`.
 
 Apply exactly one autonomy label:
 
@@ -49,9 +49,12 @@ Final owner validation does not make an issue `HITL`.
 - Use `Backlog` for triaged work that is not executable or selected.
 - Move to `Ready` only when acceptance criteria, dependencies, ownership, and autonomy are
   settled.
-- XS/S issues carry their executable specification in the issue.
-- M/L issues require a committed plan before implementation.
-- XL issues are parents and must be decomposed.
+- A `Low` issue carries its executable specification in the issue body.
+- A `Medium` issue requires a committed plan before implementation.
+- A `High` issue requires the plan and the sub-issues it decomposes into; the sub-issues are
+  what get implemented.
+- Effort is a floor, not a ceiling. Cryptography, the IPC boundary, the `.thf` schema, and
+  trust boundaries are `High` however small the diff looks.
 - Persist a concise triage rationale for material field decisions.
 
 Use the `issue-triage` skill for one issue and `issues-clarify` for an explicit whole-board


### PR DESCRIPTION
Closes #270.

`Size` was replaced by `Effort` in the doctrine v1 migration, and the `size/XS`–`size/XL` labels were deleted across 92 issues in the #243 sweep. Sixteen files kept routing real decisions on the dead vocabulary — plan or don't plan, decompose or don't — keyed on a field the board does not have.

`implement-issue` was the sharp one. Step 3 was titled *Enforce the size contract* and branched on `XS/S`, `M/L`, `XL`, so an agent had to invent a mapping before it could act. The mapping it would invent is the duration reading, which is what `Effort` exists to replace: skipped plans on work that needed one, and `High` security work executed as though it were small.

## The mapping is not one-to-one

This is why substitution would have been wrong, and it is the judgment the change turns on.

- `XS/S` → `Low`. Close enough; the issue body stays the executable specification.
- `M/L` → `Medium` mostly holds, but the meaning shifted. `Size` said how big. `Effort` says what reasoning the work needs, so a large mechanical change is `Low`.
- `XL` → **nothing.** Decomposition is not a fourth tier; it is part of what `High` already means. Every "reject `XL`" and "never execute `XL` directly" became a statement about `High` needing both a plan and sub-issues.

That last one opened a hole the reviewer caught: the planner produces the decomposition but is forbidden from mutating GitHub, and `issues-clarify` only runs during an explicit board pass — so a `High` issue would stop after planning with nobody able to file the sub-issues. `implement-issue` now reconciles them and stops, and a `High` parent never reaches the implementer.

The **floor rule** now reaches both the files that act on `Effort` and the two that assign it. It lived in `AGENTS.md` and in no routing surface, so cryptography, the IPC boundary, the `.thf` schema and trust boundaries could be triaged as small work by anyone following a runbook.

## Changed

Sixteen files route a decision. Two more — `docs/plans/roadmap.md` and `docs/knowledge/documentation-architecture.md` — only name the field in prose and were corrected alongside. With the plan, the diff touches nineteen.

Committed plans for **closed** issues keep the old words. `- **Size:** M` in a plan for a merged issue is not an instruction; it is what the board held on that date, and rewriting it would make the record assert something that was never true. Seventeen of the nineteen vocabulary-carrying plans are closed. `#58` is the one open issue whose plan states step granularity in `Size` terms, so it is translated with the translation recorded in its replan log rather than applied silently.

## Verification

- `npm run ci:local` green.
- Repository sweep returns only historical narration (`AGENTS.md:106-109`, `docs/deviations.md:33`, closed-issue plans). **`git grep -E` does not support `\b`** — it silently returns a false clean on a file containing `` `XL` ``. Use POSIX classes: `(^|[^[:alnum:]_])(XS|XL|M/L|XS/S)([^[:alnum:]_]|$)`.
- `.e0l/` carries no `Size` vocabulary, so nothing is owed upstream.

## Preflight

Four rounds, `pr-reviewer` and `slop-auditor`, read-only and parallel under #264's isolation rules. Converged with no findings against the diff.

The pattern was never the defect — the **exclusions** were, twice. I searched only `*.md` and excluded `docs/plans/` wholesale as historical, which hid the roadmap initiative template, the plan template itself, and the planning index. Both lanes found them independently. The reviewer added `docs/plans/roadmap.md` and the open `#58` plan.

Round 2's must-fix was a hole I had just dug: the `High` loop could not complete, because planning left the parent `In progress` while step 2 admitted only `Ready`, step 3 demanded sub-issues step 6 had not yet created, and step 6 would refile ones already linked. Round 3's must-fix was the fix for that regressing something else — adding the already-linked skip silently dropped "each shaped and linked", so a placeholder child would be passed over rather than repaired. Both are recorded in the plan's replan log.

## The plan, and the gate I skipped

`#270` is `Effort: Medium`, so a committed plan was required before code and there was none. The change read as vocabulary substitution until the `XL`-has-no-successor problem surfaced mid-edit, by which point it was underway. The reviewer raised it as a must-fix and suggested reordering branch history so the plan preceded implementation; I did not, because that would falsely recover a guarantee already lost. `docs/plans/270-effort-contract.md` is committed with a replan row saying outright that it was written after implementation began and that the sequencing guarantee is gone and not reconstructable.

## Owner validation

Deterministic checks cannot decide any of this:

- Is `XL` → `High`-with-decomposition right, or should an undecomposed parent still be something the board can express distinctly?
- Does `implement-issue` step 6 put sub-issue creation in the right place, or does filing issues belong to triage rather than the implementation orchestrator?
- Is repeating the floor rule in five files the right trade against it drifting out of sync?

## Filed, not folded in

**#275** — `AGENTS.md:89` permits an `Urgent` priority that `.e0l/first-principles/planning.md:163` says is never assigned, with a real argument that a fourth level above `High` just becomes the new `High`. Six live surfaces route on it, including `autonomous-issue-triage`'s selection order. Kept separate because it needs a decision between conforming, recording a deviation, and amending upstream — not an edit.