### PR TITLE
fix: tell a stored API key from one this browser can still read

### DIFF
--- a/docs/plans/234-vault-usable-status.md
+++ b/docs/plans/234-vault-usable-status.md
@@ -367,14 +367,18 @@ first if the implementer prefers a clean diff.
   `src/components/panels/ai-settings-content.tsx`.
 - **Implementation:**
   1. Move `ADAPTER_LOAD_ERROR` and `loadAdapter` (`ai-settings-content.tsx:17-33`) into
-     `get-keychain-adapter.ts` as `KEYCHAIN_LOAD_ERROR` and `loadKeychainAdapter()`, keeping
+     `load-keychain-adapter.ts` as `KEYCHAIN_LOAD_ERROR` and `loadKeychainAdapter()`, keeping
      the `console.warn` and the authored rethrow verbatim.
   2. Move `errorText` (`:106`) there as `keychainErrorText(error: unknown): string`, keeping
-     the `Error`-vs-string branch and its docblock — the Tauri adapter rejects with a string
-     from `invoke`, which is why the branch exists.
+     the `Error`-vs-string branches — the Tauri adapter rejects with a string from `invoke`,
+     which is why more than one exists. See the 2026-07-27 rows: the function gained a third
+     branch and an emptiness check during preflight, and its docblock was rewritten, because
+     the original attributed a safety guarantee to it that lives upstream.
   3. Point the panel at both. Delete the local copies.
-  4. Note in the docblock that these are the only two ways a keychain failure becomes text a
-     user reads, and that duplicating them is how the surfaces drift apart.
+  4. Note in the docblock that these are the paths by which a keychain failure becomes text on
+     the settings and chat-store surfaces, and that duplicating them is how the surfaces drift
+     apart. (`browser-chat-adapter`'s `no_api_key` re-raise is a third path, documented where
+     it lives rather than claimed here.)
 - **Targeted verification:** `npx vitest run src/components/panels/ai-settings-content.test.tsx`
   — the existing suite is the regression proof; every assertion about `ADAPTER_LOAD_ERROR` text
   and rendered failure messages (`:281`, `:303`) must pass unchanged.
@@ -597,7 +601,7 @@ Green CI cannot decide any of these.
 
 ## Follow-up issues to file (not sub-issues, not in scope)
 
-Both are new issues linked to `#234`, filed at handoff, not folded in.
+Filed at handoff as #281, #280, and #282 — linked to `#234`, not folded in.
 
 1. **`migrateLegacyKey` erases the clear-text slot on a declined import without proving the
    stored record is readable.** This is the hazard recorded in the second comment on `#234`.
@@ -619,7 +623,14 @@ Both are new issues linked to `#234`, filed at handoff, not folded in.
    wrapping key is lost"). The message therefore sends a user to destroy their saved threat
    models (`CLEARING_SITE_DATA_COST`) for something re-entry fixes. This plan deliberately does
    not touch it: AC 1 names that exact string as what must render, and changing safety copy
-   under a bug fix hides the change. File it as its own copy issue with the test as evidence.
+   under a bug fix hides the change. File it as its own copy issue with the test as evidence. **Filed as #280**, together with
+   `UNAVAILABLE_MESSAGE`, whose remedy is wrong for two of its three causes (reviewer consider
+   C4): an insecure origin has no Web Crypto and a sandboxed iframe throws on the property
+   read, and site-data permission addresses neither.
+3. **The unguarded `globalThis.indexedDB` read exists one module over.** `indexeddb.ts:87` has
+   the identical getter hazard the 2026-07-27 security row describes, with no equivalent remap.
+   Out of scope — workspace persistence, no credential — but the finding is not specific to the
+   key vault. **Filed as #282.**
 
 ## Specialist review
 
@@ -641,3 +652,7 @@ Append changes; do not rewrite prior decisions.
 | 2026-07-27 | `hasSecret`'s fault can no longer escape as a raw `DOMException`; `withVault` now opens inside its `try` | Security lane, #234 preflight. `openVault` guarded `factory.open()` and a null factory, but not the `globalThis.indexedDB` property read itself, which is a getter that throws `SecurityError` in a sandboxed iframe or storage-blocked profile — the hazard `readLegacySlot` already catches for `localStorage`. Awaited outside the `try`, that rejection bypassed the remap and would have rendered `The operation is insecure.` as the app's explanation, defeating the exact-text assertion in `ai-settings-damaged-vault.test.tsx`. Pre-existing, but this change adds a second verbatim-rendering surface reachable at mount without opening settings, so it is fixed here rather than filed |
 | 2026-07-27 | `keychainErrorText` fails closed on a rejection that is neither `Error` nor string; three comments stop crediting it with a guarantee it does not provide | Reviewer and slop lanes, independently. The function is a shape adapter — routing through it cannot establish authorship, and `String(error)` on an object renders `[object Object]` as the app's account of itself. The guarantee is real but lives upstream in `withVault`'s remap and in `key_refusal` on the Rust side; the comments now name that, because a maintainer reading "nothing unauthored can arrive" would not add a guard where one is needed |
 | 2026-07-27 | `KEY_STORAGE_UNREADABLE` exported from `keychain-adapter.ts`; both surfaces render the constant | Reviewer and slop lanes, independently. The sentence this issue exists to keep identical across two surfaces shipped as two literals coupled by nothing but a docblock claiming they matched — a copy edit to one would diverge them silently and every suite would still pass. That is #234's own defect one layer up, in copy instead of state |
+| 2026-07-27 | `keychainErrorText` also refuses an `Error` whose message is empty | Reviewer lane, round 2, and the sharpest finding on this issue. The fail-closed fix hardened the *shape* branch but not emptiness: `error.message` of `""` reaches `chat-store`'s `keyFault`, which `ai-chat-tab` tests for truthiness, so the tab falls through to `EmptyState` and claims "No API key configured" over a vault that had just faulted — this issue's exact defect, arriving through the code added to prevent it. Confirmed by reverting the guard: `shows the fault even when the rejection carries no message of its own` fails with `key-storage-fault` absent and `No API key configured` in the DOM |
+| 2026-07-27 | Discriminating tests added for the two preflight fixes above | Security and reviewer lanes, independently: both observed that reverting the `withVault` change left the whole suite green, so the security fix was unobservable to every test in the tree and invisible to a future refactor tidying it. `surfaces a user-safe message when the storage factory itself refuses to be read` installs a throwing `indexedDB` getter via `Object.defineProperty` — not `vi.spyOn(…, "get")`, which cannot spy the data property `fake-indexeddb/auto` installs — and fails with the raw `SecurityError` when the fix is reverted |
+| 2026-07-27 | `recognise` → `recognize` in `KEYCHAIN_UNKNOWN_ERROR`; `this app` → `ThreatForge` | Slop lane. The two lanes disagreed, which is what made it worth checking rather than deciding: the reviewer read `recognise` as house style, citing prose in `browser-key-vault.ts:88` and eight test names. Both are right about their own half — the repo writes British prose in comments and American copy in the UI (`Analyzing…`, `Run STRIDE analysis`, `analyze_stride`), and this string is the first to cross from one to the other. The self-reference is the reviewer's: the panel already names ThreatForge, and this renders beside it |
+| 2026-07-27 | Module header no longer claims to be the only path; step 2's body corrected to match its Files line | Reviewer lane, round 2. `browser-chat-adapter.ts:337` re-raises a `KeyVaultError` as a `no_api_key` protocol error, so a vault sentence can also reach the transcript by way of a request — the plan names this at its own `:80-82`, so the header contradicted the document it was implementing. The step-2 body still directed the extraction into `get-keychain-adapter.ts` two lines below the Files line correcting it, which is the destination the earlier replan row exists to rule out |

