### PR TITLE
docs: stop offering an Urgent priority High already covers

### DIFF
--- a/.claude/skills/autonomous-issue-triage/SKILL.md
+++ b/.claude/skills/autonomous-issue-triage/SKILL.md
@@ -19,7 +19,8 @@ Reject candidates with:
 Rank remaining work by:
 
 1. active roadmap/parent initiative
-2. `Urgent`, then `High`, then `Medium`, then `Low`
+2. `High`, then `Medium`, then `Low`; a stray `Urgent` ranks with `High` and is flagged in the
+   recommendation
 3. dependency leverage and unblock value
 4. lower `Effort`
 5. oldest settled Ready item

--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -20,8 +20,9 @@ Triage one issue. Do not plan `Medium` or `High` work, and do not edit productio
 4. Decide and explain:
    - native issue type: `Task`, `Bug`, or `Feature`
    - relevant domain labels
-   - `Priority`: `Urgent`/`High`/`Medium`/`Low`, answering how soon *within* the milestone.
-     `Urgent` and `High` require a comment naming what specifically goes wrong if this waits.
+   - `Priority`: `High`/`Medium`/`Low`, answering how soon *within* the milestone.
+     `High` requires a comment naming what specifically goes wrong if this waits. The field's
+     `Urgent` option is never assigned; `High` is the ceiling.
    - `Effort`: the reasoning class the work needs, not how long it takes — `High`/`Medium`/`Low`
      with the matching `model/opus|sonnet|haiku` label. It is a floor: cryptography, the IPC
      boundary, the `.thf` schema, and trust boundaries are `High` however small the diff looks.

--- a/.github/instructions/github.instructions.md
+++ b/.github/instructions/github.instructions.md
@@ -11,5 +11,5 @@ Follow `AGENTS.md` and `CONTRIBUTING.md`; this file adds repository-operation ru
 - Preserve exact required-check names, CODEOWNERS coverage, and owner-validation boundaries.
 - Treat Project 2 fields and lifecycle values as canonical; discover live IDs instead of hard-coding
   mutable node or option IDs.
-- Keep reporter urgency distinct from maintainer-owned `Urgent`/`High`/`Medium`/`Low` priority.
+- Keep reporter urgency distinct from maintainer-owned `High`/`Medium`/`Low` priority.
 - Do not mutate GitHub state without explicit authorization and never use owner bypass.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,11 +86,15 @@ sees an empty board and reports it as missing metadata. Read and write them thro
 `setIssueFieldValue` on the GraphQL API instead, and enumerate the option IDs from
 `organization.issueFields`.
 
-`Priority` is `Urgent` → `High` → `Medium` → `Low`, and answers *how soon* within the current
-milestone. It never means how big, and it never overrides the milestone. Every `Urgent` or `High`
-issue carries a comment naming the cost of delay; a priority with no stated reason is
-indistinguishable from one set by whoever filed it last. If more than about a fifth of open issues
-sit in the top two, the field has stopped routing anything.
+`Priority` is `High` → `Medium` → `Low`, and answers *how soon* within the current milestone. It
+never means how big, and it never overrides the milestone. Every `High` issue carries a comment
+naming the cost of delay; a priority with no stated reason is indistinguishable from one set by
+whoever filed it last. If more than about a fifth of open issues are `High`, the field has
+stopped routing anything.
+
+GitHub's field carries an `Urgent` option that is **never assigned** — `High` is the ceiling.
+That is the distribution test one level up: a fourth level above `High` only becomes the new
+`High`, and everything beneath it stops being read.
 
 `Effort` is the reasoning class the work needs — not how long it takes:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,9 +34,8 @@ execution tracker.
 There are four states and no `In review`: for a solo studio there is nobody to hand to, so an
 issue stays `In progress` until it merges.
 
-Every non-trivial issue receives an `Urgent`/`High`/`Medium`/`Low` `Priority`, a
-`High`/`Medium`/`Low` `Effort`, a `Task`/`Bug`/`Feature` `Type`, and exactly one
-autonomy label:
+Every non-trivial issue receives a `High`/`Medium`/`Low` `Priority`, a `High`/`Medium`/`Low`
+`Effort`, a `Task`/`Bug`/`Feature` `Type`, and exactly one autonomy label:
 
 - `AUTO` — an agent can reach a verification-complete PR without earlier human action
 - `HITL` — a secret, account, provisioning step, or unresolved decision is needed

