### PR TITLE
fix(browser): say what clearing site data costs on the damaged-vault path

### DIFF
--- a/src/components/panels/ai-settings-damaged-vault.test.tsx
+++ b/src/components/panels/ai-settings-damaged-vault.test.tsx
@@ -19,6 +19,7 @@ import { act, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "fake-indexeddb/auto";
 import { BrowserKeychainAdapter } from "@/lib/adapters/browser-keychain-adapter";
+import { CLEARING_SITE_DATA_COST } from "@/lib/adapters/keychain-adapter";
 import { resetKeyVault, writeWrapKeyStore } from "@/lib/adapters/test-fixtures/key-vault";
 import { useChatStore } from "@/stores/chat-store";
 import { useKeyResidueStore } from "@/stores/key-residue-store";
@@ -33,9 +34,13 @@ import { AiSettingsContent } from "./ai-settings-content";
  * could compare against it would make this assertion tautological — the test would agree with
  * whatever the module said. Spelled out here, it fails if the copy changes, which is the
  * point: this is the exact text acceptance criterion 5 requires the user to see.
+ *
+ * The cost clause is the exception, imported rather than written out (#265). It is one shared
+ * sentence appearing on every surface that gives this instruction, and a copy of it here would
+ * be the fourth place to update when it changes — which is how one surface ends up telling a
+ * user to clear their browser data without telling them it deletes their threat models.
  */
-const VAULT_DAMAGED_SENTENCE =
-	"Encrypted key storage in this browser is damaged. Clear this site's browser data, then add your API key again.";
+const VAULT_DAMAGED_SENTENCE = `Encrypted key storage in this browser is damaged. Clear this site's browser data, then add your API key again. ${CLEARING_SITE_DATA_COST}`;
 
 const SECRET = "sk-ant-test-0123456789abcdef";
 

--- a/src/lib/adapters/browser-chat-adapter.test.ts
+++ b/src/lib/adapters/browser-chat-adapter.test.ts
@@ -19,6 +19,7 @@ import { BrowserChatTransport } from "./browser-chat-adapter";
 import { KEY_VAULT_DB_NAME } from "./browser-key-vault";
 import { BrowserKeychainAdapter } from "./browser-keychain-adapter";
 import type { ProviderStreamRequest, TransportCallbacks } from "./chat-adapter";
+import { CLEARING_SITE_DATA_COST } from "./keychain-adapter";
 import { PROVIDER_ENDPOINTS } from "./provider-endpoints";
 
 const ANTHROPIC_KEY = "sk-ant-test-browser-key";
@@ -290,7 +291,12 @@ describe("BrowserChatTransport request building", () => {
 		await expect(
 			new BrowserChatTransport().open(anthropicRequest, recordingCallbacks()),
 		).rejects.toMatchObject({
-			error: { code: "no_api_key", message: expect.stringContaining("browser data") },
+			// Matching the cost clause, not "browser data": the pre-fix message contained that
+			// substring too, so the old assertion could not fail for the reason it existed.
+			error: {
+				code: "no_api_key",
+				message: expect.stringContaining(CLEARING_SITE_DATA_COST),
+			},
 		});
 		expect(fetch).not.toHaveBeenCalled();
 	});

--- a/src/lib/adapters/browser-key-vault.ts
+++ b/src/lib/adapters/browser-key-vault.ts
@@ -28,7 +28,7 @@
  * key storage never share a namespace; see `src/lib/persistence/no-key-leakage.test.ts`.
  */
 
-import type { LEGACY_RETAINED } from "./keychain-adapter";
+import { CLEARING_SITE_DATA_COST, type LEGACY_RETAINED } from "./keychain-adapter";
 
 /** Key-vault database name. Disjoint from `WORKSPACE_STORAGE_NAMESPACE`. */
 export const KEY_VAULT_DB_NAME = "threatforge-keychain";
@@ -181,8 +181,7 @@ function corruptRecord(record: SecretRecord | null): KeyVaultError {
 const UNAVAILABLE_MESSAGE =
 	"Encrypted key storage is unavailable in this browser. Check that this site is allowed to store data, then try again.";
 const CORRUPT_MESSAGE = "The stored API key could not be read and needs to be entered again.";
-const VAULT_CORRUPT_MESSAGE =
-	"Encrypted key storage in this browser is damaged. Clear this site's browser data, then add your API key again.";
+const VAULT_CORRUPT_MESSAGE = `Encrypted key storage in this browser is damaged. Clear this site's browser data, then add your API key again. ${CLEARING_SITE_DATA_COST}`;
 
 function unavailable(): KeyVaultError {
 	return new KeyVaultError("unavailable", UNAVAILABLE_MESSAGE);

--- a/src/lib/adapters/browser-keychain-adapter.test.ts
+++ b/src/lib/adapters/browser-keychain-adapter.test.ts
@@ -507,6 +507,15 @@ describe("recovering from an unreadable record", () => {
 		expect((error as KeyVaultError).reason).toBe("vault-corrupt");
 	});
 
+	it("does not tell the user to clear site data without saying what that costs", async () => {
+		const adapter = new BrowserKeychainAdapter();
+		await adapter.setKey("anthropic", SECRET);
+		await writeWrapKeyStore([["not-a-crypto-key", "aes-gcm-256-v1"]]);
+
+		const error = await adapter.getKey("anthropic").catch((caught: unknown) => caught);
+		expect((error as KeyVaultError).message).toContain(CLEARING_SITE_DATA_COST);
+	});
+
 	it("does not discard a record when the crypto layer itself fails", async () => {
 		const adapter = new BrowserKeychainAdapter();
 		await adapter.setKey("anthropic", SECRET);


### PR DESCRIPTION
Closes #265.

## What was wrong

A user whose browser key vault is damaged was told: *"Clear this site's browser data, then add your API key again."* `WORKSPACE_STORAGE_NAMESPACE` names both the `localStorage` manifest key and the IndexedDB database that holds document bodies and revisions, so clearing site data takes every threat model they have saved. The sentence did not say so. Following the app's own advice cost the user their work.

#233 already fixed this class of defect on the other surfaces and exported `CLEARING_SITE_DATA_COST` for it, placed in the platform-free keychain adapter specifically so a caller does not have to import IndexedDB code to get the string. This applies it to the one site that was missed.

## One string, not the two the issue describes

The issue names `browser-key-vault.ts:185` **and** the `browser-chat-adapter.ts` no-key message. Only the first authors a clear-data instruction.

`resolveBrowserApiKey` catches the vault's `KeyVaultError` and re-raises `error.message` verbatim as a `ProtocolException` — deliberately, to keep the actionable sentence — so the chat surface inherits the fix. Its own `missingApiKeyError` is *"No API key configured for {provider}. Open AI Settings to add one."*, which gives no clear-data instruction and owes no concession. It is also shared with the Tauri transport, where a clear-site-data sentence would be false.

The review lane did not take that on trust: it traced the re-raised message past the adapter boundary through `retry.ts:205` (propagates uncaught), `client.ts:131` (`errorEventFrom` preserves it verbatim), `chat-store.ts:429` and out to `ai-chat-tab.tsx:235`, confirming the full sentence including the cost clause reaches the rendered banner. The second surface is genuinely satisfied by inheritance rather than by doing less.

That propagation is now pinned. Its existing test asserted `stringContaining("browser data")`, which the **pre-fix** message also satisfied — the assertion could not fail for the reason it existed. It now matches the cost clause, which strictly implies the old needle.

## Verification

- `npm run ci:local` green (2207 frontend, 169 Rust).
- Reverting `VAULT_CORRUPT_MESSAGE` to its pre-fix value fails **three** tests — the new keychain test, the strengthened chat test, and the panel test, which interpolates the same constant. My commit originally claimed two; the reviewer measured it and corrected me upward.
- Appending a raw `NotFoundError` to the production string still fails the panel test, so importing the cost clause did not erode the exact-equality property that file documents.
- Emptying the constant is caught by the literal assertions at `ai-settings-content.test.tsx:517,537`, so the clause's content stays pinned by literal somewhere in the suite while the propagation assertions ride on top.

## Acceptance criteria

1. ✅ Both surfaces state the cost — one by authorship, one by inheritance, traced to the banner.
2. ✅ Independent repository-wide sweep by both lanes (wider regex than the issue's phrasing, including `src-tauri/`, `worker/`, `e2e/`, and runtime-assembled strings) finds four instruction sites, all four carrying the concession.
3. ✅ New assertions match the cost clause. Note for the reader comparing the checkbox to the file: `ai-settings-damaged-vault.test.tsx` matches the whole message by exact equality. That is its pre-existing, deliberately documented property and is *more* discriminating, not less.
4. ✅ Checked against `docs/knowledge/product-voice.md`. See below.
5. ✅ No persistence or IndexedDB import. `browser-key-vault.ts:31` widens an `import type` to a value import of `./keychain-adapter`, whose only import is a type. No runtime module-graph edge added, no cycle.

## Two things the owner should see

**The copy repeats itself, on purpose.** The shipped sentence says "clear this site's browser data" twice in adjacent sentences, because the shared constant opens *"Clearing this site's browser data also…"* and its "also" presupposes a prior mention. Both lanes flagged it, both landed on keep: `browser-keychain-adapter.ts:257-258` already ships the identical construct at the same layer, and the only lever — rewording the constant to open with "That also removes…" — reads worse at `ai-settings-content.tsx:185,198`, where it renders as a standalone `<p>` whose referent would sit in the previous paragraph. It passes every product-voice check that governs an error surface: fact first, nothing funny, second person, concrete, and it hands the reader an action rather than distancing itself from a consequence. If it bothers you, it belongs on a copy-polish issue, not here.

**This hardens a remedy #280 says is unnecessary.** The slop lane caught something no gate would have: #280 (filed three hours before this commit) says the damaged-vault message should not send the user to clear site data at all, because `installWrapKey` under `"always"` recovers the vault in place when the user re-enters a key. I verified that claim against the test it cites — `browser-keychain-adapter.test.ts:646`, *"lets the user store a new key after the wrapping key is lost"* — and it holds: `setKey` resolves and the new key reads back after the wrapping key is destroyed.

So the net effect of this PR is a wrong instruction made more detailed and more credible. It is still a strict improvement over the bare instruction for as long as the wrong remedy stands, which is why it ships. But **#265 is `M2 • Beta` and #280 is `M3 • Release 1`**, so as things stand launch carries the expensive remedy. Whether to pull #280 forward is a milestone call, and `AGENTS.md` reserves that for you — agents may not move `M3` into `M2`. Recorded on both issues.

## Review lanes

Both ran read-only against a frozen clean tree at `b306e04`, each attesting matching entry and exit state and running all mutations in a `/tmp` extract.

- **pr-reviewer — clean, approve.** No must-fix, no should-fix. Independently verified the one-string narrowing end-to-end, ran its own wider sweep for criterion 2, proved the panel test still rejects an appended `DOMException`, and confirmed `VAULT_CORRUPT_MESSAGE` is unreachable on desktop (both `isTauri()` gates), so the browser-specific sentence cannot be shown falsely to a Tauri user.
- **slop-auditor — minor.** One should-fix, the #280 interaction above, resolved as an artifact gap rather than a code change. Two `consider` comment trims applied: deleted a comment that reworded the docblock of the constant on the next line, and cut a three-line comment to the one clause that records a rejected weaker alternative. Its mutation table also showed the imported-constant assertion is vacuous under an emptied constant — closed elsewhere by the literal pins, which is the right split.

Comment trims and the corrected test count were applied after the lanes read, so the head commit is `8b386e2` rather than the reviewed `b306e04`; the delta is comments and a commit message.

Milestone: `M2 • Beta`.