### PR TITLE
fix(a11y): make the landing and /terms scroll regions keyboard-operable

### DIFF
--- a/docs/quality/e2e-visual-accessibility-rubric.md
+++ b/docs/quality/e2e-visual-accessibility-rubric.md
@@ -14,6 +14,7 @@ not claim any of them replace human visual review.
 | Empty states | Automated | Existing `empty-states`-family specs plus `e2e/accessibility-audit.spec.ts`'s empty-canvas case |
 | Errors | Automated | `e2e/accessibility-audit.spec.ts`'s ephemeral-storage case (`seedEphemeralWorkspace`) exercises the visible "This session won't be saved" degraded/error state; malformed-file alerts are native transient dialogs and cannot be axe-scanned after dismissal |
 | Responsive behavior | Partially automated | At 900×700, `e2e/accessibility-audit.spec.ts` requires each key interactive surface to be visible and fully inside the viewport (`toBeInViewport({ ratio: 1 })`) with no body-level horizontal overflow; it does not prove the layout still *looks* good |
+| Keyboard operability of scroll regions | Automated | `e2e/accessibility-audit.spec.ts` covers every container measured to scroll and be otherwise unreachable: the component palette, and the `/` and `/terms` marketing scrollers at 320px. Each asserts the region takes focus by Tab, scrolls on an arrow key, and carries an explicit `tabindex` — the last because Chromium focuses overflowing scrollers on its own, so the traversal alone passes without it while WebKit skips such a container entirely |
 | Hierarchy | Owner-validated | Evidenced by retained/attached screenshots; no automated heuristic |
 | Alignment | Owner-validated | Same |
 | Overlap | Owner-validated | Same — deliberately **not** given a new geometry-diffing utility (would be speculative, unproven, and out of proportion to this issue's scope) |

--- a/e2e/accessibility-audit.spec.ts
+++ b/e2e/accessibility-audit.spec.ts
@@ -419,11 +419,12 @@ test.describe("Accessibility audit", () => {
 });
 
 /**
- * The marketing routes have no axe coverage (#249 notes the gap; it is filed separately). This
- * describe block is narrower on purpose: one measured keyboard property on the one container on
- * those routes that was measured to scroll.
+ * The marketing routes have no axe coverage (#292). This describe block is narrower on purpose:
+ * one measured keyboard property on each container that was measured to scroll on those routes.
+ * A sweep of `/`, `/downloads`, `/about`, `/privacy`, `/terms` and `/support` at 1280/768/390/320
+ * found exactly two, plus the page `<body>`, which is inherently keyboard-scrollable.
  */
-test.describe("Landing page keyboard access", () => {
+test.describe("Marketing route keyboard access", () => {
 	test("the .thf sample can be reached and scrolled by keyboard where it overflows", async ({
 		page,
 	}) => {
@@ -447,9 +448,11 @@ test.describe("Landing page keyboard access", () => {
 		expect(before.scrollLeft).toBe(0);
 
 		// Tab from the top of the document rather than calling focus(): the WCAG property is that
-		// the region is *reachable*, which focus() would assert nothing about. The bound is a
-		// generous multiple of the page's focusable count, so it fails on unreachable rather than
-		// hanging, and the count is reported when it does.
+		// the region is *reachable*, which focus() would assert nothing about. The bound is the
+		// page's focusable count plus a small margin, so it fails on unreachable rather than
+		// hanging, and the count is reported when it does. Undercounting only ever produces a
+		// false red; overcounting only permits wrap-around, and a region reached after wrapping
+		// is still reachable.
 		const focusableCount = await page.evaluate(
 			() => document.querySelectorAll("a[href], button, input, [tabindex]").length,
 		);
@@ -475,5 +478,38 @@ test.describe("Landing page keyboard access", () => {
 		// overflowing `<pre>` between two buttons, Tab goes straight past it to the second button.
 		// Safari users are the ones this attribute is for, and this project only runs Chromium.
 		await expect(sample).toHaveAttribute("tabindex", "0");
+	});
+
+	test("the licence notices box can be reached and scrolled by keyboard", async ({ page }) => {
+		// Worse than the landing sample and found only because a review lane swept the route the
+		// first sweep missed: 4784px of licence text in a 384px box, so this one hides its content
+		// at every viewport width rather than only narrow ones.
+		await page.goto("/terms");
+
+		await page.getByText("Open-source and third-party license notices").click();
+
+		const notices = page.getByRole("region", { name: "Open-source licence notices", exact: true });
+		await expect(notices).toBeVisible();
+
+		const before = await notices.evaluate((element) => ({
+			scrollHeight: element.scrollHeight,
+			clientHeight: element.clientHeight,
+			scrollTop: element.scrollTop,
+		}));
+		expect(
+			before.scrollHeight,
+			`the notices box must actually overflow for this test to mean anything (scrollHeight ${before.scrollHeight} vs clientHeight ${before.clientHeight})`,
+		).toBeGreaterThan(before.clientHeight);
+		expect(before.scrollTop).toBe(0);
+
+		await notices.focus();
+		await page.keyboard.press("ArrowDown");
+		await expect
+			.poll(() => notices.evaluate((element) => element.scrollTop))
+			.toBeGreaterThan(before.scrollTop);
+
+		// Same reason as above: Chromium focuses overflowing scrollers by itself, so only a direct
+		// assertion can see the tab stop that WebKit needs.
+		await expect(notices).toHaveAttribute("tabindex", "0");
 	});
 });

--- a/e2e/accessibility-audit.spec.ts
+++ b/e2e/accessibility-audit.spec.ts
@@ -417,3 +417,63 @@ test.describe("Accessibility audit", () => {
 		).toBeLessThanOrEqual(overflow.clientWidth);
 	});
 });
+
+/**
+ * The marketing routes have no axe coverage (#249 notes the gap; it is filed separately). This
+ * describe block is narrower on purpose: one measured keyboard property on the one container on
+ * those routes that was measured to scroll.
+ */
+test.describe("Landing page keyboard access", () => {
+	test("the .thf sample can be reached and scrolled by keyboard where it overflows", async ({
+		page,
+	}) => {
+		// 320px, the narrowest width #249 measured. The sample is 392px wide and cannot reflow,
+		// so this is where a keyboard user would otherwise lose the right-hand half of every line.
+		await page.setViewportSize({ width: 320, height: 900 });
+		await page.goto("/");
+
+		const sample = page.getByRole("region", { name: "Example threat model file", exact: true });
+		await expect(sample).toBeVisible();
+
+		const before = await sample.evaluate((element) => ({
+			scrollWidth: element.scrollWidth,
+			clientWidth: element.clientWidth,
+			scrollLeft: element.scrollLeft,
+		}));
+		expect(
+			before.scrollWidth,
+			`the sample must actually overflow at 320px for this test to mean anything (scrollWidth ${before.scrollWidth} vs clientWidth ${before.clientWidth})`,
+		).toBeGreaterThan(before.clientWidth);
+		expect(before.scrollLeft).toBe(0);
+
+		// Tab from the top of the document rather than calling focus(): the WCAG property is that
+		// the region is *reachable*, which focus() would assert nothing about. The bound is a
+		// generous multiple of the page's focusable count, so it fails on unreachable rather than
+		// hanging, and the count is reported when it does.
+		const focusableCount = await page.evaluate(
+			() => document.querySelectorAll("a[href], button, input, [tabindex]").length,
+		);
+		await page.evaluate(() => document.body.focus());
+		let reached = false;
+		for (let press = 0; press < focusableCount + 5 && !reached; press++) {
+			await page.keyboard.press("Tab");
+			reached = await sample.evaluate((element) => element === document.activeElement);
+		}
+		expect(
+			reached,
+			`the sample never took focus within ${focusableCount + 5} Tab presses, so a keyboard user cannot reach it`,
+		).toBe(true);
+
+		await page.keyboard.press("ArrowRight");
+		await expect
+			.poll(() => sample.evaluate((element) => element.scrollLeft))
+			.toBeGreaterThan(before.scrollLeft);
+
+		// The traversal above cannot see the explicit tab stop, and this is the only honest way to
+		// pin it. Chromium focuses overflowing scroll containers on its own, so the loop passes
+		// with `tabIndex` deleted — measured, not assumed. WebKit does not: probing a minimal
+		// overflowing `<pre>` between two buttons, Tab goes straight past it to the second button.
+		// Safari users are the ones this attribute is for, and this project only runs Chromium.
+		await expect(sample).toHaveAttribute("tabindex", "0");
+	});
+});

--- a/src/pages/landing-page.test.tsx
+++ b/src/pages/landing-page.test.tsx
@@ -58,6 +58,14 @@ describe("LandingPage", () => {
 		renderLandingPage();
 		expect(screen.getByText("Yes, it's just a file")).toBeInTheDocument();
 		expect(screen.getByText("payment-service.thf")).toBeInTheDocument();
+		// The sample scrolls sideways on a narrow screen, so it needs a name and a tab stop
+		// (#249). Asserted here as well as in E2E because this suite catches a rename in under a
+		// second, and because the E2E lane runs Chromium only — where the tab stop is invisible,
+		// since Chromium focuses overflowing scrollers whether or not the attribute is there.
+		expect(screen.getByRole("region", { name: "Example threat model file" })).toHaveAttribute(
+			"tabindex",
+			"0",
+		);
 	});
 
 	it("renders the bottom CTA section", () => {

--- a/src/pages/landing-page.tsx
+++ b/src/pages/landing-page.tsx
@@ -175,16 +175,14 @@ function YamlShowcaseSection() {
 						<span className="font-mono text-xs text-muted-foreground">payment-service.thf</span>
 					</div>
 					{/*
-					 * Below roughly 400px this sample scrolls sideways — `white-space: pre` is the point
-					 * of showing a file, so it cannot reflow. A mouse user drags it; without a tab stop a
-					 * keyboard user simply cannot read the right-hand half (WCAG 2.1.1, #249).
+					 * Below about 440px this sample scrolls sideways — `white-space: pre` is the point of
+					 * showing a file, so it cannot reflow, and without a tab stop a keyboard user cannot
+					 * read the right-hand half of any line (WCAG 2.1.1, #249).
 					 *
 					 * The `<section>` exists to carry the label: `<pre>` maps to `generic`, which supports no
-					 * accessible name at all. Scrolling moves out to it and padding stays on the `<pre>`,
-					 * which also fixes the usual quirk where a scroller's own right padding vanishes once
-					 * you scroll to the end. `w-max` keeps the `<pre>` sized to its content rather than
-					 * shrinking to the scroller. The ring is inset because the card wrapping this is
-					 * `overflow-hidden` and would clip an outset one.
+					 * accessible name at all. `w-max` on the `<pre>` stops a block child from shrinking to
+					 * the scroller. The ring is inset because the card wrapping this is `overflow-hidden`
+					 * and would clip an outset one.
 					 *
 					 * No `onKeyDown` guard here, unlike the component palette this borrows from. That guard
 					 * exists to keep arrow keys away from the canvas shortcuts, and those mount in

--- a/src/pages/landing-page.tsx
+++ b/src/pages/landing-page.tsx
@@ -174,9 +174,32 @@ function YamlShowcaseSection() {
 						<FileCode className="h-4 w-4 text-muted-foreground" />
 						<span className="font-mono text-xs text-muted-foreground">payment-service.thf</span>
 					</div>
-					<pre className="overflow-x-auto p-4 font-mono text-xs leading-relaxed text-muted-foreground">
-						<code>{YAML_SAMPLE}</code>
-					</pre>
+					{/*
+					 * Below roughly 400px this sample scrolls sideways — `white-space: pre` is the point
+					 * of showing a file, so it cannot reflow. A mouse user drags it; without a tab stop a
+					 * keyboard user simply cannot read the right-hand half (WCAG 2.1.1, #249).
+					 *
+					 * The `<section>` exists to carry the label: `<pre>` maps to `generic`, which supports no
+					 * accessible name at all. Scrolling moves out to it and padding stays on the `<pre>`,
+					 * which also fixes the usual quirk where a scroller's own right padding vanishes once
+					 * you scroll to the end. `w-max` keeps the `<pre>` sized to its content rather than
+					 * shrinking to the scroller. The ring is inset because the card wrapping this is
+					 * `overflow-hidden` and would clip an outset one.
+					 *
+					 * No `onKeyDown` guard here, unlike the component palette this borrows from. That guard
+					 * exists to keep arrow keys away from the canvas shortcuts, and those mount in
+					 * `app-layout`, which the marketing routes never render.
+					 */}
+					<section
+						aria-label="Example threat model file"
+						className="overflow-x-auto focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+						// biome-ignore lint/a11y/noNoninteractiveTabindex: a scrollable region must be focusable for keyboard access
+						tabIndex={0}
+					>
+						<pre className="w-max p-4 font-mono text-xs leading-relaxed text-muted-foreground">
+							<code>{YAML_SAMPLE}</code>
+						</pre>
+					</section>
 				</div>
 			</div>
 		</section>

--- a/src/pages/terms-page.tsx
+++ b/src/pages/terms-page.tsx
@@ -31,11 +31,25 @@ export function TermsPage() {
 							<summary className="cursor-pointer font-medium text-foreground">
 								Open-source and third-party license notices
 							</summary>
-							<pre className="mt-4 max-h-96 overflow-auto whitespace-pre-wrap text-xs">
-								{licenseRaw}
-								{"\n\n"}
-								{noticeRaw}
-							</pre>
+							{/*
+							 * A 4800px licence dump in a 384px box, and it scrolls horizontally too below
+							 * ~360px. Same treatment and same reason as the landing page's file sample
+							 * (#249): the `<section>` carries the label because `<pre>` is `generic` and
+							 * takes no accessible name, and the tab stop is what a Safari keyboard user
+							 * needs — Chromium focuses overflowing scrollers on its own and WebKit does not.
+							 */}
+							<section
+								aria-label="Open-source licence notices"
+								className="mt-4 max-h-96 overflow-auto focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+								// biome-ignore lint/a11y/noNoninteractiveTabindex: a scrollable region must be focusable for keyboard access
+								tabIndex={0}
+							>
+								<pre className="whitespace-pre-wrap text-xs">
+									{licenseRaw}
+									{"\n\n"}
+									{noticeRaw}
+								</pre>
+							</section>
 						</details>
 					</Section>
 


### PR DESCRIPTION
Closes #249.

## What was wrong

The `.thf` sample on the landing page overflows sideways below ~440px. `white-space: pre` is the entire point of showing a file, so it cannot reflow — it scrolls. A mouse user drags it. A keyboard user had no tab stop and simply could not read the right-hand half of any line. WCAG 2.1.1.

Measured at 320px: 392px of content in a 270px box.

## The fix

A labelled `<section>` wraps the `<pre>` and carries the scrolling, the tab stop, and the focus ring — following the component palette (`95aa1bb`), which solved the same shape. The label names a purpose rather than echoing the file, so a screen reader does not read the sample twice. `w-max` on the `<pre>` stops a block child shrinking to the scroller; `ring-inset` because the card wrapping it is `overflow-hidden` and would clip an outset ring.

No `onKeyDown` guard, unlike the palette. That guard keeps arrow keys off the global canvas shortcuts, and `useKeyboardShortcuts` is called from exactly one place — `app-layout.tsx:44`, reached only via `/app`. Both lanes verified this independently, including every `keydown` listener reachable from a marketing route. The guard would have defended against nothing, and the comment explaining its absence is the artifact that stops the next reader adding a dead handler.

## Review caught the thing that mattered

**My sweep never visited `/terms`, and `/terms` has a worse instance of the same defect.** Both lanes found it independently. The Apache licence + NOTICE dump at `terms-page.tsx:34` is 4784px of text in a 384px box — it hides ~92% of its content at *every* viewport width, not just narrow ones, and overflows horizontally at 320px as well. It had no tab stop and no name.

That is fixed here with the same pattern rather than deferred, since AC 5 asks for exactly this. The test file's claim that only one such container existed is corrected, and #292 — which inherited the same omission — has been corrected too.

**One claim in the first commit did not survive measurement.** I wrote that moving padding onto the `<pre>` also fixed the quirk where a scroller's trailing padding vanishes at the scroll end. The slop lane measured the gap at 16px both before and after, in Chromium and WebKit. The padding move is still correct — `w-max` needs a padded child — but it fixes nothing, and the comment no longer says otherwise. The first commit is immutable, so the correction is recorded in the follow-up and here.

Also corrected: the stated threshold was ~40px low (swept it — 460px clean, 440px overflows), and the test's "generous multiple" was really the focusable count plus five, a 26% margin.

## The awkward part of the test, stated plainly

The Tab traversal **cannot see the tab stop**. Chromium natively focuses overflowing scroll containers, so the loop passes with `tabIndex` deleted — measured, not assumed. So each test also asserts `tabindex="0"` directly.

That attribute is not decoration. Probing WebKit with the real page: at the parent commit a keyboard user could not reach the landing sample at all (`reached: false`); with the fix, they can. Same split for the vertical `/terms` scroller. Safari users are who this is for, and this project runs Chromium only — which is also why the assertion moved into `landing-page.test.tsx`, where a rename fails in under a second.

## Verification

- `npm run ci:local` green.
- Mutation matrix, landing: deleting `tabIndex`, `aria-label`, or `overflow-x-auto` each turns the test red. Baseline green. Independently reproduced by both lanes.
- Mutation matrix, `/terms`: deleting `tabIndex` or `aria-label` each turns its test red.
- Geometry identical before and after at 320/390/768/1280 — `392/270`, `392/340`, `718/718`, `550/550`, region height 676, card height 715, and `body.scrollHeight` unchanged (4597 @390, 4873 @320). The reviewer reproduced this on two dev servers running the two commits side by side.
- Focus ring verified visible, `inset`, and unclipped by the `overflow-hidden` card; absent when unfocused.

## Filed rather than folded in

**#292** — the marketing routes have no axe coverage, and a one-off scan found four pre-existing serious `color-contrast` failures on the landing page, including the accent word in the `h1`. Confirmed pre-existing by scanning a stashed tree.

That probe is worth a warning: my first run reported a clean pass and was wrong. Removing the element-visibility wait let axe scan before the lazy route chunk painted, and an unpainted page produces zero violations — indistinguishable from a healthy one. #292 records the trap.

Review also measured the focus-ring token itself at **2.58:1** against the card, under the 3:1 WCAG 2.2 SC 1.4.11 threshold. It is the site-wide `--ring`, used byte-identically in three existing places, so it belongs in #292 where it gets fixed once. Related and recorded there: all three `focus-visible:outline-none` sites predate Tailwind v4 semantics, and since the indicator is a `ring-*` (a `box-shadow`, which forced-colors strips), there is currently no focus indicator at all in Windows High Contrast.

## Review lanes

Both read-only against a frozen clean tree at `b93c2dd`, each attesting matching entry and exit state, mutating only in `/tmp` extracts, and reaping their own dev servers.

- **pr-reviewer — changes requested.** One must-fix (`/terms`), one should-fix (component-level coverage), two considers. Reproduced every measured claim in the commit without a refutation, and independently confirmed the WebKit asymmetry against the real page rather than a synthetic probe.
- **slop-auditor — needs-work.** Two must-fixes: the same `/terms` gap, and the fabricated padding-quirk claim. It also refuted one of *my* premises in the right direction — I asked whether `expect.poll` was masking a timing assumption, and it measured `scrollLeft` reading 0 immediately after ArrowRight 6 times out of 6, landing 19–34ms later. A plain assertion would have failed every run.

All must-fix and should-fix findings are resolved in `fddb9f1`.

Milestone: `M2 • Beta`.