--- a/docs/plans/234-vault-usable-status.md
+++ b/docs/plans/234-vault-usable-status.md
@@ -1,0 +1,632 @@
+# Issue 234 — Stop reporting a key the browser vault cannot read as configured
+
+## Objective
+
+On a browser profile whose vault wrapping key is lost or damaged while encrypted records
+survive, every surface that describes the user's credential reports a fault with the authored
+remedy instead of a green "API key configured" dot. A status check still performs no
+decryption, and desktop behaviour is untouched.
+
+## Issue contract
+
+- **Issue:** `#234`
+- **Parent initiative:** `N/A` (related: `#133` made the state reachable, `#233` added the
+  surfaced-error path this plugs into, `#266` was the `#233` PR)
+- **Type:** `Bug`
+- **Effort:** `High` — by the `AGENTS.md` floor rule ("any work touching cryptography, the IPC
+  boundary, the `.thf` schema, or a trust boundary is `High` regardless of how small the diff
+  looks"), not by scale. See "Decomposition" below: this is **not** decomposed into sub-issues.
+- **Priority:** `High` — cost of delay recorded on the issue: a false-positive in secret
+  handling, the class of bug that erodes trust in everything else the tool claims.
+- **Autonomy:** `AUTO`. No secret, provisioning step, or external account action gates any
+  step. Two copy decisions need owner *validation* after the fact, not before (see "Owner
+  validation"); neither blocks implementation.
+- **Dependencies:** none open. `#133` and `#233` are merged and on `main` at `24fc808`.
+- **Non-goals:**
+  - Any change to the vault's encryption, marker, or migration behaviour.
+  - Clear-text residue after a refused `localStorage.removeItem` — that is `#233`, merged.
+  - Making a status check prove that a *specific record* decrypts. Explicitly ruled out below,
+    with the reason.
+  - Changing `TauriKeychainAdapter`, `get_api_key_status`, or `KeyStorage`.
+
+## Current behavior and evidence
+
+All line numbers are against `main` at `24fc808`.
+
+**The vault answers two different questions and one of them is not asked.**
+
+- `browser-key-vault.ts:641` — `hasSecret(id)` opens one readonly transaction on `secrets` and
+  returns `count(id) > 0`. It never reads the wrapping key and never decrypts.
+- `browser-key-vault.ts:608` — `getSecret(id)` reads the record, then `readWrapKey(db)`
+  (`:617`). A wrap key that is absent throws `vaultCorrupt()` (`:618`); one that is present but
+  not a usable AES-GCM encrypt/decrypt key throws `vaultCorrupt()` from inside `readWrapKey`
+  (`:405-409`). An AES-GCM `OperationError` throws `corruptRecord(record)` (`:632`); any other
+  decrypt rejection throws `vaultCorrupt()` (`:634`), because it is not evidence about that
+  record.
+- `browser-keychain-adapter.ts:196` — `hasKey` is `migrateLegacyKey` then `hasSecret`, under
+  the per-provider lock.
+- `browser-keychain-adapter.ts:205` — `getKey` catches `reason === "corrupt"`, calls
+  `dropUnreadableSecret`, returns `null`; it rethrows `vault-corrupt` and `unavailable`.
+
+**The divergence is already pinned by a passing test.**
+`browser-keychain-adapter.test.ts:1222` ("is rejected as a vault fault rather than destroying
+the stored record") stores a key, replaces the wrapping key with an encrypt-only `CryptoKey`,
+asserts `getKey` rejects `vault-corrupt`, and then asserts `hasKey` returns `true`. Verified
+green on this tree:
+
+```
+npx vitest run src/lib/adapters/browser-keychain-adapter.test.ts \
+  -t "is rejected as a vault fault rather than destroying the stored record"
+→ 1 passed
+```
+
+That assertion is the bug, written down as an expectation. Its *intent* is "the record
+survives, so restoring the correct wrapping key would recover it" — which the plan preserves
+with a different assertion (step 1).
+
+**Every consumer of the boolean already handles a rejection; none of them ever sees one here.**
+
+- `ai-settings-content.tsx:57` — `type KeyStatus = boolean | "unknown" | "unchecked"`, and
+  `statusToneOf` (`:69`) maps `"unknown"` to an amber dot and `"Key storage could not be
+  checked"`. `:317` records a rejected `hasKey` as `"unknown"`; `:321-324` surfaces the
+  rejection's message. The removal control (`:602`) and the "Replace API Key" label (`:559`)
+  render only for `keyStatus === true`. **The rendering vocabulary for this fault already
+  exists and is tested** (`ai-settings-content.test.tsx:206`, `:223`). The defect is upstream:
+  `hasKey` resolves `true`.
+- `chat-store.ts:523` — `checkApiKey` sets `hasApiKey` from `adapter.hasKey(provider)` and its
+  `catch` sets `hasApiKey: false`, which `ai-chat-tab.tsx:121` renders as the `EmptyState`
+  heading "No API key configured" (`:131`). So today a rejection on that path produces exactly
+  the absence claim the panel refuses to make — the two surfaces disagree.
+- `browser-chat-adapter.ts:337` — the request path already re-raises a `KeyVaultError` as a
+  `no_api_key` protocol error carrying the vault's authored sentence. That third surface is
+  already correct and needs no change.
+- `app-layout.tsx:61-94` — the launch effect probes `readLegacyResidue` first and calls
+  `hasKey` **only when some provider has a clear-text slot** (`:82`), inside
+  `Promise.allSettled`. The surrounding comment explains why: an unconditional `hasKey` created
+  the keychain database at launch for every profile. A rejecting `hasKey` is already normal
+  there — `migrateLegacyKey` → `importLegacySecret` (`browser-key-vault.ts:793`) throws
+  `vaultCorrupt()` today whenever records exist and the wrap key cannot be produced — and the
+  `allSettled` plus the unconditional `refreshAllResidue()` that follows already absorb it. The
+  gate is on slot presence, not on the answer, so nothing about this change alters whether the
+  database is created.
+
+**A rejection cannot wedge the provider queue.** `withProviderLock`
+(`browser-keychain-adapter.ts:148-162`) parks a link that never rejects, so a failed `hasKey`
+does not poison later calls for that provider.
+
+**Desktop is a different implementation of the same idea and is already honest.**
+`TauriKeychainAdapter.hasKey` invokes `get_api_key_status` (`ai_commands.rs:19`), which calls
+`KeyStorage::has_key` (`keychain.rs:106`) — a lookup in an in-memory `HashMap`. That map only
+exists because `KeyStorage::new` (`keychain.rs:73-77`) already decrypted `keys.enc` at startup,
+and a failure there aborts app setup (`lib.rs:52-57`). A desktop profile therefore cannot reach
+the state this issue describes: there is no "record present, key undecryptable" reachable
+through `has_key`, because an undecryptable store means the app did not start. `has_key`'s only
+reachable failure is a poisoned lock, which is already mapped to the authored string "the
+stored API key could not be read" and is tested for payload leakage
+(`ai_commands.rs:266`).
+
+## Decision — how "usable" is established
+
+### The three candidates
+
+**A. Make `hasKey` authoritative (decrypt on every status check).**
+`hasSecret` reads the record, reads the wrap key, and decrypts.
+*Cost:* one AES-GCM decrypt per status check, on a render path that currently does no crypto.
+*Ruled out.* Not for the microseconds — for what it forces next. A decrypt on the status path
+produces an `OperationError` for a damaged record, and then the status path has to choose
+between two worse behaviours:
+  - drop the record, as `getKey` does (`browser-keychain-adapter.ts:220`). That makes opening
+    the settings dialog silently delete key material. `dropUnreadableSecret` is deliberately
+    scoped to a read the user asked for, and it also settles the provider's clear-text slot
+    (`browser-key-vault.ts:731-735`) — so a render-path drop can destroy a surviving
+    clear-text copy the user never asked anything about. **A status check that deletes
+    credentials is a worse bug than the one being fixed.**
+  - or report the fault without dropping, in which case the panel shows a fault that never
+    clears, while the very next `getKey` drops the record and flips the panel to "No API key
+    configured". The two surfaces disagree again, in the opposite direction.
+
+It also changes `hasKey`'s meaning for the Tauri adapter, where — per the evidence above —
+there is nothing to strengthen: `has_key` is already downstream of a successful decrypt.
+
+**B. A separate `probeKey` / vault-health call used only by the settings panel.**
+*Ruled out.* It creates a second predicate whose answer the first one is allowed to contradict,
+which is the shape of the bug (`hasApiKey` vs. the panel status), reintroduced as an interface.
+It adds a member to `KeychainAdapter` that `TauriKeychainAdapter` would have to implement as a
+no-op or an alias of `hasKey` — a capability declared for one platform and stubbed on the
+other, when the platforms genuinely share the question. And it leaves `hasKey` count-only, so
+`chat-store.ts` keeps the wrong answer unless it also calls the probe — at which point there
+was one predicate all along.
+
+**C. `hasSecret` establishes the vault-level preconditions when, and only when, a record
+exists. Chosen.**
+
+```ts
+export async function hasSecret(id: string): Promise<boolean> {
+	return withVault(async (db) => {
+		const store = db.transaction(STORE_SECRETS, "readonly").objectStore(STORE_SECRETS);
+		const count = await awaitRequest(store.count(id));
+		if (count === 0) return false;
+		requireSubtle();
+		if (!(await readWrapKey(db))) throw vaultCorrupt();
+		return true;
+	});
+}
+```
+
+The failing state named in the issue is `vault-corrupt`: the **wrapping key** is lost or
+damaged while records survive. That is a property of the vault, not of a record, so it is
+answerable without touching a record's bytes. Two lines, both already written elsewhere in this
+module for exactly this purpose — `getSecret:617-618` and `importLegacySecret:793` make the
+same check, in the same order, and throw the same error.
+
+### The cost, stated (acceptance criterion 2)
+
+- **Zero cryptographic operations.** `readWrapKey` is an IndexedDB `get` plus `isWrapKey`,
+  which reads `algorithm.name` and `usages` off a structured-clone `CryptoKey` handle. No
+  `subtle.decrypt`, no `subtle.encrypt`. Step 1 pins this with a `subtle.decrypt` spy so the
+  claim is a test rather than a sentence in a plan.
+- **One extra readonly IndexedDB transaction and one `get`, only for providers that have a
+  record.** A provider with nothing stored costs exactly what it costs today: one `count`.
+- **`requireSubtle()` is a property read** (`globalThis.crypto?.subtle`) and no transaction at
+  all.
+- **Call frequency:** the settings panel mount (two providers), `chat-store.checkApiKey` on AI
+  tab mount and provider switch and after save/delete, a residue recheck click, and the launch
+  effect *only when a clear-text slot exists*. This is not a hot path and does not become one.
+- **No new database creation.** `hasSecret` already opens the vault; the second transaction is
+  on the connection `withVault` already holds and closes.
+- **Blast radius of the added rejection is narrower than it looks.** A profile that still has a
+  clear-text slot *already* rejects on this path, from `importLegacySecret:793`, before
+  `hasSecret` is reached. The new rejection is therefore observable mainly on slot-free
+  profiles — the ordinary post-`#133` case.
+
+### What C does **not** cover, and why that is the right line
+
+- **A single damaged record while the wrap key is fine.** `count` is 1, the wrap key reads
+  back, `hasSecret` returns `true`, and only `subtle.decrypt` would reveal the truncation or
+  tamper. This case remains reported as "API key configured" until the user's next request,
+  which fails with the authored `CORRUPT_MESSAGE` ("The stored API key could not be read and
+  needs to be entered again"), drops the record, and leaves the panel showing "No API key
+  configured" with the message on screen. That is imperfect but bounded, self-healing, and
+  actionable — and closing it requires the render-path decrypt-and-delete ruled out under
+  option A. **This boundary is made explicit by a named test (step 1) rather than left as an
+  unstated gap.**
+- **A crypto-layer fault at decrypt time that is not an `OperationError`** (`:634`). The wrap
+  key reads back fine, so a status check cannot see it. Same reasoning: only a decrypt would
+  show it, and the vault deliberately treats it as non-evidence about the record.
+- **A record whose stored value does not parse as `{ iv, ciphertext }`** (`:615`,
+  `corruptRecord(null)`). Detectable without crypto by reading the record instead of counting
+  it — but the honest response is the same per-record drop decision as above, so it is left
+  with the per-record case rather than half-covered. If a future issue wants the per-record
+  class covered, the parse check and the decrypt belong in the *same* change with a decided
+  answer about who deletes what, and not on a render path.
+
+### Why `requireSubtle()` is included and is not a speculative defense
+
+Without `SubtleCrypto` no record in the vault is decryptable, which is the same vault-level
+fact as a missing wrap key. It is reachable — `crypto.subtle` is exposed only in secure
+contexts, so a self-hosted `http://` deployment has none — and the vault already treats it as
+reachable: `requireSubtle` exists (`:274`), `unavailable()` is authored for it, and
+`browser-keychain-adapter.test.ts:387` tests the save path for it. Step 1 adds the matching
+status-path test, so it is pinned rather than assumed.
+
+### What the function is *not* renamed to
+
+`hasSecret` keeps its name. `hasUsableSecret` would overclaim in exactly the direction this
+issue is about — it does not prove the record decrypts — and a name that promises more than the
+body delivers is how the original defect reads. The docblock states the contract precisely
+instead.
+
+### Tauri (acceptance criterion 6)
+
+**No change to `tauri-keychain-adapter.ts`, `ai_commands.rs`, or `keychain.rs`.**
+
+`KeychainAdapter.hasKey` gains **no new rejection mode**: it is already `Promise<boolean>` and
+both implementations already reject — the browser through `withVault`'s authored
+`KeyVaultError`, desktop through `invoke` rejecting with `key_refusal`'s authored string, which
+`ai-settings-content.tsx:106` already renders via its string branch. What changes is *when* the
+browser rejects, not *whether* the contract permits it. The interface docblock is updated to
+say so, because "returns a boolean" is what let a caller assume the answer was total.
+
+Desktop already has the property this issue asks for, by construction: `has_key` reads a map
+that only exists because `keys.enc` decrypted at startup. Strengthening it would mean inventing
+a failure the platform cannot produce.
+
+### Panel and chat wording
+
+The amber `"unknown"` tone is reused, not replaced. It already means "storage did not give a
+usable answer", it already suppresses the destructive removal control, and the authored
+`VAULT_CORRUPT_MESSAGE` — carrying the remedy — is already rendered in the message block. A
+fourth tone keyed on a reason code would buy a colour, not information, and would require
+exporting vault reason codes to a component that deliberately matches structurally
+(`isRetainedLegacyCopy`, `:118`). Destructive red is deliberately *not* used: red is owned by
+"a live clear-text credential is readable in this browser", an exposure. A damaged vault is a
+loss of function, and the panel's documented precedence (`statusToneOf`) already ranks the
+exposure above it.
+
+One string does change. `"Key storage could not be checked"` was true when `hasKey` only
+counted; after this change the dominant case is a check that *did* answer and answered
+"damaged". `"Key storage could not be read"` is true of every case that reaches this tone —
+damaged vault, unavailable storage, a rejected migration — and it is a sentence the chat
+surface can share verbatim, which is what stops the two surfaces from disagreeing in wording
+while agreeing in fact.
+
+## Decomposition — this issue does not get sub-issues
+
+`AGENTS.md` requires `High` work to be decomposed into executable sub-issues. It is `High` here
+because of the floor rule, and decomposition would make the result worse, so the steps below
+are the decomposition and they all land in one PR against `#234`.
+
+Evidence and reasoning:
+
+- **Scale.** The production diff is one function body in `browser-key-vault.ts`, three
+  docblocks, one string, two small helpers moved, ~6 lines in `chat-store.ts`, and one
+  presentational component in `ai-chat-tab.tsx`. There is no schema change, no new capability
+  on `KeychainAdapter`, no migration, and no Rust.
+- **Coherence.** The acceptance criteria are mutually dependent. Shipping the vault change
+  alone (AC 1) *creates* an AC 3 violation: the panel would show the fault while
+  `chat-store`'s `catch` turned the same rejection into "No API key configured". Shipping the
+  chat reconciliation alone changes nothing observable, because `hasKey` never rejects in this
+  state. Sub-issues here would be a sequence of states in which the product is more wrong than
+  it is today, filed as separately mergeable units.
+- **Precedent.** `#233` was `High` for the same floor reason, was planned as steps rather than
+  sub-issues, and shipped as one PR (`fddaab3`, PR `#266`). Its plan is
+  `docs/plans/233-persistent-clear-text-key-warning.md`.
+- **What decomposition is for.** Sub-issues buy independent review and independent revert of
+  genuinely separable work. Nothing here is separable: every step exists to keep a single
+  predicate honest across three surfaces.
+
+Two genuinely separate defects surfaced while planning. They are **not** sub-issues and are
+**not** in scope — they are new issues to file. See "Follow-up issues to file".
+
+## Implementation steps
+
+Each step is `Low` on its own. Steps 1–6 are ordered; 2 is behaviour-preserving and can land
+first if the implementer prefers a clean diff.
+
+### 1. `hasSecret` answers for the vault as well as the record
+
+- **Behavior:** `hasSecret(id)` resolves `false` when no record is stored for `id`; resolves
+  `true` when a record is stored and this browser can produce the material to decrypt it; and
+  rejects with `KeyVaultError` — `vault-corrupt` when the wrapping key is missing or unusable,
+  `unavailable` when Web Crypto or IndexedDB is not usable here — when a record is stored and it
+  cannot. It performs no decryption and deletes nothing, ever.
+- **Files:**
+  - `src/lib/adapters/browser-key-vault.ts` (`hasSecret`, `:641`)
+  - `src/lib/adapters/browser-keychain-adapter.ts` (`hasKey` docblock, `:196`)
+  - `src/lib/adapters/keychain-adapter.ts` (`hasKey` docblock on the interface)
+  - `src/lib/adapters/test-fixtures/key-vault.ts` (fixture extraction)
+  - `src/lib/adapters/browser-keychain-adapter.test.ts`
+- **Implementation:**
+  1. Replace the body of `hasSecret` with the form quoted under "Decision — option C". Keep the
+     `withVault` wrapper: it is what guarantees no raw `DOMException` escapes.
+  2. Order is load-bearing and must be commented: the `count` gates both later checks, so a
+     provider with nothing stored still reads as "no key" on a damaged vault rather than
+     inheriting another provider's fault.
+  3. Reuse `readWrapKey(db)` as-is, in its own transaction, exactly as `getSecret:617` does.
+     Do **not** refactor it to share one transaction with the count: `readWrapKey` has three
+     callers, and the only thing the split loses is snapshot consistency against a concurrent
+     tab minting or wiping a key — which can change a *status*, never a destructive action.
+     Note that trade in the docblock.
+  4. Rewrite the docblock. State what it establishes, what it does not (the per-record case),
+     and that it never decrypts.
+  5. Update `BrowserKeychainAdapter.hasKey`'s docblock: it now rejects for a vault that cannot
+     decrypt anything, and callers must not read a rejection as absence.
+  6. Update `KeychainAdapter.hasKey`'s docblock in the interface: the rejection mode is part of
+     the contract on both platforms, browser and desktop each state how they reach it, and a
+     caller that collapses a rejection to `false` is making a claim about storage that did not
+     answer.
+  7. Move `openVaultDb` and `writeWrapKeyStore` out of `browser-keychain-adapter.test.ts` into
+     `src/lib/adapters/test-fixtures/key-vault.ts` (which exists for exactly this) and import
+     them back. Behaviour-identical move; step 3 needs them from a second file.
+- **Tests to add** in `browser-keychain-adapter.test.ts`, in a new
+  `describe("a status check over a vault that cannot decrypt")`:
+  - `it("reports a stored key the vault can no longer decrypt as a fault, not as configured")`
+    — `setKey`, `writeWrapKeyStore([])`, expect `hasKey` to reject with `reason:
+    "vault-corrupt"`, and assert `await countSecrets()` is still `1`, so the status check
+    destroyed nothing.
+  - `it("reports a wrapping key of the wrong shape as a fault")` — same with an encrypt-only
+    `CryptoKey`, covering `readWrapKey`'s throw branch as distinct from its `null` branch.
+  - `it("still answers false for a provider with no record while another's is stranded")` —
+    `setKey("anthropic")`, `writeWrapKeyStore([])`, expect `hasKey("openai")` to resolve
+    `false`. Pins the count gate: an unconfigured provider must not inherit the fault.
+  - `it("does not decrypt to answer a status check")` — spy on `crypto.subtle.decrypt`, expect
+    `hasKey` to resolve `true` and the spy not to have been called. This is the durable
+    evidence for the cost claim in AC 2.
+  - `it("reports a stored key as unreadable when Web Crypto is unavailable")` — seed a record,
+    then remove `crypto.subtle` the way `:387` does; expect rejection with `reason:
+    "unavailable"` and the record intact.
+  - `it("reports a per-record decryption failure only once a read has established it")` —
+    `setKey`, `corruptStoredRecord("anthropic")`, assert `hasKey` still resolves `true`, then
+    `getKey` resolves `null`, then `hasKey` resolves `false`. This is the deliberate boundary
+    of the fix, written down so a later reader does not assume the per-record case is covered.
+- **Tests to change:**
+  - `:1222` "is rejected as a vault fault rather than destroying the stored record" — replace
+    `expect(await adapter.hasKey("anthropic")).toBe(true)` with a rejection assertion plus
+    `expect(await countSecrets()).toBe(1)`. The assertion's stated intent ("the record
+    survives, so restoring the correct wrapping key would recover it") is preserved; only the
+    predicate used to observe it changes.
+  - `:1806` "does not report an unreadable record dropped when its transaction aborts" —
+    unchanged. The wrap key is healthy there and only the ciphertext is damaged, so `hasKey`
+    still returns `true` by design. Confirm it still passes rather than editing it.
+- **Targeted verification:**
+  `npx vitest run src/lib/adapters/browser-keychain-adapter.test.ts src/lib/adapters/keychain-adapter.test.ts`
+  — discriminating assertion: reverting the two added lines in `hasSecret` must fail
+  "reports a stored key the vault can no longer decrypt as a fault, not as configured", and
+  adding a decrypt to `hasSecret` must fail "does not decrypt to answer a status check".
+- **Intent validation:** the owner reads the new `hasSecret` docblock and agrees the stated
+  contract is exactly what the body does — in particular that "usable" is claimed about the
+  vault and never about the record.
+
+### 2. One authored-message path for both surfaces
+
+- **Behavior:** loading the keychain adapter and rendering a keychain failure as user-safe text
+  are done by one pair of functions that the settings panel and `chat-store` share. No
+  behaviour changes.
+- **Files:** `src/lib/adapters/get-keychain-adapter.ts`,
+  `src/components/panels/ai-settings-content.tsx`.
+- **Implementation:**
+  1. Move `ADAPTER_LOAD_ERROR` and `loadAdapter` (`ai-settings-content.tsx:17-33`) into
+     `get-keychain-adapter.ts` as `KEYCHAIN_LOAD_ERROR` and `loadKeychainAdapter()`, keeping
+     the `console.warn` and the authored rethrow verbatim.
+  2. Move `errorText` (`:106`) there as `keychainErrorText(error: unknown): string`, keeping
+     the `Error`-vs-string branch and its docblock — the Tauri adapter rejects with a string
+     from `invoke`, which is why the branch exists.
+  3. Point the panel at both. Delete the local copies.
+  4. Note in the docblock that these are the only two ways a keychain failure becomes text a
+     user reads, and that duplicating them is how the surfaces drift apart.
+- **Targeted verification:** `npx vitest run src/components/panels/ai-settings-content.test.tsx`
+  — the existing suite is the regression proof; every assertion about `ADAPTER_LOAD_ERROR` text
+  and rendered failure messages (`:281`, `:303`) must pass unchanged.
+- **Intent validation:** none beyond CI. This step changes no observable behaviour; if any
+  panel test needed editing, something moved that should not have.
+
+### 3. The settings panel says "could not be read", proven over a real damaged vault
+
+- **Behavior:** the amber status reads "Key storage could not be read". On a real vault whose
+  wrapping key is gone, the panel reports neither "API key configured" nor "No API key
+  configured", renders the authored `VAULT_CORRUPT_MESSAGE`, and offers no removal control.
+- **Files:** `src/components/panels/ai-settings-content.tsx`,
+  `src/components/panels/ai-settings-content.test.tsx`, new
+  `src/components/panels/ai-settings-damaged-vault.test.tsx`.
+- **Implementation:**
+  1. Change `STATUS_TEXT.unknown` (`:80`) to `"Key storage could not be read"` and update the
+     `KeyStatus`/`statusToneOf` docblocks (`:47-75`) to say what `"unknown"` now means: a check
+     that failed *or* answered that this browser cannot read storage.
+  2. Update the two references in `ai-settings-content.test.tsx` (`:219` assertion, `:246`
+     comment).
+  3. Add the end-to-end test file. It is separate from the panel suite deliberately: it needs
+     `import "fake-indexeddb/auto"` and a real `BrowserKeychainAdapter`, and installing a
+     global IndexedDB into the 800-line mocked suite would change the environment for tests
+     that must not have one. `src/lib/persistence/no-key-leakage.test.ts` is the precedent for
+     a property-named test file that composes real storage with rendered components.
+  4. The test mocks `@/lib/adapters/get-keychain-adapter` to return a real
+     `new BrowserKeychainAdapter()`, seeds a key through it, damages the vault with the
+     extracted `writeWrapKeyStore([])`, renders `<AiSettingsContent />` inside `act`, and
+     asserts:
+     - `screen.queryByText("API key configured")` is null
+     - `screen.queryByText("No API key configured")` is null
+     - `screen.getByText("Key storage could not be read")` is present
+     - the message block contains the authored sentence
+       (`/Encrypted key storage in this browser is damaged/`)
+     - `screen.queryByRole("button", { name: "Remove API key" })` is null
+     - the rendered document contains no `DOMException`/internal detail — assert the message
+       block's text equals the authored sentence exactly, which is the AC 5 check that cannot
+       pass on a leaked raw error.
+  5. Add a second case in the same file: a healthy vault with a stored key still renders "API
+     key configured", so the file proves the fault path did not simply break the happy path.
+- **Targeted verification:**
+  `npx vitest run src/components/panels/ai-settings-content.test.tsx src/components/panels/ai-settings-damaged-vault.test.tsx`
+  — discriminating assertion: reverting step 1 makes the damaged-vault case render "API key
+  configured" and fail on the first assertion.
+- **Intent validation:** the owner opens AI settings in a browser profile whose wrap key has
+  been removed via devtools and confirms the panel reads as a fault with the remedy, that
+  "Remove API key" is absent, that the input is labelled "API Key" rather than "Replace API
+  Key", and that saving a fresh key recovers the vault in place (which it does —
+  `installWrapKey`'s `"always"` policy, pinned by `browser-keychain-adapter.test.ts:631`).
+
+### 4. `chat-store` stops turning a fault into an absence
+
+- **Behavior:** when the keychain check rejects, `checkApiKey` sets `hasApiKey: false` — no
+  request can be signed, which is true — **and** records the authored message in a new
+  `keyFault: string | null`. When it resolves, `keyFault` is cleared. An adapter that fails to
+  load produces the authored `KEYCHAIN_LOAD_ERROR`, never a bundler message.
+- **Files:** `src/stores/chat-store.ts`, `src/stores/chat-store.test.ts`.
+- **Implementation:**
+  1. Add `keyFault: string | null` to `ChatState` with a docblock stating why it is separate
+     from `error` (that one is "the last request failed"; this one is "storage cannot be read",
+     and it exists before any request) and separate from `hasApiKey` (that one gates sending).
+  2. In `checkApiKey`, load the adapter with `loadKeychainAdapter()` and render any rejection
+     with `keychainErrorText()` from step 2, so nothing unauthored can reach this field.
+  3. On success: `set({ hasApiKey, keyFault: null })`. On rejection:
+     `set({ hasApiKey: false, keyFault: <authored text> })`.
+  4. Leave the trailing `refreshResidue(provider)` call and its comment exactly as they are —
+     `#233` depends on that ordering and on it running after both outcomes.
+- **Tests to add** in `chat-store.test.ts` (extend the existing module-scoped keychain mock
+  with a rejection knob rather than adding a second mock):
+  - `it("does not report a vault it cannot read as no key configured")` — `hasKey` rejects with
+    the authored damaged-vault sentence; assert `hasApiKey === false` **and** `keyFault` is
+    that exact sentence.
+  - `it("clears the storage fault once the check answers again")` — reject, then resolve
+    `true`; assert `keyFault` is `null` and `hasApiKey` is `true`.
+  - `it("re-reads the clear-text slot even when the key check failed")` — assert the residue
+    refresh still runs after a rejection, so `#233`'s guarantee is not conditional on success.
+- **Targeted verification:** `npx vitest run src/stores/chat-store.test.ts` — discriminating
+  assertion: reverting the `catch` to `set({ hasApiKey: false })` leaves `keyFault` null and
+  fails the first test.
+- **Intent validation:** the owner confirms `hasApiKey` still means exactly "a request can be
+  signed" and that nothing now gates sending on `keyFault`.
+
+### 5. The AI chat tab reports the fault instead of claiming there is no key
+
+- **Behavior:** when `keyFault` is set, the chat tab renders a fault state — the shared heading
+  "Key storage could not be read", the authored message beneath it, and a button into AI
+  settings — instead of the "No API key configured" empty state. With no fault, the empty state
+  is byte-for-byte what it is today.
+- **Files:** `src/components/panels/ai-chat-tab.tsx`,
+  `src/components/panels/ai-chat-tab.test.tsx`.
+- **Implementation:**
+  1. Read `keyFault` from `useChatStore` beside `hasApiKey` (`:56`).
+  2. Change the branch at `:121` to: `keyFault ? <KeyStorageFault … /> : !hasApiKey ?
+     <EmptyState … /> : <ChatView />`. The fault outranks the absence because it is the
+     stronger and truer claim, mirroring `statusToneOf`'s documented precedence in the panel.
+  3. Add `KeyStorageFault({ message, onConfigure })` next to `EmptyState`: `role="alert"`,
+     `data-testid="key-storage-fault"`, an amber `AlertTriangle`, the heading `Key storage
+     could not be read`, `{message}` rendered verbatim as the body, and a button labelled
+     `Open AI settings` wired to `openAiSettings`.
+  4. Copy check against `docs/knowledge/product-voice.md`: the fact comes first, nothing in an
+     error is allowed to be funny, and the button promises only what it does — it opens
+     settings; it does not promise a fix, because for an `unavailable` fault entering a key
+     does not help. The remedy itself is the vault's authored sentence, not new copy.
+  5. Amber, not destructive red, for the same hierarchy reason recorded in the decision
+     section.
+- **Tests to add** in `ai-chat-tab.test.tsx` (the existing mock at `:35` already returns a
+  keychain stub; give it a rejection knob):
+  - `it("shows the storage fault instead of claiming no key is configured")` — `hasKey`
+    rejects; assert the authored sentence is on screen and `screen.queryByText("No API key
+    configured")` is null.
+  - `it("still shows the empty state when storage answers that there is no key")` — `hasKey`
+    resolves `false`; assert the existing empty state is unchanged. Without this, the fault
+    branch could swallow the ordinary path and no test would notice.
+- **Targeted verification:**
+  `npx vitest run src/components/panels/ai-chat-tab.test.tsx` then
+  `npx playwright test e2e/ai-chat.spec.ts e2e/empty-states.spec.ts` — both specs assert the
+  right panel contains "No API key configured" (`e2e/ai-chat.spec.ts:10`,
+  `e2e/empty-states.spec.ts:31`), so they are the guard that the no-key path did not move. Stop
+  the Playwright web server when the run ends.
+- **Intent validation:** the owner opens the AI tab on a damaged-vault profile and confirms the
+  chat surface and the settings panel state the same thing in the same words, and that the
+  button lands on the AI settings tab.
+
+### 6. Sweep for surfaces that still read a rejection as absence
+
+- **Behavior:** no remaining caller of `hasKey` collapses a rejection into "no key".
+- **Files:** read-only sweep; edits only if the sweep finds something.
+- **Implementation:** `rg "hasKey\(" src e2e` and confirm each caller:
+  `ai-settings-content.tsx:295` and `:435` (already `"unknown"`), `chat-store.ts:523` (step 4),
+  `app-layout.tsx:83` (`allSettled`, migration-only, deliberately does not commit the answer —
+  leave it, and confirm the launch path still creates no keychain database for a slot-free
+  profile). Record the result in the PR body; do not add a defensive branch anywhere the sweep
+  finds nothing.
+- **Targeted verification:** `npx vitest run src/components/layout` and `npx tsc --noEmit`.
+- **Intent validation:** the owner reads the sweep result in the handoff and agrees no surface
+  was missed.
+
+## Cross-cutting requirements
+
+- **Security and privacy:** the trust boundary is the browser key vault. Every rejection that
+  leaves it is authored inside `browser-key-vault.ts` and remapped by `withVault:495-505`, so
+  no raw `DOMException` and no ciphertext can reach a surface; step 3 asserts the rendered
+  sentence exactly, which is what makes AC 5 a test rather than an assurance. No path added by
+  this plan writes, deletes, or decrypts anything: the status check is strictly read-only, and
+  the deliberate refusal to delete on a render path is the core of the decision. `keyFault`
+  holds an authored sentence, never key material, and lives in memory only — it is never
+  persisted, exactly as `key-residue-store.ts` documents for residue.
+- **`.thf` compatibility:** untouched. No schema, no serialization, no migration.
+- **Browser and desktop:** the difference is intentional and documented in the interface
+  docblock. The browser vault establishes decryptability at status time because it can lose a
+  wrapping key while keeping records; desktop cannot reach that state, because `KeyStorage::new`
+  decrypts at startup and setup fails otherwise. No Rust, no capability, no IPC change.
+- **AI safety:** unchanged. This plan touches credential *status*, not model output, tool
+  execution, approval, or undo.
+- **Accessibility and UX:** the fault state uses `role="alert"`, matching
+  `ClearTextKeyNotice`. Colour is never the sole carrier — the heading text states the
+  condition, and the amber pairs `text-amber-600 dark:text-amber-400` for both themes as the
+  panel already does. The new button is a real `<button>` in tab order.
+- **Observability and evidence:** the PR records the sweep from step 6, the passing
+  `does not decrypt to answer a status check` test as the evidence for the stated cost, and a
+  before/after screenshot of both surfaces on a damaged-vault profile.
+
+## Verification gate
+
+Targeted, in order:
+
+```bash
+npx vitest run src/lib/adapters/browser-keychain-adapter.test.ts src/lib/adapters/keychain-adapter.test.ts
+npx vitest run src/components/panels/ai-settings-content.test.tsx src/components/panels/ai-settings-damaged-vault.test.tsx
+npx vitest run src/stores/chat-store.test.ts src/components/panels/ai-chat-tab.test.tsx
+npx tsc --noEmit
+npx biome check .
+```
+
+Then the full gate:
+
+```bash
+npm run ci:local
+```
+
+E2E is opt-in in `scripts/ci-local.sh` (`--e2e`). The chat empty state is on two specs, so run
+them before handoff — either `npm run ci:local -- --e2e` or the two specs directly:
+
+```bash
+npx playwright test e2e/ai-chat.spec.ts e2e/empty-states.spec.ts
+```
+
+Only one lane runs a full-suite command at a time, and any Playwright web server started for
+these specs is stopped when the run ends (`AGENTS.md`, "Local machine resources").
+
+## Owner validation
+
+Green CI cannot decide any of these.
+
+1. **Is the trade the right one?** The fix leaves the single-damaged-record case reporting
+   "API key configured" until the next request. The plan argues that is better than a status
+   check that deletes key material. The owner is the one who accepts that residual.
+2. **Copy.** Two user-visible strings are proposed here and neither is dictated by the issue:
+   the panel's `"Key storage could not be read"` (replacing `"could not be checked"`) and the
+   chat tab's fault heading plus the `Open AI settings` button label. Read them aloud on both
+   surfaces at once; they are meant to be the same sentence in two places.
+3. **Recovery still exists and is discoverable.** On a damaged vault the panel now hides
+   "Remove API key" (status is no longer `true`). The way out is saving a fresh key, which
+   works — `installWrapKey`'s `"always"` policy clears the stranded records and mints a new
+   wrapping key. Walk it: damage the vault, open settings, read the message, save a key, send a
+   request. If that path does not feel obvious from what is on screen, the remedy sentence is
+   the thing to change, not the status logic.
+4. **A false alarm costs a status, not a credential.** Two tabs racing — one wiping or minting
+   a wrapping key between this check's `count` and its wrap-key read — can produce a fault
+   report for a vault that is fine. Nothing destructive follows from it and a re-check clears
+   it. Confirm that is acceptable rather than worth a single-transaction read.
+5. **Launch behaviour is unchanged.** A profile with no clear-text slot must still create no
+   keychain database at launch. Confirm on a fresh browser profile with devtools open.
+
+## Follow-up issues to file (not sub-issues, not in scope)
+
+Both are new issues linked to `#234`, filed at handoff, not folded in.
+
+1. **`migrateLegacyKey` erases the clear-text slot on a declined import without proving the
+   stored record is readable.** This is the hazard recorded in the second comment on `#234`.
+   `importLegacySecret` declines whenever a record already exists for the provider —
+   decryptable or not (`browser-key-vault.ts:795`) — and `migrateLegacyKey` then calls
+   `removeLegacyKey` regardless (`browser-keychain-adapter.ts:133`), so a user with a damaged
+   record plus a surviving clear-text slot loses their last readable copy. `#233` made this
+   reachable at launch. It is a **separate defect on the erase path**, not the status path:
+   none of `#234`'s acceptance criteria mention it, its fix necessarily costs a decrypt (the
+   only way to "prove the stored record is readable"), and it needs its own tests. Note what
+   this plan does to it: the `vault-corrupt` half is already refused before the erase
+   (`browser-key-vault.ts:793`) and step 1 does not change that path at all, so the remaining
+   exposure is exactly the per-record case. The comment's conclusion stands and should be
+   quoted in the new issue: the fix belongs in `migrateLegacyKey`, not in any caller's gate.
+2. **`VAULT_CORRUPT_MESSAGE` prescribes a remedy the app no longer needs.** It says "Clear this
+   site's browser data, then add your API key again", but saving a key recovers the vault in
+   place — `installWrapKey` under `"always"` clears the stranded records and mints a new key,
+   pinned by `browser-keychain-adapter.test.ts:631` ("lets the user store a new key after the
+   wrapping key is lost"). The message therefore sends a user to destroy their saved threat
+   models (`CLEARING_SITE_DATA_COST`) for something re-entry fixes. This plan deliberately does
+   not touch it: AC 1 names that exact string as what must render, and changing safety copy
+   under a bug fix hides the change. File it as its own copy issue with the test as evidence.
+
+## Specialist review
+
+- [ ] PR reviewer
+- [ ] Slop auditor
+- [ ] Security auditor — required. Cryptography, key storage, and a trust boundary
+      (`.github/instructions/security.instructions.md` applies to `src/lib/adapters/**`).
+- [ ] Threat-model expert — not applicable. No `.thf` schema, STRIDE, or threat-quality
+      surface is touched.
+
+## Replan log
+
+Append changes; do not rewrite prior decisions.
+
+| Date | Change | Evidence and reason |
+|------|--------|---------------------|
+| 2026-07-27 | Initial plan | Issue `#234` and its two comments; `main` at `24fc808`; source read at `browser-key-vault.ts:608-647`, `browser-keychain-adapter.ts:123-228`, `keychain-adapter.ts`, `tauri-keychain-adapter.ts`, `ai_commands.rs:19-56`, `keychain.rs:31-123`, `lib.rs:52-57`, `ai-settings-content.tsx:47-121,283-334,556-616`, `chat-store.ts:512-534`, `ai-chat-tab.tsx:56-145`, `app-layout.tsx:61-94`, `browser-chat-adapter.ts:327-346`; existing coverage read at `browser-keychain-adapter.test.ts:456-800,1221-1259,1770-1810` and `ai-settings-content.test.tsx:50-330`; `browser-keychain-adapter.test.ts:1222` executed green as proof that `hasKey` returns `true` on a vault `getKey` refuses |

--- a/docs/plans/234-vault-usable-status.md
+++ b/docs/plans/234-vault-usable-status.md
@@ -362,7 +362,8 @@ first if the implementer prefers a clean diff.
 - **Behavior:** loading the keychain adapter and rendering a keychain failure as user-safe text
   are done by one pair of functions that the settings panel and `chat-store` share. No
   behaviour changes.
-- **Files:** `src/lib/adapters/get-keychain-adapter.ts`,
+- **Files:** `src/lib/adapters/load-keychain-adapter.ts` (new — see the 2026-07-27 replan row;
+  the plan originally named `get-keychain-adapter.ts` and was wrong about the test harness),
   `src/components/panels/ai-settings-content.tsx`.
 - **Implementation:**
   1. Move `ADAPTER_LOAD_ERROR` and `loadAdapter` (`ai-settings-content.tsx:17-33`) into
@@ -587,6 +588,12 @@ Green CI cannot decide any of these.
    it. Confirm that is acceptable rather than worth a single-transaction read.
 5. **Launch behaviour is unchanged.** A profile with no clear-text slot must still create no
    keychain database at launch. Confirm on a fresh browser profile with devtools open.
+6. **First run in a storage-blocked profile is now a fault, not onboarding.** Private mode or
+   blocked cookies makes `openVault` reject regardless of count, so a user who has never
+   configured anything sees the fault card where they used to see "No API key configured".
+   That follows from the acceptance criteria and is arguably the better answer — inviting
+   someone to save a key that cannot be saved is the absence-claim problem again — but it is a
+   first-run product change, and it is the owner's call rather than the plan's.
 
 ## Follow-up issues to file (not sub-issues, not in scope)
 
@@ -630,3 +637,7 @@ Append changes; do not rewrite prior decisions.
 | Date | Change | Evidence and reason |
 |------|--------|---------------------|
 | 2026-07-27 | Initial plan | Issue `#234` and its two comments; `main` at `24fc808`; source read at `browser-key-vault.ts:608-647`, `browser-keychain-adapter.ts:123-228`, `keychain-adapter.ts`, `tauri-keychain-adapter.ts`, `ai_commands.rs:19-56`, `keychain.rs:31-123`, `lib.rs:52-57`, `ai-settings-content.tsx:47-121,283-334,556-616`, `chat-store.ts:512-534`, `ai-chat-tab.tsx:56-145`, `app-layout.tsx:61-94`, `browser-chat-adapter.ts:327-346`; existing coverage read at `browser-keychain-adapter.test.ts:456-800,1221-1259,1770-1810` and `ai-settings-content.test.tsx:50-330`; `browser-keychain-adapter.test.ts:1222` executed green as proof that `hasKey` returns `true` on a vault `getKey` refuses |
+| 2026-07-27 | Step 2 lands in a new `load-keychain-adapter.ts`, not in `get-keychain-adapter.ts` | The plan was wrong about the test harness. Six suites `vi.mock("@/lib/adapters/get-keychain-adapter")` with a factory returning only `getKeychainAdapter`, so extracting into that module puts the extracted code behind every one of those mocks: implemented literally, the panel suite went 24 failed / 7 passed on `No "keychainErrorText" export is defined on the ... mock`. Adding the exports to each mock factory would make `says so when the storage adapter itself will not load` assert a re-implementation rather than production code, which `tests.instructions.md` forbids; `importActual` does not help, because `loadKeychainAdapter`'s call to `getKeychainAdapter` would be a module-local binding no mock intercepts, so the real `BrowserKeychainAdapter` would be constructed and cached for the file. A sibling module that *imports* `getKeychainAdapter` crosses a module boundary the mocks do intercept. Result: 31 panel tests pass with zero assertion edits, which is what step 2's own tripwire asked for |
+| 2026-07-27 | `hasSecret`'s fault can no longer escape as a raw `DOMException`; `withVault` now opens inside its `try` | Security lane, #234 preflight. `openVault` guarded `factory.open()` and a null factory, but not the `globalThis.indexedDB` property read itself, which is a getter that throws `SecurityError` in a sandboxed iframe or storage-blocked profile — the hazard `readLegacySlot` already catches for `localStorage`. Awaited outside the `try`, that rejection bypassed the remap and would have rendered `The operation is insecure.` as the app's explanation, defeating the exact-text assertion in `ai-settings-damaged-vault.test.tsx`. Pre-existing, but this change adds a second verbatim-rendering surface reachable at mount without opening settings, so it is fixed here rather than filed |
+| 2026-07-27 | `keychainErrorText` fails closed on a rejection that is neither `Error` nor string; three comments stop crediting it with a guarantee it does not provide | Reviewer and slop lanes, independently. The function is a shape adapter — routing through it cannot establish authorship, and `String(error)` on an object renders `[object Object]` as the app's account of itself. The guarantee is real but lives upstream in `withVault`'s remap and in `key_refusal` on the Rust side; the comments now name that, because a maintainer reading "nothing unauthored can arrive" would not add a guard where one is needed |
+| 2026-07-27 | `KEY_STORAGE_UNREADABLE` exported from `keychain-adapter.ts`; both surfaces render the constant | Reviewer and slop lanes, independently. The sentence this issue exists to keep identical across two surfaces shipped as two literals coupled by nothing but a docblock claiming they matched — a copy edit to one would diverge them silently and every suite would still pass. That is #234's own defect one layer up, in copy instead of state |

--- a/src/components/layout/app-layout.tsx
+++ b/src/components/layout/app-layout.tsx
@@ -83,7 +83,7 @@ export function AppLayout() {
 					await Promise.allSettled(RESIDUE_PROVIDERS.map((name) => adapter.hasKey(name)));
 				}
 			} catch (err) {
-				// Logged rather than swallowed: the panel's `ADAPTER_LOAD_ERROR` reaches a user
+				// Logged rather than swallowed: the authored `KEYCHAIN_LOAD_ERROR` reaches a user
 				// who opens AI settings, and a permanently broken chunk has to leave a trace for
 				// one who never does. The refresh below leaves the previous value rather than
 				// claiming absence.

--- a/src/components/panels/ai-chat-tab.test.tsx
+++ b/src/components/panels/ai-chat-tab.test.tsx
@@ -21,8 +21,12 @@ const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 // transport is an inert stand-in the mocked client never touches.
 const streamConversationMock = vi.hoisted(() => vi.fn());
 // Whether the mocked keychain reports a stored key; a test flips it to reach the
-// chat view instead of the empty state.
-const keychain = vi.hoisted(() => ({ hasKey: false }));
+// chat view instead of the empty state. `rejection` is the #234 case: storage that
+// could not answer at all, which must not read as "no key configured".
+const keychain = vi.hoisted((): { hasKey: boolean; rejection: Error | null } => ({
+	hasKey: false,
+	rejection: null,
+}));
 
 vi.mock("@/lib/ai/protocol/client", () => ({
 	streamConversation: streamConversationMock,
@@ -33,7 +37,13 @@ vi.mock("@/lib/adapters/get-chat-transport", () => ({
 }));
 
 vi.mock("@/lib/adapters/get-keychain-adapter", () => ({
-	getKeychainAdapter: () => Promise.resolve({ hasKey: async () => keychain.hasKey }),
+	getKeychainAdapter: () =>
+		Promise.resolve({
+			hasKey: async () => {
+				if (keychain.rejection) throw keychain.rejection;
+				return keychain.hasKey;
+			},
+		}),
 }));
 
 function makeModel(title: string): ThreatModel {
@@ -58,6 +68,7 @@ beforeEach(() => {
 	vi.clearAllMocks();
 	localStorage.clear();
 	keychain.hasKey = false;
+	keychain.rejection = null;
 	// jsdom does not implement scrollIntoView, which the message list calls on update.
 	Element.prototype.scrollIntoView = vi.fn();
 	useDocumentRegistry.setState({
@@ -77,6 +88,8 @@ beforeEach(() => {
 		messages: [],
 		isStreaming: false,
 		error: null,
+		hasApiKey: false,
+		keyFault: null,
 		provider: "anthropic",
 	});
 });
@@ -475,5 +488,64 @@ describe("AiChatTab undo affordance", () => {
 		const undoButton = screen.getByRole("button", { name: /Undo this turn/ });
 		expect(undoButton).toBeDisabled();
 		expect(undoButton.getAttribute("title")).toContain("superseded");
+	});
+});
+
+/**
+ * #234: `checkApiKey` rejects when the vault holds records this browser cannot decrypt. The
+ * tab used to render that as "No API key configured" — the same claim the settings panel
+ * refuses to make about the same storage, so the two surfaces disagreed about one fact.
+ */
+describe("AiChatTab key storage faults", () => {
+	/**
+	 * A stand-in, not the vault's copy. The keychain is mocked here, so this suite injects the
+	 * string and reads it back — any sentence would pass, and spelling the real one would read
+	 * as a pin it is not. The vault's actual wording is pinned once, against a real vault, in
+	 * `ai-settings-damaged-vault.test.tsx`. What this suite proves is that whatever the
+	 * keychain says reaches the chat surface instead of "No API key configured".
+	 */
+	const VAULT_DAMAGED = "TEST-ONLY authored fault sentence from the keychain layer.";
+
+	function openDocument(): void {
+		const registry = useDocumentRegistry.getState();
+		const id = registry.createDocument({
+			model: makeModel("A"),
+			filePath: null,
+			pendingLayout: null,
+		});
+		registry.activateDocument(id);
+	}
+
+	it("shows the storage fault instead of claiming no key is configured", async () => {
+		keychain.rejection = new Error(VAULT_DAMAGED);
+		openDocument();
+
+		await act(async () => {
+			render(<AiChatTab />);
+		});
+
+		// The heading is the settings panel's status text verbatim, so the two surfaces state
+		// one fact in one sentence, and the vault's authored remedy is what the user reads.
+		expect(screen.getByTestId("key-storage-fault")).toBeInTheDocument();
+		expect(screen.getByText("Key storage could not be read")).toBeInTheDocument();
+		expect(screen.getByText(VAULT_DAMAGED)).toBeInTheDocument();
+		expect(screen.queryByText("No API key configured")).toBeNull();
+		expect(screen.getByRole("button", { name: "Open AI settings" })).toBeInTheDocument();
+	});
+
+	it("still shows the empty state when storage answers that there is no key", async () => {
+		keychain.hasKey = false;
+		openDocument();
+
+		await act(async () => {
+			render(<AiChatTab />);
+		});
+
+		// Without this the fault branch could swallow the ordinary unconfigured path and no
+		// test would notice: a first-run user has no key and no fault, and must be invited to
+		// add one rather than warned about storage.
+		expect(screen.getByText("No API key configured")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Configure API Key" })).toBeInTheDocument();
+		expect(screen.queryByTestId("key-storage-fault")).toBeNull();
 	});
 });

--- a/src/components/panels/ai-chat-tab.test.tsx
+++ b/src/components/panels/ai-chat-tab.test.tsx
@@ -525,12 +525,28 @@ describe("AiChatTab key storage faults", () => {
 		});
 
 		// The heading is the settings panel's status text verbatim, so the two surfaces state
-		// one fact in one sentence, and the vault's authored remedy is what the user reads.
+		// one fact in one sentence, and whatever the keychain authored is what the user reads.
 		expect(screen.getByTestId("key-storage-fault")).toBeInTheDocument();
 		expect(screen.getByText("Key storage could not be read")).toBeInTheDocument();
 		expect(screen.getByText(VAULT_DAMAGED)).toBeInTheDocument();
 		expect(screen.queryByText("No API key configured")).toBeNull();
 		expect(screen.getByRole("button", { name: "Open AI settings" })).toBeInTheDocument();
+	});
+
+	it("shows the fault even when the rejection carries no message of its own", async () => {
+		// The fault branch tests `keyFault` for truthiness, so an empty message would fall
+		// through to the empty state and claim no key is configured over a vault that just
+		// faulted — this issue's own defect, arriving through the code added to prevent it.
+		keychain.rejection = new Error("");
+		openDocument();
+
+		await act(async () => {
+			render(<AiChatTab />);
+		});
+
+		expect(screen.getByTestId("key-storage-fault")).toBeInTheDocument();
+		expect(screen.queryByText("No API key configured")).toBeNull();
+		expect(screen.getByText(/does not recognize/)).toBeInTheDocument();
 	});
 
 	it("still shows the empty state when storage answers that there is no key", async () => {

--- a/src/components/panels/ai-chat-tab.tsx
+++ b/src/components/panels/ai-chat-tab.tsx
@@ -156,8 +156,10 @@ export function AiChatTab() {
  * red belongs to a credential exposed in clear text, and this is a loss of function.
  *
  * `role="alert"` is assertive deliberately. This replaces the whole conversation surface after
- * a check the user did not initiate, so a screen-reader user who is told about it late has
- * already been typing into a panel that was never going to send.
+ * a check the user did not initiate — on a provider switch, or a re-check that newly fails
+ * while the transcript is on screen, a screen-reader user told about it late has already been
+ * typing into a panel that was never going to send. (On first mount there is no input yet, so
+ * that path is the one that earns the interruption.)
  */
 function KeyStorageFault({ message, onConfigure }: { message: string; onConfigure: () => void }) {
 	return (

--- a/src/components/panels/ai-chat-tab.tsx
+++ b/src/components/panels/ai-chat-tab.tsx
@@ -1,5 +1,6 @@
 import {
 	AlertCircle,
+	AlertTriangle,
 	Bot,
 	Check,
 	ChevronDown,
@@ -17,6 +18,7 @@ import {
 	X,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { KEY_STORAGE_UNREADABLE } from "@/lib/adapters/keychain-adapter";
 import {
 	extractLegacyActions,
 	extractLegacyThreats,
@@ -54,6 +56,7 @@ export function AiChatTab() {
 	const filePath = useModelStore((s) => s.filePath);
 	const activeDocumentId = useDocumentRegistry((s) => s.activeDocumentId);
 	const hasApiKey = useChatStore((s) => s.hasApiKey);
+	const keyFault = useChatStore((s) => s.keyFault);
 	const checkApiKey = useChatStore((s) => s.checkApiKey);
 	const loadSessionsForFile = useChatStore((s) => s.loadSessionsForFile);
 	const migrateSessionKey = useChatStore((s) => s.migrateSessionKey);
@@ -118,7 +121,65 @@ export function AiChatTab() {
 				</button>
 			</div>
 
-			{!hasApiKey ? <EmptyState onConfigure={openAiSettings} /> : <ChatView />}
+			{/* The fault outranks the absence: it is the stronger and truer claim about the same
+			    storage, mirroring the documented precedence in the settings panel's
+			    `statusToneOf`. Reporting "no API key configured" over a vault nobody could read
+			    points the user at entering a key, which is the one thing that will not help. */}
+			{keyFault ? (
+				<KeyStorageFault message={keyFault} onConfigure={openAiSettings} />
+			) : !hasApiKey ? (
+				<EmptyState onConfigure={openAiSettings} />
+			) : (
+				<ChatView />
+			)}
+		</div>
+	);
+}
+
+/**
+ * What the chat surface shows when key storage could not be read at all (#234).
+ *
+ * The heading is {@link KEY_STORAGE_UNREADABLE}, the same constant the settings panel's status
+ * row renders, so a user who checks both surfaces reads one sentence rather than two accounts
+ * of one fault. Shared as a constant rather than as matching literals: this issue exists
+ * because two surfaces disagreed about one stored key, and a copy edit that reached only one
+ * of them would be the same defect in a quieter form.
+ *
+ * The remedy is the keychain's own authored message, rendered verbatim — no copy is invented
+ * here. What keeps an internal string out of it is upstream, not this component: every browser
+ * fault is remapped to an authored `KeyVaultError` by `withVault`, and the desktop adapter
+ * relays a sentence authored in Rust.
+ *
+ * The button promises exactly what it does. It opens settings; it does not promise a fix,
+ * because for an `unavailable` fault — an insecure origin with no Web Crypto — entering a key
+ * there changes nothing. Amber rather than destructive red for the reason the panel records:
+ * red belongs to a credential exposed in clear text, and this is a loss of function.
+ *
+ * `role="alert"` is assertive deliberately. This replaces the whole conversation surface after
+ * a check the user did not initiate, so a screen-reader user who is told about it late has
+ * already been typing into a panel that was never going to send.
+ */
+function KeyStorageFault({ message, onConfigure }: { message: string; onConfigure: () => void }) {
+	return (
+		<div
+			role="alert"
+			data-testid="key-storage-fault"
+			className="flex flex-1 flex-col items-center justify-center gap-3 py-8 text-center"
+		>
+			<AlertTriangle className="h-10 w-10 text-amber-600 dark:text-amber-400" />
+			<div>
+				<p className="text-xs font-medium text-amber-600 dark:text-amber-400">
+					{KEY_STORAGE_UNREADABLE}
+				</p>
+				<p className="mt-1 text-[10px] text-muted-foreground/70">{message}</p>
+			</div>
+			<button
+				type="button"
+				onClick={onConfigure}
+				className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+			>
+				Open AI settings
+			</button>
 		</div>
 	);
 }

--- a/src/components/panels/ai-settings-content.test.tsx
+++ b/src/components/panels/ai-settings-content.test.tsx
@@ -216,7 +216,7 @@ describe("key storage that cannot answer", () => {
 		// reported as "No API key configured" — reassurance in exactly the wrong direction,
 		// on a surface whose whole job is telling the user where their credential is.
 		expect(screen.queryByText("No API key configured")).toBeNull();
-		expect(screen.getByText("Key storage could not be checked")).toBeInTheDocument();
+		expect(screen.getByText("Key storage could not be read")).toBeInTheDocument();
 		expect(screen.getByText("Key storage in this browser is damaged.")).toBeInTheDocument();
 	});
 
@@ -243,7 +243,7 @@ describe("key storage that cannot answer", () => {
 		);
 		expect(control).toHaveTextContent("Try removing it again");
 		// A readable clear-text copy outranks an unreadable vault in the status row. Both facts
-		// are true at once here, and "Key storage could not be checked" is the weaker one: it
+		// are true at once here, and "Key storage could not be read" is the weaker one: it
 		// describes the encrypted record while a usable credential sits in clear text.
 		expect(screen.getByText("Clear-text API key still in this browser")).toBeInTheDocument();
 
@@ -298,6 +298,27 @@ describe("key storage that cannot answer", () => {
 			expect.stringContaining("Key storage adapter failed to load"),
 			expect.objectContaining({ message: expect.stringContaining("dynamically imported") }),
 		);
+	});
+
+	it("does not render an object as its own explanation", async () => {
+		// A rejection that is neither an `Error` nor a string came from no layer that authored
+		// a message. `String(error)` would put `[object Object]` on screen as the app's account
+		// of what went wrong, so the shape adapter fails closed onto authored copy instead.
+		getAdapter = async () => ({
+			setKey: async () => undefined,
+			hasKey: async () => {
+				throw { code: 17, name: "InvalidStateError" };
+			},
+			deleteKey: async () => undefined,
+		});
+
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+
+		expect(screen.getByText(/does not recognise/)).toBeInTheDocument();
+		expect(screen.queryByText(/object Object/)).not.toBeInTheDocument();
+		expect(screen.queryByText(/InvalidStateError/)).not.toBeInTheDocument();
 	});
 
 	it("does not put a bundler failure in front of the user when saving", async () => {

--- a/src/components/panels/ai-settings-content.test.tsx
+++ b/src/components/panels/ai-settings-content.test.tsx
@@ -316,7 +316,7 @@ describe("key storage that cannot answer", () => {
 			render(<AiSettingsContent />);
 		});
 
-		expect(screen.getByText(/does not recognise/)).toBeInTheDocument();
+		expect(screen.getByText(/does not recognize/)).toBeInTheDocument();
 		expect(screen.queryByText(/object Object/)).not.toBeInTheDocument();
 		expect(screen.queryByText(/InvalidStateError/)).not.toBeInTheDocument();
 	});

--- a/src/components/panels/ai-settings-content.tsx
+++ b/src/components/panels/ai-settings-content.tsx
@@ -1,36 +1,18 @@
 import { AlertTriangle, Eye, EyeOff, Loader2, RefreshCw, Trash2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
-import { getKeychainAdapter } from "@/lib/adapters/get-keychain-adapter";
 import {
 	CLEARING_SITE_DATA_COST,
+	KEY_STORAGE_UNREADABLE,
 	LEGACY_RETAINED,
 	type LegacyResidue,
 } from "@/lib/adapters/keychain-adapter";
+import { keychainErrorText, loadKeychainAdapter } from "@/lib/adapters/load-keychain-adapter";
 import { getDefaultModelId, getModelById, getModelsForProvider } from "@/lib/ai-models";
 import { isTauri } from "@/lib/platform";
 import { cn } from "@/lib/utils";
 import { type AiProvider, useChatStore } from "@/stores/chat-store";
 import { useKeyResidueStore } from "@/stores/key-residue-store";
 import { useSettingsStore } from "@/stores/settings-store";
-
-/** Authored so a bundler or network detail never reaches the user as an error message. */
-const ADAPTER_LOAD_ERROR = "Key storage could not be loaded. Reload the page and try again.";
-
-/**
- * Load the keychain adapter, replacing a module-load failure with an authored message.
- *
- * Adapters author their own user-safe messages; a failure to load one does not, and would
- * otherwise render a bundle URL and a hash as the explanation. The cause is logged rather
- * than dropped, so a real chunk-load regression is still diagnosable from a bug report.
- */
-async function loadAdapter(): Promise<Awaited<ReturnType<typeof getKeychainAdapter>>> {
-	try {
-		return await getKeychainAdapter();
-	} catch (err) {
-		console.warn("Key storage adapter failed to load:", err);
-		throw new Error(ADAPTER_LOAD_ERROR);
-	}
-}
 
 /**
  * The providers this panel offers, and the company each key belongs to.
@@ -48,11 +30,12 @@ const PROVIDERS: { value: AiProvider; label: string; vendor: string }[] = [
  * What the panel knows about a provider's stored key.
  *
  * Neither non-boolean member is the same as `false`. `"unknown"` is a `hasKey` that rejected —
- * an unreadable vault, a record that will not decrypt — which used to be collapsed into "no API
- * key configured", reassurance in exactly the wrong direction. `"unchecked"` is the seed value
- * before the mount check has answered at all, which used to be `false` for the same reason
- * `useState` needs something: it made the panel assert that the encrypted record was gone during
- * every mount, over a vault that may well hold a key.
+ * a check that could not answer, or one that answered that this browser cannot read storage at
+ * all (#234: a vault holding records whose wrapping key is gone) — which used to be collapsed
+ * into "no API key configured", reassurance in exactly the wrong direction. `"unchecked"` is the
+ * seed value before the mount check has answered at all, which used to be `false` for the same
+ * reason `useState` needs something: it made the panel assert that the encrypted record was gone
+ * during every mount, over a vault that may well hold a key.
  */
 type KeyStatus = boolean | "unknown" | "unchecked";
 
@@ -63,6 +46,12 @@ type KeyStatus = boolean | "unknown" | "unchecked";
  * is gone, but a usable credential is still in this browser. Neither a check that failed nor one
  * that has not answered yet is reported that way either — that sentence is a claim about storage
  * that answered.
+ *
+ * `"unknown"` covers both a check that could not run and one that ran and reported storage as
+ * unreadable. They share a tone because they share a remedy — nothing the user types into this
+ * panel fixes either — and amber rather than destructive red because a damaged vault is a loss
+ * of function, while red is owned by `"retained"`, a live credential exposed in clear text. That
+ * is why the exposure outranks it above.
  */
 type StatusTone = "configured" | "retained" | "unknown" | "checking" | "empty";
 
@@ -77,7 +66,7 @@ function statusToneOf(status: KeyStatus, residue: LegacyResidue): StatusTone {
 const STATUS_TEXT: Record<StatusTone, string> = {
 	configured: "API key configured",
 	retained: "Clear-text API key still in this browser",
-	unknown: "Key storage could not be checked",
+	unknown: KEY_STORAGE_UNREADABLE,
 	checking: "Checking key storage…",
 	empty: "No API key configured",
 };
@@ -97,15 +86,6 @@ const STATUS_TEXT_CLASS: Record<StatusTone, string> = {
 	checking: "text-muted-foreground",
 	empty: "text-muted-foreground",
 };
-
-/**
- * Render a keychain failure for display. Adapters throw different shapes — the browser vault
- * throws an `Error` carrying an authored, user-safe message, while the Tauri adapter rejects
- * with a string from `invoke` — so the message is preferred when there is one.
- */
-function errorText(error: unknown): string {
-	return error instanceof Error ? error.message : String(error);
-}
 
 /**
  * Whether `error` reports a removal that succeeded but left a clear-text copy behind.
@@ -284,7 +264,7 @@ export function AiSettingsContent() {
 		let current = true;
 		async function checkStatus() {
 			try {
-				const adapter = await loadAdapter();
+				const adapter = await loadKeychainAdapter();
 				if (!current) return;
 				// Settled independently so one provider's failure does not erase the other's
 				// status. Unreadable storage rejects for both, and a vault too damaged to migrate
@@ -320,11 +300,11 @@ export function AiSettingsContent() {
 				});
 				const failure = fresh.find(([, answer]) => answer.status === "rejected")?.[1];
 				if (failure?.status === "rejected") {
-					setMessage({ type: "error", text: errorText(failure.reason) });
+					setMessage({ type: "error", text: keychainErrorText(failure.reason) });
 				}
 			} catch (err) {
 				// Only the adapter load rejects here; `allSettled` never does.
-				if (current) setMessage({ type: "error", text: errorText(err) });
+				if (current) setMessage({ type: "error", text: keychainErrorText(err) });
 			}
 		}
 		void checkStatus();
@@ -349,7 +329,7 @@ export function AiSettingsContent() {
 		setMessage(null);
 
 		try {
-			const adapter = await loadAdapter();
+			const adapter = await loadKeychainAdapter();
 			await adapter.setKey(provider, apiKey.trim());
 			// Recorded once the write has actually landed, so a save that fails does not leave
 			// the mount check discarded and the panel stuck reporting no key at all.
@@ -363,7 +343,7 @@ export function AiSettingsContent() {
 			setMessage({ type: "success", text: successText });
 			await checkApiKey(provider);
 		} catch (err) {
-			setMessage({ type: "error", text: errorText(err) });
+			setMessage({ type: "error", text: keychainErrorText(err) });
 		} finally {
 			setSaving(false);
 			// `setKey` attempts the clear-text erase and deliberately ignores the outcome, so a
@@ -389,7 +369,7 @@ export function AiSettingsContent() {
 		}
 
 		try {
-			const adapter = await loadAdapter();
+			const adapter = await loadKeychainAdapter();
 			await adapter.deleteKey(target);
 			recordRemoval();
 			const successText = isTauri() ? "API key removed." : "API key removed from this browser.";
@@ -404,7 +384,7 @@ export function AiSettingsContent() {
 				recordRemoval();
 				await syncTransport();
 			}
-			setMessage({ type: "error", text: errorText(err) });
+			setMessage({ type: "error", text: keychainErrorText(err) });
 		} finally {
 			setBusy(target, false);
 			// The state transition this issue is about. Covers the retained rejection, a clean
@@ -431,7 +411,7 @@ export function AiSettingsContent() {
 		setMessage(null);
 		let reported = false;
 		try {
-			const adapter = await loadAdapter();
+			const adapter = await loadKeychainAdapter();
 			const present = await adapter.hasKey(target);
 			// This answer is newer than any mount check still in flight, so it outranks it.
 			mutated.current.add(target);
@@ -439,7 +419,7 @@ export function AiSettingsContent() {
 			if (target === provider) await checkApiKey(provider);
 		} catch (err) {
 			setKeyStatus((prev) => ({ ...prev, [target]: "unknown" }));
-			setMessage({ type: "error", text: errorText(err) });
+			setMessage({ type: "error", text: keychainErrorText(err) });
 			reported = true;
 		} finally {
 			setBusy(target, false);

--- a/src/components/panels/ai-settings-damaged-vault.test.tsx
+++ b/src/components/panels/ai-settings-damaged-vault.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * #234: the AI settings panel over a real, damaged browser key vault.
+ *
+ * The panel suite in `ai-settings-content.test.tsx` mocks the keychain adapter, so it can pin
+ * how the panel renders a rejection but not that a damaged vault produces one. This file
+ * composes the real {@link BrowserKeychainAdapter}, real IndexedDB and real Web Crypto with
+ * the rendered panel, so the property under test is end to end: a profile whose wrapping key
+ * is gone while its encrypted record survives must not read as "API key configured", and must
+ * not read as "No API key configured" either.
+ *
+ * Separate from that suite deliberately. It needs `fake-indexeddb/auto` installed as the
+ * global factory, and doing that inside the mocked suite would change the environment for
+ * eight hundred lines of tests that must not have one.
+ * `src/lib/persistence/no-key-leakage.test.ts` is the precedent for a property-named file that
+ * composes real storage with rendered components.
+ */
+
+import { act, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "fake-indexeddb/auto";
+import { BrowserKeychainAdapter } from "@/lib/adapters/browser-keychain-adapter";
+import { resetKeyVault, writeWrapKeyStore } from "@/lib/adapters/test-fixtures/key-vault";
+import { useChatStore } from "@/stores/chat-store";
+import { useKeyResidueStore } from "@/stores/key-residue-store";
+import { useSettingsStore } from "@/stores/settings-store";
+import { DEFAULT_USER_SETTINGS } from "@/types/settings";
+import { AiSettingsContent } from "./ai-settings-content";
+
+/**
+ * The vault's authored sentence for a damaged vault, written out rather than imported.
+ *
+ * `VAULT_CORRUPT_MESSAGE` is private to `browser-key-vault.ts`, and exporting it so a test
+ * could compare against it would make this assertion tautological — the test would agree with
+ * whatever the module said. Spelled out here, it fails if the copy changes, which is the
+ * point: this is the exact text acceptance criterion 5 requires the user to see.
+ */
+const VAULT_DAMAGED_SENTENCE =
+	"Encrypted key storage in this browser is damaged. Clear this site's browser data, then add your API key again.";
+
+const SECRET = "sk-ant-test-0123456789abcdef";
+
+vi.mock("@/lib/adapters/get-keychain-adapter", () => ({
+	getKeychainAdapter: async () => new BrowserKeychainAdapter(),
+}));
+
+beforeEach(() => {
+	resetKeyVault();
+	localStorage.clear();
+	useChatStore.setState({ provider: "anthropic" });
+	useKeyResidueStore.setState({ residue: { anthropic: null, openai: null } });
+	useSettingsStore.setState({ settings: { ...DEFAULT_USER_SETTINGS } });
+});
+
+describe("AI settings over a vault this browser cannot read", () => {
+	it("reports the fault instead of reporting the stored key as configured", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		// The state the issue describes: the ciphertext survives, the wrapping key does not.
+		await writeWrapKeyStore([]);
+
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+
+		// Awaited rather than read synchronously: the real vault answers over several IndexedDB
+		// task turns, so the panel is still on "Checking key storage…" when `render` returns.
+		expect(await screen.findByText("Key storage could not be read")).toBeInTheDocument();
+		// The defect, stated as an assertion: a green dot over a credential nothing can
+		// decrypt, which the user only discovers when a request fails.
+		expect(screen.queryByText("API key configured")).toBeNull();
+		// And not the opposite claim either. The record is still there; "no API key" points the
+		// user at entering one, and hides that their stored credential is stranded.
+		expect(screen.queryByText("No API key configured")).toBeNull();
+
+		// The remedy reaches the user, and nothing else does. Compared exactly rather than by
+		// substring: a raw `DOMException` appended to the authored sentence would still satisfy
+		// a `/damaged/` match, and this is the check that a vault fault carries no internal
+		// detail to the UI.
+		const messageBlock = screen.getByText(/Encrypted key storage in this browser is damaged/);
+		expect(messageBlock.textContent).toBe(VAULT_DAMAGED_SENTENCE);
+
+		// `deleteKey` writes a permanent revocation marker. A status the panel could not read is
+		// not a licence to offer that over a record nobody has successfully read.
+		expect(screen.queryByRole("button", { name: "Remove API key" })).toBeNull();
+	});
+
+	it("still reports a healthy vault's stored key as configured", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+
+		await act(async () => {
+			render(<AiSettingsContent />);
+		});
+
+		// Without this, the fault branch could report every vault as damaged and the case above
+		// would still pass. The status check has to keep answering for the ordinary profile.
+		expect(await screen.findByText("API key configured")).toBeInTheDocument();
+		expect(screen.queryByText("Key storage could not be read")).toBeNull();
+		expect(screen.queryByText(/Encrypted key storage in this browser is damaged/)).toBeNull();
+	});
+});

--- a/src/lib/adapters/browser-key-vault.ts
+++ b/src/lib/adapters/browser-key-vault.ts
@@ -491,16 +491,24 @@ function installWrapKey(
  * Anything that is not already a {@link KeyVaultError} is remapped, so a raw `DOMException`
  * from `transaction()` or a Web Crypto rejection cannot reach the UI with internal detail
  * attached. Only messages authored in this module are ever surfaced.
+ *
+ * Opening is inside the `try` for that reason and not by accident. `openVault` guards the
+ * throws it anticipates, but reading `globalThis.indexedDB` is itself a getter that throws
+ * `SecurityError` in a sandboxed iframe or a storage-blocked profile — the same hazard
+ * `readLegacySlot` catches one layer up for `localStorage`. Awaited outside the `try`, that
+ * rejection would bypass the remap and render `The operation is insecure.` as the app's
+ * explanation of itself.
  */
 async function withVault<T>(operation: (db: IDBDatabase) => Promise<T>): Promise<T> {
-	const db = await openVault();
+	let db: IDBDatabase | undefined;
 	try {
+		db = await openVault();
 		return await operation(db);
 	} catch (error) {
 		if (error instanceof KeyVaultError) throw error;
 		throw unavailable();
 	} finally {
-		db.close();
+		db?.close();
 	}
 }
 
@@ -637,12 +645,42 @@ export async function getSecret(id: string): Promise<string | null> {
 	});
 }
 
-/** Report whether a secret is stored for `id` without decrypting it. */
+/**
+ * Report whether a secret is stored for `id` that this browser could still decrypt.
+ *
+ * `true` establishes two things: a record exists, and the vault holds the material needed to
+ * read one. It does **not** establish that this particular record decrypts — a truncated or
+ * tampered ciphertext under a healthy wrapping key still answers `true` here, and is only
+ * discovered by {@link getSecret}, which is the read the user asked for and the only place
+ * allowed to discard a record on that evidence. Claiming more would mean decrypting on a
+ * status path, and then deleting key material from one; see `docs/plans/234-vault-usable-status.md`.
+ *
+ * Nothing here decrypts, writes, or deletes. `readWrapKey` is an IndexedDB `get` plus a shape
+ * check on the returned handle, so a status check costs no cryptographic operation.
+ *
+ * The order is load-bearing. The count gates both later checks, so a provider with nothing
+ * stored still answers `false` on a damaged vault instead of inheriting a fault that belongs
+ * to another provider's record — "no key configured" is the truth for a provider that has
+ * nothing to be unable to read.
+ *
+ * The count and the wrap-key read are separate transactions, as {@link getSecret} also does.
+ * The only thing that split gives up is snapshot consistency against a concurrent tab minting
+ * or wiping a wrapping key between them, which can misreport a *status* and never licenses a
+ * destructive action; a re-check clears it.
+ *
+ * @throws KeyVaultError with reason `vault-corrupt` when a record is stored but the wrapping
+ * key is missing or unusable, or `unavailable` when Web Crypto is not usable here. A caller
+ * must not read either rejection as "no key is stored": the record is still there, and
+ * re-entering a key is not what fixes an insecure origin.
+ */
 export async function hasSecret(id: string): Promise<boolean> {
 	return withVault(async (db) => {
 		const store = db.transaction(STORE_SECRETS, "readonly").objectStore(STORE_SECRETS);
 		const count = await awaitRequest(store.count(id));
-		return count > 0;
+		if (count === 0) return false;
+		requireSubtle();
+		if (!(await readWrapKey(db))) throw vaultCorrupt();
+		return true;
 	});
 }
 

--- a/src/lib/adapters/browser-keychain-adapter.test.ts
+++ b/src/lib/adapters/browser-keychain-adapter.test.ts
@@ -4,7 +4,7 @@ import { KEY_VAULT_DB_NAME, KEY_VAULT_DB_VERSION, KeyVaultError } from "./browse
 import { BrowserKeychainAdapter } from "./browser-keychain-adapter";
 import { CLEARING_SITE_DATA_COST, LEGACY_RETAINED } from "./keychain-adapter";
 import { yieldHostTask } from "./test-fixtures/host-task";
-import { resetKeyVault } from "./test-fixtures/key-vault";
+import { openVaultDb, resetKeyVault, writeWrapKeyStore } from "./test-fixtures/key-vault";
 
 /**
  * #133: browser BYOK keys are encrypted at rest under a non-extractable wrapping key.
@@ -88,15 +88,6 @@ function describeStoredValue(value: unknown): string {
 	return Object.values(value).map(describeStoredValue).join(",");
 }
 
-/** Open the vault database directly, to inspect or damage it the way a test needs. */
-async function openVaultDb(): Promise<IDBDatabase> {
-	return new Promise<IDBDatabase>((resolve, reject) => {
-		const request = globalThis.indexedDB.open(KEY_VAULT_DB_NAME);
-		request.onsuccess = () => resolve(request.result);
-		request.onerror = () => reject(request.error);
-	});
-}
-
 /**
  * Empty the wrap-key store immediately after the next read of it, then stop.
  *
@@ -150,21 +141,6 @@ async function writeMetaValue(key: string, value: unknown): Promise<void> {
 		tx.objectStore("meta").put(value, key);
 		tx.oncomplete = () => resolve();
 		tx.onerror = () => reject(tx.error);
-	});
-	db.close();
-}
-
-/** Replace the contents of the wrap-key store, simulating a damaged vault. */
-async function writeWrapKeyStore(entries: [unknown, string][]): Promise<void> {
-	const db = await openVaultDb();
-	await new Promise<void>((resolve, reject) => {
-		const tx = db.transaction("wrap-key", "readwrite");
-		const store = tx.objectStore("wrap-key");
-		store.clear();
-		for (const [value, key] of entries) store.put(value, key);
-		tx.oncomplete = () => resolve();
-		tx.onerror = () => reject(tx.error);
-		tx.onabort = () => reject(tx.error);
 	});
 	db.close();
 }
@@ -1238,8 +1214,10 @@ describe("a wrapping key of the wrong shape", () => {
 		const error = await adapter.getKey("anthropic").catch((caught: unknown) => caught);
 
 		expect((error as KeyVaultError).reason).toBe("vault-corrupt");
-		// The record survives, so restoring the correct wrapping key would recover it.
-		expect(await adapter.hasKey("anthropic")).toBe(true);
+		// The record survives, so restoring the correct wrapping key would recover it. Observed
+		// by counting rather than by `hasKey`, which used to answer `true` here and thereby
+		// reported an unreadable credential as configured (#234).
+		expect(await countSecrets()).toBe(1);
 	});
 
 	it("refuses to save under it rather than reporting a save that cannot be read back", async () => {
@@ -1254,6 +1232,105 @@ describe("a wrapping key of the wrong shape", () => {
 		await expect(adapter.setKey("anthropic", "sk-ant-second")).rejects.toBeInstanceOf(
 			KeyVaultError,
 		);
+	});
+});
+
+/**
+ * #234: a status check answered "is there a record", never "could this browser read one", so a
+ * profile that lost its wrapping key while its ciphertext survived was reported as configured.
+ * The check establishes the vault's preconditions now — and only those. It still performs no
+ * decryption and still deletes nothing, because a status check that destroys key material is a
+ * worse defect than the one it would close.
+ */
+describe("a status check over a vault that cannot decrypt", () => {
+	it("reports a stored key the vault can no longer decrypt as a fault, not as configured", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		await writeWrapKeyStore([]);
+
+		await expect(adapter.hasKey("anthropic")).rejects.toMatchObject({
+			reason: "vault-corrupt",
+		});
+		// Reported without touching the record: restoring the profile's storage restores the
+		// key, and nothing a user only looked at may delete a credential.
+		expect(await countSecrets()).toBe(1);
+	});
+
+	it("reports a wrapping key of the wrong shape as a fault", async () => {
+		const encryptOnly = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, false, [
+			"encrypt",
+		]);
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		await writeWrapKeyStore([[encryptOnly, "aes-gcm-256-v1"]]);
+
+		// A key that is present but cannot decrypt is the same fact as one that is gone, and
+		// `readWrapKey` reaches it down a different branch — a throw rather than a `null`.
+		await expect(adapter.hasKey("anthropic")).rejects.toMatchObject({
+			reason: "vault-corrupt",
+		});
+		expect(await countSecrets()).toBe(1);
+	});
+
+	it("still answers false for a provider with no record while another's is stranded", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		await writeWrapKeyStore([]);
+
+		// The wrapping key is shared, so the damage is vault-wide — but a provider with nothing
+		// stored has nothing it cannot read. Reporting a fault for it would put a storage
+		// warning on a provider the user never configured.
+		expect(await adapter.hasKey("openai")).toBe(false);
+	});
+
+	it("does not decrypt to answer a status check", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		const decrypt = vi.spyOn(crypto.subtle, "decrypt");
+
+		expect(await adapter.hasKey("anthropic")).toBe(true);
+		// The cost of the check, pinned rather than asserted in prose: a status check reads the
+		// wrap-key handle's shape and never runs AES-GCM, so it stays off the crypto path even
+		// though the settings panel runs it on mount for every provider.
+		expect(decrypt).not.toHaveBeenCalled();
+	});
+
+	it("reports a stored key as unreadable when Web Crypto is unavailable", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		vi.spyOn(globalThis.crypto, "subtle", "get").mockReturnValue(
+			undefined as unknown as SubtleCrypto,
+		);
+
+		// `crypto.subtle` is exposed only in secure contexts, so an `http://` deployment has
+		// none — and there no record is decryptable, which is the same vault-level fact as a
+		// missing wrapping key. Entering a key would not help, so it must not read as absence.
+		await expect(adapter.hasKey("anthropic")).rejects.toMatchObject({
+			reason: "unavailable",
+		});
+		// The other half of the count gate. `requireSubtle` sits below the count, so a provider
+		// with nothing stored still answers "no key" on an insecure origin rather than being
+		// told storage is broken — which would be a fault report about a record that does not
+		// exist. Hoisting `requireSubtle` above the count is what this catches.
+		expect(await adapter.hasKey("openai")).toBe(false);
+		vi.restoreAllMocks();
+		expect(await countSecrets()).toBe(1);
+	});
+
+	it("reports a per-record decryption failure only once a read has established it", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		await corruptStoredRecord("anthropic");
+
+		// The deliberate boundary of the fix, written down so a later reader does not assume
+		// the per-record case is covered. The wrapping key is healthy, so only a decrypt could
+		// reveal this record's damage — and a decrypt on the status path would have to either
+		// delete the record from a render, or report a fault the next `getKey` contradicts.
+		expect(await adapter.hasKey("anthropic")).toBe(true);
+		// The read the user asked for is where it is established, and where the record is
+		// dropped. The panel is honest from then on.
+		expect(await adapter.getKey("anthropic")).toBeNull();
+		expect(await adapter.hasKey("anthropic")).toBe(false);
 	});
 });
 

--- a/src/lib/adapters/browser-keychain-adapter.test.ts
+++ b/src/lib/adapters/browser-keychain-adapter.test.ts
@@ -386,6 +386,34 @@ describe("failing closed when encrypted storage is unavailable", () => {
 		expect((error as KeyVaultError).message).not.toContain("IDBFactory");
 	});
 
+	it("surfaces a user-safe message when the storage factory itself refuses to be read", async () => {
+		// `open()` throwing is the guarded case. Reading `globalThis.indexedDB` at all is not:
+		// it is a getter, and in a sandboxed iframe or a storage-blocked profile it throws
+		// before there is a factory to call. That rejection is why `withVault` opens inside its
+		// own `try` — awaited outside it, the raw `SecurityError` bypasses the remap and the app
+		// explains itself to the user with "The operation is insecure."
+		const real = Object.getOwnPropertyDescriptor(globalThis, "indexedDB");
+		// `defineProperty`, not `vi.spyOn(…, "get")`: `fake-indexeddb/auto` installs
+		// `indexedDB` as a data property, and an accessor spy over one throws.
+		Object.defineProperty(globalThis, "indexedDB", {
+			configurable: true,
+			get() {
+				throw new DOMException("The operation is insecure.", "SecurityError");
+			},
+		});
+
+		try {
+			const adapter = new BrowserKeychainAdapter();
+			const error = await adapter.hasKey("anthropic").catch((caught: unknown) => caught);
+
+			expect(error).toBeInstanceOf(KeyVaultError);
+			expect((error as KeyVaultError).reason).toBe("unavailable");
+			expect((error as KeyVaultError).message).not.toContain("insecure");
+		} finally {
+			if (real) Object.defineProperty(globalThis, "indexedDB", real);
+		}
+	});
+
 	it("redacts a failure raised after the database is open", async () => {
 		// `open()` succeeding is not the only way in. A vault database that already exists at
 		// the expected version but has no stores opens cleanly and then raises a real

--- a/src/lib/adapters/browser-keychain-adapter.ts
+++ b/src/lib/adapters/browser-keychain-adapter.ts
@@ -193,6 +193,16 @@ export class BrowserKeychainAdapter implements KeychainAdapter {
 		});
 	}
 
+	/**
+	 * Report whether this provider has a stored key this browser could still read.
+	 *
+	 * Rejects rather than answering `false` when the vault holds a record but cannot produce
+	 * the material to decrypt any of it — a lost or damaged wrapping key, or an origin with no
+	 * Web Crypto. A caller must not collapse that rejection into "no API key configured": the
+	 * record is still stored, nothing has been deleted, and entering a key is not what fixes an
+	 * insecure origin. It never decrypts, so a record damaged under a healthy wrapping key
+	 * still answers `true` until {@link BrowserKeychainAdapter.getKey} reads it.
+	 */
 	async hasKey(provider: AiProvider): Promise<boolean> {
 		return withProviderLock(provider, async () => {
 			await migrateLegacyKey(provider);

--- a/src/lib/adapters/keychain-adapter.ts
+++ b/src/lib/adapters/keychain-adapter.ts
@@ -18,7 +18,20 @@ import type { AiProvider } from "@/stores/chat-store";
 export interface KeychainAdapter {
 	/** Store an API key for a provider. */
 	setKey(provider: AiProvider, key: string): Promise<void>;
-	/** Check if an API key exists for a provider. */
+	/**
+	 * Check if an API key exists for a provider.
+	 *
+	 * Rejecting is part of the contract on both platforms, and a rejection is not `false`. A
+	 * caller that collapses one into "no API key configured" makes a claim about storage that
+	 * never answered, and points the user at entering a key when entering a key is not the
+	 * remedy. Surface the rejection's message instead; both implementations author it.
+	 *
+	 * The browser reaches it when the vault holds records but cannot produce the material to
+	 * decrypt them, or where Web Crypto is unavailable. Desktop reaches it when the keychain
+	 * refuses to answer, since `KeyStorage` only exists at all once `keys.enc` has decrypted at
+	 * startup — so a desktop "record present, key unreadable" state is unreachable rather than
+	 * unchecked.
+	 */
 	hasKey(provider: AiProvider): Promise<boolean>;
 	/** Delete an API key for a provider. */
 	deleteKey(provider: AiProvider): Promise<void>;
@@ -59,6 +72,23 @@ export type LegacyResidue = "retained" | "unverified" | null;
  */
 export const CLEARING_SITE_DATA_COST =
 	"Clearing this site's browser data also removes the threat models saved in this browser, so export anything you need first.";
+
+/**
+ * What both surfaces call the state where storage answered, and the answer was "I can't" (#234).
+ *
+ * The AI settings panel and the AI chat tab describe the same fault, and the whole point of
+ * #234 is that they cannot disagree about a stored key. Shipping the sentence twice would put
+ * that agreement back in a human's hands: an edit to one copy diverges the surfaces in wording
+ * while they still agree in fact, which is a quieter version of the bug being fixed.
+ *
+ * Deliberately not "could not be checked". A check that never answered and a check that
+ * answered "this browser cannot read it" are different claims, and the second is the one the
+ * vault now makes.
+ *
+ * The tests assert this text as their own literals rather than importing it. An assertion that
+ * imports the string it is checking passes for any value of that string.
+ */
+export const KEY_STORAGE_UNREADABLE = "Key storage could not be read";
 
 /**
  * Reason code for a removal that succeeded but left a readable clear-text copy behind.

--- a/src/lib/adapters/load-keychain-adapter.ts
+++ b/src/lib/adapters/load-keychain-adapter.ts
@@ -1,0 +1,69 @@
+/**
+ * The only two ways a keychain failure becomes text a user reads (#234).
+ *
+ * The AI settings panel and the chat store both describe the same storage faults, and both
+ * used to carry their own copy of this pair. That is how one fault comes to be described in
+ * two different ways on two surfaces — the defect #234 exists to remove — so the copy and the
+ * `unknown`-shape handling live in one place that both import.
+ *
+ * Kept beside {@link getKeychainAdapter} rather than inside its module because every suite
+ * that renders one of those surfaces mocks `./get-keychain-adapter` to supply a stand-in
+ * adapter. Defining the wrapper there would put it behind the same mock, so a test could only
+ * exercise it by re-implementing it — and the authored-message guarantee would then be proven
+ * against the re-implementation instead of against this code.
+ */
+
+import { getKeychainAdapter } from "./get-keychain-adapter";
+import type { KeychainAdapter } from "./keychain-adapter";
+
+/** Authored so a bundler or network detail never reaches the user as an error message. */
+export const KEYCHAIN_LOAD_ERROR =
+	"Key storage could not be loaded. Reload the page and try again.";
+
+/**
+ * The fallback for a rejection shaped like nothing this app produces.
+ *
+ * Deliberately vague, because a value that is neither an `Error` nor a string came from no
+ * layer that authored a message, so there is nothing truthful to say about it. Vague and
+ * honest beats `[object Object]`, and beats guessing at a cause the app cannot see.
+ */
+export const KEYCHAIN_UNKNOWN_ERROR =
+	"Key storage reported a problem this app does not recognise. Reload the page and try again.";
+
+/**
+ * Load the keychain adapter, replacing a module-load failure with an authored message.
+ *
+ * Adapters author their own user-safe messages; a failure to load one does not, and would
+ * otherwise render a bundle URL and a hash as the explanation. The cause is logged rather
+ * than dropped, so a real chunk-load regression is still diagnosable from a bug report.
+ */
+export async function loadKeychainAdapter(): Promise<KeychainAdapter> {
+	try {
+		return await getKeychainAdapter();
+	} catch (err) {
+		console.warn("Key storage adapter failed to load:", err);
+		throw new Error(KEYCHAIN_LOAD_ERROR);
+	}
+}
+
+/**
+ * Render a keychain failure as text a user can read.
+ *
+ * This function authors nothing and filters nothing — it is a shape adapter. What guarantees
+ * the text is safe to show lives upstream, in the two layers that produce these rejections:
+ * `withVault` remaps every non-`KeyVaultError` to an authored `unavailable()` before it leaves
+ * the browser vault, and the Tauri adapter relays a sentence authored in Rust, where
+ * `key_refusal` deliberately keeps `ThreatForgeError`'s `Display` — which names storage keys
+ * and filesystem paths — off the wire. A new caller that throws its own error is what would
+ * break that, not this line.
+ *
+ * The two branches exist because the two platforms reject with different shapes: the browser
+ * vault throws an `Error`, and `invoke` rejects with a bare string. A value that is neither
+ * has come from no layer that authored anything, so it is replaced rather than stringified —
+ * `String(error)` on an object renders `[object Object]` as the app's explanation of itself.
+ */
+export function keychainErrorText(error: unknown): string {
+	if (error instanceof Error) return error.message;
+	if (typeof error === "string") return error;
+	return KEYCHAIN_UNKNOWN_ERROR;
+}

--- a/src/lib/adapters/load-keychain-adapter.ts
+++ b/src/lib/adapters/load-keychain-adapter.ts
@@ -1,10 +1,15 @@
 /**
- * The only two ways a keychain failure becomes text a user reads (#234).
+ * How a keychain failure becomes text on the settings and chat-store surfaces (#234).
  *
  * The AI settings panel and the chat store both describe the same storage faults, and both
  * used to carry their own copy of this pair. That is how one fault comes to be described in
  * two different ways on two surfaces — the defect #234 exists to remove — so the copy and the
  * `unknown`-shape handling live in one place that both import.
+ *
+ * Not the only path a vault message can reach a user: `browser-chat-adapter` re-raises a
+ * `KeyVaultError` as a `no_api_key` protocol error, so the same sentence can also arrive in
+ * the transcript by way of a request the user made. That path authors its own framing and is
+ * documented where it lives.
  *
  * Kept beside {@link getKeychainAdapter} rather than inside its module because every suite
  * that renders one of those surfaces mocks `./get-keychain-adapter` to supply a stand-in
@@ -28,7 +33,7 @@ export const KEYCHAIN_LOAD_ERROR =
  * honest beats `[object Object]`, and beats guessing at a cause the app cannot see.
  */
 export const KEYCHAIN_UNKNOWN_ERROR =
-	"Key storage reported a problem this app does not recognise. Reload the page and try again.";
+	"Key storage reported a problem ThreatForge does not recognize. Reload the page and try again.";
 
 /**
  * Load the keychain adapter, replacing a module-load failure with an authored message.
@@ -57,13 +62,19 @@ export async function loadKeychainAdapter(): Promise<KeychainAdapter> {
  * and filesystem paths — off the wire. A new caller that throws its own error is what would
  * break that, not this line.
  *
- * The two branches exist because the two platforms reject with different shapes: the browser
- * vault throws an `Error`, and `invoke` rejects with a bare string. A value that is neither
- * has come from no layer that authored anything, so it is replaced rather than stringified —
- * `String(error)` on an object renders `[object Object]` as the app's explanation of itself.
+ * The two shape branches exist because the two platforms reject differently: the browser vault
+ * throws an `Error`, and `invoke` rejects with a bare string. Anything else came from no layer
+ * that authored a message, so it is replaced rather than stringified — `String(error)` on an
+ * object renders `[object Object]` as the app's explanation of itself.
+ *
+ * The emptiness check is the one that matters most, and it is not decoration. This value ends
+ * up in `chat-store`'s `keyFault`, which the chat tab tests for truthiness: an empty string
+ * would fall through to the "No API key configured" empty state over a vault that had just
+ * faulted, which is the exact defect #234 exists to remove, arriving through the code added to
+ * prevent it. An `Error` with nothing in it says no more than an object does.
  */
 export function keychainErrorText(error: unknown): string {
-	if (error instanceof Error) return error.message;
-	if (typeof error === "string") return error;
+	if (error instanceof Error) return error.message || KEYCHAIN_UNKNOWN_ERROR;
+	if (typeof error === "string") return error || KEYCHAIN_UNKNOWN_ERROR;
 	return KEYCHAIN_UNKNOWN_ERROR;
 }

--- a/src/lib/adapters/test-fixtures/key-vault.ts
+++ b/src/lib/adapters/test-fixtures/key-vault.ts
@@ -6,11 +6,40 @@
  * which `localStorage.clear()` does not touch — a suite that still relies on it would carry
  * a key between cases and quietly stop testing the unconfigured path. Replacing the factory
  * is what actually empties the vault.
+ *
+ * The direct-access helpers live here rather than in one suite because more than one suite
+ * has to damage a real vault: the adapter tests and the settings panel's damaged-vault test
+ * both need to remove the wrapping key while the encrypted records survive (#234).
  */
 
 import { IDBFactory } from "fake-indexeddb";
+import { KEY_VAULT_DB_NAME } from "../browser-key-vault";
 
 /** Discard every stored key by giving the process a fresh, empty IndexedDB. */
 export function resetKeyVault(): void {
 	globalThis.indexedDB = new IDBFactory();
+}
+
+/** Open the vault database directly, to inspect or damage it the way a test needs. */
+export async function openVaultDb(): Promise<IDBDatabase> {
+	return new Promise<IDBDatabase>((resolve, reject) => {
+		const request = globalThis.indexedDB.open(KEY_VAULT_DB_NAME);
+		request.onsuccess = () => resolve(request.result);
+		request.onerror = () => reject(request.error);
+	});
+}
+
+/** Replace the contents of the wrap-key store, simulating a damaged vault. */
+export async function writeWrapKeyStore(entries: [unknown, string][]): Promise<void> {
+	const db = await openVaultDb();
+	await new Promise<void>((resolve, reject) => {
+		const tx = db.transaction("wrap-key", "readwrite");
+		const store = tx.objectStore("wrap-key");
+		store.clear();
+		for (const [value, key] of entries) store.put(value, key);
+		tx.oncomplete = () => resolve();
+		tx.onerror = () => reject(tx.error);
+		tx.onabort = () => reject(tx.error);
+	});
+	db.close();
 }

--- a/src/stores/chat-store.test.ts
+++ b/src/stores/chat-store.test.ts
@@ -33,13 +33,24 @@ let keychainCalls: string[] = [];
 let slot: Record<string, LegacyResidue> = { anthropic: null, openai: null };
 /** Whether `hasKey` migrates the slot away, as it does for every upgrading pre-#133 user. */
 let hasKeyMigrates = false;
+/**
+ * What `hasKey` rejects with, or `null` when it answers.
+ *
+ * A knob on the one keychain mock rather than a second mock: `checkApiKey`'s two boundary
+ * calls have to stay in the same order and the same recording, and a separate mock for the
+ * failure case would let the two drift into testing different call sequences (#234).
+ */
+let hasKeyRejection: Error | null = null;
+/** What `hasKey` answers when it does not reject. */
+let hasKeyAnswer = false;
 vi.mock("@/lib/adapters/get-keychain-adapter", () => ({
 	getKeychainAdapter: async () => ({
 		setKey: async () => undefined,
 		hasKey: async (provider: string) => {
 			keychainCalls.push(`hasKey:${provider}`);
+			if (hasKeyRejection) throw hasKeyRejection;
 			if (hasKeyMigrates) slot[provider] = null;
-			return false;
+			return hasKeyAnswer;
 		},
 		deleteKey: async () => undefined,
 		readLegacyResidue: async (provider: string) => {
@@ -78,6 +89,8 @@ function seedSession(): void {
 		messages: [],
 		isStreaming: false,
 		error: null,
+		hasApiKey: false,
+		keyFault: null,
 	});
 }
 
@@ -94,6 +107,8 @@ beforeEach(() => {
 	keychainCalls = [];
 	slot = { anthropic: null, openai: null };
 	hasKeyMigrates = false;
+	hasKeyRejection = null;
+	hasKeyAnswer = false;
 	useKeyResidueStore.setState({ residue: { anthropic: null, openai: null } });
 	seedSession();
 });
@@ -322,6 +337,63 @@ describe("chat store clear-text key residue", () => {
 
 		// The re-read is a re-derivation, not a dismissal: a browser that still refuses the
 		// erase keeps its warning.
+		expect(useKeyResidueStore.getState().residue.anthropic).toBe("retained");
+	});
+});
+
+/**
+ * #234: `hasKey` rejects for a vault that holds records this browser cannot decrypt. The
+ * store's `catch` used to turn that into `hasApiKey: false` and nothing else, which the AI
+ * chat tab renders as "No API key configured" — the exact claim the settings panel refuses to
+ * make about the same storage. Two surfaces, one fact, opposite answers.
+ */
+describe("chat store key storage faults", () => {
+	/**
+	 * A stand-in, not the vault's copy. The keychain is mocked here, so this suite injects the
+	 * string and reads it back — any sentence would pass, and spelling the real one would read
+	 * as a pin it is not. The vault's actual wording is pinned once, against a real vault, in
+	 * `ai-settings-damaged-vault.test.tsx`. What this suite proves is that whatever the
+	 * keychain says arrives intact rather than being replaced by "no key configured".
+	 */
+	const VAULT_DAMAGED = "TEST-ONLY authored fault sentence from the keychain layer.";
+
+	it("does not report a vault it cannot read as no key configured", async () => {
+		hasKeyRejection = new Error(VAULT_DAMAGED);
+
+		await useChatStore.getState().checkApiKey("anthropic");
+
+		// Both, and they say different things. No request can be signed, which is what
+		// `hasApiKey` means — but the reason is not an absence, and the reason is what the user
+		// has to read, because entering a key is not what repairs a damaged vault.
+		expect(useChatStore.getState().hasApiKey).toBe(false);
+		expect(useChatStore.getState().keyFault).toBe(VAULT_DAMAGED);
+	});
+
+	it("clears the storage fault once the check answers again", async () => {
+		hasKeyRejection = new Error(VAULT_DAMAGED);
+		await useChatStore.getState().checkApiKey("anthropic");
+
+		hasKeyRejection = null;
+		hasKeyAnswer = true;
+		await useChatStore.getState().checkApiKey("anthropic");
+
+		// A fault that outlived the condition would leave a permanent warning over storage that
+		// is working — and saving a fresh key is exactly what repairs this vault.
+		expect(useChatStore.getState().keyFault).toBeNull();
+		expect(useChatStore.getState().hasApiKey).toBe(true);
+	});
+
+	it("re-reads the clear-text slot even when the key check failed", async () => {
+		useKeyResidueStore.setState({ residue: { anthropic: null, openai: null } });
+		slot = { anthropic: "retained", openai: null };
+		hasKeyRejection = new Error(VAULT_DAMAGED);
+
+		await useChatStore.getState().checkApiKey("anthropic");
+
+		// #233's guarantee is not conditional on the key check succeeding. A damaged vault is
+		// precisely when a surviving clear-text copy matters most, so the residue read has to
+		// run after both outcomes.
+		expect(keychainCalls).toEqual(["hasKey:anthropic", "residue:anthropic"]);
 		expect(useKeyResidueStore.getState().residue.anthropic).toBe("retained");
 	});
 });

--- a/src/stores/chat-store.ts
+++ b/src/stores/chat-store.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { getChatTransport } from "@/lib/adapters/get-chat-transport";
-import { getKeychainAdapter } from "@/lib/adapters/get-keychain-adapter";
+import { keychainErrorText, loadKeychainAdapter } from "@/lib/adapters/load-keychain-adapter";
 import { capMessageHistory } from "@/lib/ai/protocol/budget";
 import { streamConversation } from "@/lib/ai/protocol/client";
 import type { StopReason, StreamEvent, TokenUsage } from "@/lib/ai/protocol/events";
@@ -191,6 +191,16 @@ interface ChatState {
 	provider: AiProvider;
 	/** Whether the selected provider has an API key configured */
 	hasApiKey: boolean;
+	/**
+	 * Authored message for storage that could not be read at all, or `null` when it answered.
+	 *
+	 * Separate from `error`, which is "the last request failed" and only exists once a request
+	 * has been made; this one is "storage cannot be read" and is true before any request. And
+	 * separate from `hasApiKey`, which gates sending: a fault means no request can be signed, so
+	 * both are set, but nothing gates sending on this field. Holds only text the keychain layer
+	 * authored — never key material — and lives in memory only, never persisted.
+	 */
+	keyFault: string | null;
 	/** Error message from the last request, if any */
 	error: string | null;
 
@@ -217,6 +227,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
 	isStreaming: false,
 	provider: "anthropic",
 	hasApiKey: false,
+	keyFault: null,
 	error: null,
 
 	loadSessionsForFile: (filePath) => {
@@ -519,11 +530,18 @@ export const useChatStore = create<ChatState>((set, get) => ({
 	checkApiKey: async (providerOverride) => {
 		const provider = providerOverride ?? get().provider;
 		try {
-			const adapter = await getKeychainAdapter();
+			const adapter = await loadKeychainAdapter();
 			const hasKey = await adapter.hasKey(provider);
-			set({ hasApiKey: hasKey });
-		} catch {
-			set({ hasApiKey: false });
+			set({ hasApiKey: hasKey, keyFault: null });
+		} catch (err) {
+			// `hasApiKey: false` because no request can be signed, which is true. But a rejection
+			// is not the claim "there is no key" — the record may be sitting in a vault this
+			// browser cannot read — so the reason is carried too, and the chat surface reports
+			// the fault rather than an absence the user would try to fix by entering a key.
+			// What keeps an internal string out of this field is upstream: the browser vault
+			// remaps everything that is not a `KeyVaultError` before it leaves `withVault`, and
+			// the desktop adapter relays a sentence authored in Rust.
+			set({ hasApiKey: false, keyFault: keychainErrorText(err) });
 		}
 		// `hasKey` is also what migrates a pre-#133 clear-text key into the vault and erases the
 		// slot, so a slot that was there when the session started may be gone now. Re-read it


### PR DESCRIPTION
Closes #234.

The AI settings panel said **"API key configured"** for a key the browser vault could no longer decrypt. The user's next message failed anyway, and the panel kept insisting the key was there — so the one screen that exists to answer *"is my key set up?"* was the screen lying about it.

## The fix is five lines, and what took the time was deciding which five

`hasSecret` used to answer from the existence of a record. It now also asks whether the vault can still be read:

```ts
if (count === 0) return false;
requireSubtle();
if (!(await readWrapKey(db))) throw vaultCorrupt();
return true;
```

**Zero cryptographic operations.** `readWrapKey` is an IndexedDB `get` and a shape check. That is the whole point: the common failure here is `vault-corrupt` — the wrapping key is gone while the encrypted records survive — and that is a property of the *vault*, not of any record, so it is answerable without touching a single ciphertext.

The `count === 0` gate is load-bearing rather than an optimisation. A provider with nothing stored must not inherit another provider's vault-wide fault, or removing a key from one provider would light up an error on a second that never had one. Both halves have a test.

**The two options the issue proposed were both ruled out with evidence** (`docs/plans/234-vault-usable-status.md`, `## Decision`). Decrypting on the status path forces a choice between dropping the record as `getKey` does — which makes *opening the settings dialog silently delete key material*, and `dropUnreadableSecret` also settles the clear-text slot, so it can destroy a surviving readable copy — or a fault that never clears while the next `getKey` drops the record anyway. A separate `probeKey` was rejected because it creates a second predicate the first is allowed to contradict: this bug, reintroduced as an interface.

**One residual is deliberate and pinned by name.** A single damaged record under a *healthy* wrap key still reads as configured until the next request. Bounded and self-healing, and the test `reports a per-record decryption failure only once a read has established it` says so, so no later reader assumes coverage that isn't there.

## The bug had a twin, and the fix grew one of its own

The sentence this issue exists to keep identical across two surfaces shipped as **two string literals**, coupled by nothing but a docblock claiming they matched. A copy edit to one would have diverged them silently with every suite still green — #234's own defect, one layer up, in copy instead of state. Now `KEY_STORAGE_UNREADABLE`, exported from `keychain-adapter.ts`, whose only import is `import type { AiProvider }` — fully erased, so the panel pulls in no IndexedDB code to get a string. The tests keep their own literals deliberately: an assertion that imports the string it checks passes for any value.

Then the fix did it again. `keychainErrorText` was hardened to fail closed on an unrecognised *shape*, but not on an empty message — and `""` reaching `chat-store`'s `keyFault`, which the chat tab tests for truthiness, renders **"No API key configured" over a vault that just faulted**. Caught by the reviewer lane, confirmed by reverting the guard and watching the new test fail with `key-storage-fault` absent and the empty state in the DOM. Both branches now refuse an empty message.

## Verification

- `npm run ci:local` green on the final commit, plus `npx playwright test e2e/ai-chat.spec.ts e2e/empty-states.spec.ts` → **6 passed**, server reaped, so the real-browser empty-state path survives the reordered branch.
- **Three preflight lanes — reviewer, security, slop — read-only and parallel on a frozen tree, three rounds to convergence.** All three returned clean on `4b2bf9c`. Every round's tree state is attested in the lane reports.
- **Both fixes shipped this round were proven to discriminate by reverting them**, because both lanes independently observed that the security fix had no test that failed without it — the whole suite stayed green with it reverted, which made it invisible to any future refactor tidying `withVault`.

### What the lanes found that the implementation missed

- **Security:** `withVault` awaited `openVault()` *outside* its own `try`. `openVault` guarded `factory.open()` and a null factory but not the `globalThis.indexedDB` **property read** — a getter that throws `SecurityError` in a sandboxed iframe or storage-blocked profile. That would have rendered *"The operation is insecure."* as the app's explanation of itself. `DOMException` **is** `instanceof Error`, so no downstream shape check would have caught it; upstream was the only correct layer.
- **Reviewer + slop, independently:** three comments credited `keychainErrorText` with authoring safe messages. It is a shape adapter — it authors and filters nothing. The guarantee is real but lives in `withVault`'s remap and in `key_refusal` on the Rust side, which deliberately keeps `ThreatForgeError`'s `Display` — naming storage keys and filesystem paths — off the wire. Comments rewritten to point at where the property actually holds, **and** the function made genuinely fail-closed, so an unrecognised rejection no longer renders `[object Object]`.
- **Slop:** `recognise` in a user-facing string. The lanes disagreed — the reviewer read it as house style — which is why it got checked rather than decided. The repo writes British prose in comments and American copy in the UI (`Analyzing…`, `Run STRIDE Analysis`), and this was the first string to cross. Both lanes retracted their own position on it afterwards.

## Deferred deliberately, filed rather than folded in

Changing safety copy under a bug fix hides the change, so two messages stay verbatim and go to their own issue:

- **#280** — `VAULT_CORRUPT_MESSAGE` tells the user to clear site data, destroying every saved threat model, when saving a key recovers the vault in place (pinned by an existing test). `UNAVAILABLE_MESSAGE` prescribes a remedy right for one of its three causes.
- **#281** — `migrateLegacyKey` erases the clear-text slot on a declined import without proving the stored record is readable. A separate defect on the **erase** path; its fix necessarily costs a decrypt, which is the thing this issue established the status path must never do.
- **#282** — the identical unguarded `globalThis.indexedDB` read in `src/lib/persistence/indexeddb.ts:87`, generalising the security lane's finding beyond the key vault.

All three are `M3 • Release 1`. **#281 loses user key material and is worth pulling into `M2` — that call is yours, not mine.**

## Owner validation

Six items in `docs/plans/234-vault-usable-status.md`, `## Owner validation`. The one a reviewer could not verify: **first run in a storage-blocked browser profile**, where the vault is unavailable rather than corrupt and the panel must not present a remedy that does nothing. Everything else is covered by tests or the E2E run.