--- a/docs/plans/0000-template.md
+++ b/docs/plans/0000-template.md
@@ -10,7 +10,7 @@ State the measurable user or system outcome.
 - **Parent initiative:** `#N` or `N/A`
 - **Type:** `Task`, `Bug`, or `Feature`
 - **Effort:** `Medium` or `High`
-- **Priority:** `Urgent`, `High`, `Medium`, or `Low`
+- **Priority:** `High`, `Medium`, or `Low`
 - **Autonomy:** `AUTO` or `HITL`
 - **Dependencies:** linked issues, external prerequisites, or `None`
 - **Non-goals:** behavior explicitly excluded from this change


### PR DESCRIPTION
Closes #275.

`AGENTS.md` described `Priority` as a four-level scale, `Urgent` → `High` → `Medium` → `Low`, and five other live surfaces repeated it. The inherited doctrine at `.e0l/first-principles/planning.md:163` says the opposite: the `Urgent` option exists on GitHub's field and is **never assigned**, because a fourth level above `High` only becomes the new `High`. `.e0l/` is vendored and cannot be edited here, so the question was which side to conform — and `AGENTS.md` was already arguing the doctrine's case two sentences below the line that contradicted it.

## What the board actually said

Of **54 open** issues carrying a Priority, zero are `Urgent` — 6 `High`, 41 `Medium`, 7 `Low`. Of **65 closed**, 50 carry one and two of those are `Urgent`: #232 and #233. Both stay as they are; a closed issue's field records what the board held that day, the same boundary that leaves #233's committed plan saying `Priority: Urgent`.

The field history is what settles the decision. #232 went `Low` → `Urgent` and #233 `Medium` → `Urgent`, 24 seconds apart in one escalation pass, and closed 58 minutes and 12 hours later. Both jumped straight past `High`, which was the rung directly beneath, and both are security defects sitting squarely inside the `High` bar. The argument is not that nothing used the fourth level — it is that `High` was right there when it did.

## Six live surfaces

`AGENTS.md`, `CONTRIBUTING.md`, `issue-triage`, `autonomous-issue-triage` (a ranking order an agent executes), `.github/instructions/github.instructions.md`, and `docs/plans/0000-template.md` — which lives among records but is the template every new plan copies. Committed plans for closed issues keep the words they were written with.

`AGENTS.md` and `issue-triage` still name `Urgent` once each, to say it is never assigned: `AGENTS.md:86-87` tells an agent to enumerate the option IDs, and that query returns four. `autonomous-issue-triage` ranks a stray one *with* `High` rather than above it, since ranking it higher would quietly reinstate the scale this removes.

## Verification

`npm run ci:local` passes. Docs-only diff, six files, +18/−13.

## Preflight

Three rounds of `pr-reviewer` and `slop-auditor`, run read-only and in parallel against a frozen tree, each lane attesting `HEAD` / `git status --porcelain` / diff hash on entry and exit. Both converged clean.

Round 1 produced two must-fixes, each found independently by both lanes:

- **Dropping a level changed what an untouched line meant.** `AGENTS.md`'s distribution test read "more than about a fifth of open issues in the top two". With four levels that was `Urgent`+`High`, 6 of 54; with three it becomes `High`+`Medium`, **47 of 54**, so the file would have asserted its own field was dead — the exact defect class this issue exists to remove, one level down. Now says `High`, matching `planning.md:167` and `e0l-issues-refresh`.
- **My board sweep excluded its own counterexamples.** I had swept only open issues and written "nothing on the board disagreed with the doctrine". Both closed `Urgent` issues were closed *hours before* this commit.

Round 2 killed a replacement claim that was also wrong: I had explained the blind spot with "an urgent issue is the one that closes fastest", and the slop lane measured both at 29.7h and 39.8h against a 15.0h median — the slowest third. The real mechanism is the label-to-close interval, not lifetime, and the message now says so.

## Not in this PR

The recognition pattern behind that first defect — a negative claim established over a filter correlated with the property being counted — belongs in `docs/quality/agentic-slop.md`, and #267 is the open issue for exactly that. Recorded there rather than widening a vocabulary-conformance diff.

## For owner validation

Nothing here changes product behavior. The judgment call worth checking is the one at the top: conforming the repository to upstream rather than amending upstream to permit `Urgent`. Two issues did reach for the level this week, so it is not that nobody wanted an escalation signal — it is that `High` was unused underneath them both times.