### PR TITLE
fix(chat): keep long AI answers from scrolling the app out of reach

### DIFF
--- a/e2e/ai-tool-loop.spec.ts
+++ b/e2e/ai-tool-loop.spec.ts
@@ -1,5 +1,12 @@
-import type { Page, Route } from "@playwright/test";
-import { createModel, expect, seedAnthropicApiKey, test } from "./fixtures";
+import type { Page } from "@playwright/test";
+import {
+	addElementResponse,
+	openAiPanelWithModel,
+	routeAnthropic,
+	send,
+	textResponse,
+} from "./anthropic-sse";
+import { expect, test } from "./fixtures";
 
 /**
  * A deterministic, browser-only proof of the bounded tool loop (issue #62).
@@ -10,109 +17,6 @@ import { createModel, expect, seedAnthropicApiKey, test } from "./fixtures";
  * before and after must be identical, which fails for any implementation that
  * commits a mutation the user never approved.
  */
-
-interface SseFrame {
-	event: string;
-	data: unknown;
-}
-
-/** Serialize frames to Anthropic's SSE wire format. */
-function sse(frames: SseFrame[]): string {
-	return frames.map((f) => `event: ${f.event}\ndata: ${JSON.stringify(f.data)}\n\n`).join("");
-}
-
-const MODEL = "claude-sonnet-5";
-
-/** One assistant turn that calls add_element for a "Cache" process. */
-function addElementResponse(): string {
-	return sse([
-		{
-			event: "message_start",
-			data: {
-				message: { id: "msg_1", model: MODEL, usage: { input_tokens: 20, output_tokens: 1 } },
-			},
-		},
-		{ event: "content_block_start", data: { index: 0, content_block: { type: "text", text: "" } } },
-		{
-			event: "content_block_delta",
-			data: { index: 0, delta: { type: "text_delta", text: "Adding a cache." } },
-		},
-		{ event: "content_block_stop", data: { index: 0 } },
-		{
-			event: "content_block_start",
-			data: {
-				index: 1,
-				content_block: { type: "tool_use", id: "call_1", name: "add_element", input: {} },
-			},
-		},
-		{
-			event: "content_block_delta",
-			data: {
-				index: 1,
-				delta: {
-					type: "input_json_delta",
-					partial_json: JSON.stringify({
-						action: "add_element",
-						element: { type: "process", name: "Cache" },
-					}),
-				},
-			},
-		},
-		{ event: "content_block_stop", data: { index: 1 } },
-		{
-			event: "message_delta",
-			data: {
-				delta: { stop_reason: "tool_use", stop_sequence: null },
-				usage: { output_tokens: 15 },
-			},
-		},
-		{ event: "message_stop", data: { type: "message_stop" } },
-	]);
-}
-
-/** A plain text turn that ends the conversation. */
-function textResponse(text: string): string {
-	return sse([
-		{
-			event: "message_start",
-			data: {
-				message: { id: "msg_2", model: MODEL, usage: { input_tokens: 25, output_tokens: 1 } },
-			},
-		},
-		{ event: "content_block_start", data: { index: 0, content_block: { type: "text", text: "" } } },
-		{ event: "content_block_delta", data: { index: 0, delta: { type: "text_delta", text } } },
-		{ event: "content_block_stop", data: { index: 0 } },
-		{
-			event: "message_delta",
-			data: { delta: { stop_reason: "end_turn" }, usage: { output_tokens: 5 } },
-		},
-		{ event: "message_stop", data: { type: "message_stop" } },
-	]);
-}
-
-/** Route the Anthropic endpoint to return each scripted response in order. */
-async function routeAnthropic(page: Page, responses: string[]): Promise<void> {
-	let index = 0;
-	await page.route("https://api.anthropic.com/v1/messages", async (route: Route) => {
-		const body = responses[Math.min(index, responses.length - 1)];
-		index += 1;
-		await route.fulfill({ status: 200, contentType: "text/event-stream", body });
-	});
-}
-
-async function openAiPanelWithModel(page: Page): Promise<void> {
-	await seedAnthropicApiKey(page);
-	await page.goto("/app");
-	await createModel(page);
-	await page.getByTestId("tab-ai").click();
-	await expect(page.getByPlaceholder("Ask about threats...")).toBeVisible();
-}
-
-async function send(page: Page, message: string): Promise<void> {
-	const input = page.getByPlaceholder("Ask about threats...");
-	await input.fill(message);
-	await input.press("Enter");
-}
 
 const nodes = (page: Page) => page.locator("[data-testid^='node-']");
 

--- a/e2e/anthropic-sse.ts
+++ b/e2e/anthropic-sse.ts
@@ -1,0 +1,117 @@
+import type { Page, Route } from "@playwright/test";
+import { createModel, expect, seedAnthropicApiKey } from "./fixtures";
+
+/**
+ * Canned Anthropic streaming responses, and the panel helpers that drive them, for
+ * browser-only AI tests.
+ *
+ * No key and no network: `seedAnthropicApiKey` unlocks the panel and every request to the
+ * Anthropic endpoint is fulfilled with a scripted SSE body. Keeping the wire format in one
+ * place means a change to Anthropic's streaming contract breaks in one file rather than
+ * drifting between specs that each grew their own copy.
+ */
+
+interface SseFrame {
+	event: string;
+	data: unknown;
+}
+
+/** Serialize frames to Anthropic's SSE wire format. */
+export function sse(frames: SseFrame[]): string {
+	return frames.map((f) => `event: ${f.event}\ndata: ${JSON.stringify(f.data)}\n\n`).join("");
+}
+
+export const MODEL = "claude-sonnet-5";
+
+/** One assistant turn that calls add_element for a "Cache" process. */
+export function addElementResponse(): string {
+	return sse([
+		{
+			event: "message_start",
+			data: {
+				message: { id: "msg_1", model: MODEL, usage: { input_tokens: 20, output_tokens: 1 } },
+			},
+		},
+		{ event: "content_block_start", data: { index: 0, content_block: { type: "text", text: "" } } },
+		{
+			event: "content_block_delta",
+			data: { index: 0, delta: { type: "text_delta", text: "Adding a cache." } },
+		},
+		{ event: "content_block_stop", data: { index: 0 } },
+		{
+			event: "content_block_start",
+			data: {
+				index: 1,
+				content_block: { type: "tool_use", id: "call_1", name: "add_element", input: {} },
+			},
+		},
+		{
+			event: "content_block_delta",
+			data: {
+				index: 1,
+				delta: {
+					type: "input_json_delta",
+					partial_json: JSON.stringify({
+						action: "add_element",
+						element: { type: "process", name: "Cache" },
+					}),
+				},
+			},
+		},
+		{ event: "content_block_stop", data: { index: 1 } },
+		{
+			event: "message_delta",
+			data: {
+				delta: { stop_reason: "tool_use", stop_sequence: null },
+				usage: { output_tokens: 15 },
+			},
+		},
+		{ event: "message_stop", data: { type: "message_stop" } },
+	]);
+}
+
+/** A plain text turn that ends the conversation. */
+export function textResponse(text: string): string {
+	return sse([
+		{
+			event: "message_start",
+			data: {
+				message: { id: "msg_2", model: MODEL, usage: { input_tokens: 25, output_tokens: 1 } },
+			},
+		},
+		{ event: "content_block_start", data: { index: 0, content_block: { type: "text", text: "" } } },
+		{ event: "content_block_delta", data: { index: 0, delta: { type: "text_delta", text } } },
+		{ event: "content_block_stop", data: { index: 0 } },
+		{
+			event: "message_delta",
+			data: { delta: { stop_reason: "end_turn" }, usage: { output_tokens: 5 } },
+		},
+		{ event: "message_stop", data: { type: "message_stop" } },
+	]);
+}
+
+/** Route the Anthropic endpoint to return each scripted response in order. */
+export async function routeAnthropic(page: Page, responses: string[]): Promise<void> {
+	let index = 0;
+	await page.route("https://api.anthropic.com/v1/messages", async (route: Route) => {
+		const body = responses[Math.min(index, responses.length - 1)];
+		index += 1;
+		await route.fulfill({ status: 200, contentType: "text/event-stream", body });
+	});
+}
+
+/** Open the AI panel on a model, with a key seeded and the endpoint already routed. */
+export async function openAiPanelWithModel(page: Page): Promise<void> {
+	await seedAnthropicApiKey(page);
+	await page.goto("/app");
+	await createModel(page);
+	await page.getByTestId("tab-ai").click();
+	await expect(page.getByPlaceholder("Ask about threats...")).toBeVisible();
+}
+
+/** Type a message into the chat input and submit it. */
+export async function send(page: Page, message: string): Promise<void> {
+	const input = page.getByPlaceholder("Ask about threats...");
+	await input.fill(message);
+	await input.press("Enter");
+}

--- a/e2e/chat-scroll-containment.spec.ts
+++ b/e2e/chat-scroll-containment.spec.ts
@@ -1,0 +1,104 @@
+import {
+	addElementResponse,
+	MODEL,
+	openAiPanelWithModel,
+	routeAnthropic,
+	send,
+	sse,
+} from "./anthropic-sse";
+import { expect, test } from "./fixtures";
+
+/**
+ * A long AI answer must never scroll the application out from under the user (issue #293).
+ *
+ * The failure this pins is specific and was measured, not assumed. A long tool-loop turn makes
+ * the right panel's content taller than its box. `scrollIntoView` then walks every scrollable
+ * ancestor of the anchor — including the layout's middle row, which is `overflow: hidden`
+ * precisely so the user cannot scroll it. The script scrolls it anyway, the user cannot scroll
+ * it back, and the chat input rides up out of reach. Measured on the unfixed build at a 520px
+ * viewport: middle row `scrollTop` 390, chat input top 48 instead of 438.
+ *
+ * Reverting `useScrollPinnedToBottom` to `scrollIntoView` fails the ancestor assertion below.
+ *
+ * The short viewport is not incidental. A taller one leaves the panel enough room that nothing
+ * overflows, and with nothing to scroll the bug cannot appear at all.
+ */
+
+/** A closing text turn long enough to overflow the panel several times over. */
+function longTextResponse(): string {
+	const body = `Here is what changed. ${"Each sentence adds another line of explanation to the answer. ".repeat(120)}`;
+	return sse([
+		{
+			event: "message_start",
+			data: {
+				message: { id: "msg_2", model: MODEL, usage: { input_tokens: 30, output_tokens: 1 } },
+			},
+		},
+		{ event: "content_block_start", data: { index: 0, content_block: { type: "text", text: "" } } },
+		{ event: "content_block_delta", data: { index: 0, delta: { type: "text_delta", text: body } } },
+		{ event: "content_block_stop", data: { index: 0 } },
+		{
+			event: "message_delta",
+			data: { delta: { stop_reason: "end_turn" }, usage: { output_tokens: 900 } },
+		},
+		{ event: "message_stop", data: { type: "message_stop" } },
+	]);
+}
+
+test.describe("Chat scroll containment", () => {
+	test.use({ viewport: { width: 1000, height: 520 } });
+
+	test("a long answer leaves the layout and the chat input where they were", async ({ page }) => {
+		await routeAnthropic(page, [addElementResponse(), longTextResponse()]);
+		await openAiPanelWithModel(page);
+
+		const input = page.getByPlaceholder("Ask about threats...");
+		const inputBoxBefore = await input.boundingBox();
+		expect(inputBoxBefore).not.toBeNull();
+
+		await send(page, "add a cache");
+		await page.getByRole("button", { name: "Approve" }).click();
+		await expect(page.getByTestId("right-panel")).toContainText("Here is what changed.");
+
+		// The panel content must actually exceed its box, or the containment proves nothing.
+		const overflowed = await page.evaluate(() => {
+			const scroller = document.querySelector<HTMLElement>("[data-testid='chat-messages']");
+			return scroller ? scroller.scrollHeight > scroller.clientHeight * 2 : false;
+		});
+		expect(overflowed, "the answer must overflow the panel for this test to discriminate").toBe(
+			true,
+		);
+
+		// The smooth scroll settles a few frames after the last token.
+		await expect
+			.poll(async () =>
+				page.evaluate(() => {
+					const scroller = document.querySelector<HTMLElement>("[data-testid='chat-messages']");
+					return scroller ? Math.round(scroller.scrollTop) : 0;
+				}),
+			)
+			.toBeGreaterThan(0);
+
+		// Nothing outside the message list may have scrolled. The middle row is `overflow: hidden`,
+		// so any scroll offset here is one the user has no way to undo.
+		const strayScroll = await page.evaluate(() => {
+			const offsets: { where: string; top: number }[] = [];
+			const scroller = document.querySelector<HTMLElement>("[data-testid='chat-messages']");
+			for (let node = scroller?.parentElement ?? null; node; node = node.parentElement) {
+				if (node.scrollTop !== 0) {
+					offsets.push({ where: node.className.toString().slice(0, 60), top: node.scrollTop });
+				}
+			}
+			const doc = document.scrollingElement;
+			if (doc && doc.scrollTop !== 0) {
+				offsets.push({ where: "document", top: doc.scrollTop });
+			}
+			return offsets;
+		});
+		expect(strayScroll).toEqual([]);
+
+		// And the input the user types into stays exactly where it was.
+		const inputBoxAfter = await input.boundingBox();
+		expect(inputBoxAfter?.y).toBeCloseTo(inputBoxBefore?.y ?? -1, 0);
+	});
+});

--- a/src/components/panels/ai-chat-tab.test.tsx
+++ b/src/components/panels/ai-chat-tab.test.tsx
@@ -23,6 +23,9 @@ const streamConversationMock = vi.hoisted(() => vi.fn());
 // Whether the mocked keychain reports a stored key; a test flips it to reach the
 // chat view instead of the empty state. `rejection` is the #234 case: storage that
 // could not answer at all, which must not read as "no key configured".
+/** Every `scrollTo` the component made, with the element it was aimed at. */
+let scrollCalls: { target: Element; options: ScrollToOptions }[];
+
 const keychain = vi.hoisted((): { hasKey: boolean; rejection: Error | null } => ({
 	hasKey: false,
 	rejection: null,
@@ -69,8 +72,17 @@ beforeEach(() => {
 	localStorage.clear();
 	keychain.hasKey = false;
 	keychain.rejection = null;
-	// jsdom does not implement scrollIntoView, which the message list calls on update.
-	Element.prototype.scrollIntoView = vi.fn();
+	// jsdom implements no scroll methods, so the message list's own call needs a stand-in.
+	// It records rather than discards, because a test below asserts where the scroll landed.
+	scrollCalls = [];
+	Element.prototype.scrollTo = function scrollTo(
+		this: Element,
+		options?: ScrollToOptions | number,
+	) {
+		if (typeof options === "object" && options !== null) {
+			scrollCalls.push({ target: this, options });
+		}
+	};
 	useDocumentRegistry.setState({
 		documents: {},
 		openDocumentIds: [],
@@ -304,6 +316,17 @@ describe("AiChatTab tool-loop turn", () => {
 		expect(useAiTurnStore.getState().turn?.phase).toBe("awaiting_approval");
 		expect(screen.getByTitle("Stop generating (Esc)")).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "Approve" })).toBeInTheDocument();
+
+		// The conversation scrolls its own container and nothing above it (#293). jsdom has no
+		// layout engine, so it cannot show that ancestors stay put — that is
+		// `e2e/chat-scroll-containment.spec.ts`, and it remains the only guard for the
+		// containment itself. What this does catch is the call being dropped or aimed at the
+		// wrong element, which is how the bug was written in the first place.
+		expect(scrollCalls.length).toBeGreaterThan(0);
+		for (const { target, options } of scrollCalls) {
+			expect(target).toBe(screen.getByTestId("chat-messages"));
+			expect(options).toEqual({ top: expect.any(Number), behavior: "smooth" });
+		}
 	});
 
 	it("settles a live turn cancelled when the active document switches", async () => {

--- a/src/components/panels/ai-chat-tab.tsx
+++ b/src/components/panels/ai-chat-tab.tsx
@@ -345,14 +345,35 @@ function SessionBar() {
 	);
 }
 
-function MessageList({ messages, isStreaming }: { messages: ChatMessage[]; isStreaming: boolean }) {
-	const messagesEndRef = useRef<HTMLDivElement>(null);
+/**
+ * Keep a scroll container pinned to its own bottom as content arrives.
+ *
+ * Deliberately not `scrollIntoView`. That does not scroll one container — it walks every
+ * scrollable ancestor up to the document and scrolls each so the anchor sits at its start.
+ * `styles.css` sets `html, body { overflow: hidden }` for the desktop-app feel, which stops the
+ * *user* scrolling but not a script, so an ancestor driven that way cannot be dragged back
+ * (#293). `scrollTo` on the container itself moves that one element and nothing above it.
+ *
+ * The container is measured on each run rather than captured, because the streaming turn
+ * replaces its children between frames.
+ */
+function useScrollPinnedToBottom(dependency: unknown) {
+	const containerRef = useRef<HTMLDivElement>(null);
 
-	// Auto-scroll to bottom on new messages
-	// biome-ignore lint/correctness/useExhaustiveDependencies: messages intentionally in deps to trigger scroll on content change
+	// biome-ignore lint/correctness/useExhaustiveDependencies: the dependency signals that new content arrived rather than supplying a value the effect reads
 	useEffect(() => {
-		messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-	}, [messages]);
+		const container = containerRef.current;
+		if (!container) {
+			return;
+		}
+		container.scrollTo({ top: container.scrollHeight, behavior: "smooth" });
+	}, [dependency]);
+
+	return containerRef;
+}
+
+function MessageList({ messages, isStreaming }: { messages: ChatMessage[]; isStreaming: boolean }) {
+	const messagesRef = useScrollPinnedToBottom(messages);
 
 	if (messages.length === 0) {
 		return (
@@ -366,7 +387,11 @@ function MessageList({ messages, isStreaming }: { messages: ChatMessage[]; isStr
 	}
 
 	return (
-		<div className="flex flex-1 flex-col gap-2 overflow-y-auto">
+		<div
+			ref={messagesRef}
+			data-testid="chat-messages"
+			className="flex flex-1 flex-col gap-2 overflow-y-auto"
+		>
 			{messages.map((msg, i) => (
 				<MessageBubble
 					// biome-ignore lint/suspicious/noArrayIndexKey: messages are append-only
@@ -376,7 +401,6 @@ function MessageList({ messages, isStreaming }: { messages: ChatMessage[]; isStr
 					isStreaming={isStreaming && i === messages.length - 1 && msg.role === "assistant"}
 				/>
 			))}
-			<div ref={messagesEndRef} />
 		</div>
 	);
 }
@@ -399,7 +423,6 @@ function TurnConversation({ turn }: { turn: TurnState }) {
 	// those edits so the button's disabled state stays accurate; the depth itself
 	// is not otherwise needed, only its change.
 	const historyStackDepth = useHistoryStore((s) => s.past.length);
-	const messagesEndRef = useRef<HTMLDivElement>(null);
 
 	// A tool-enabled turn reviews mutations through the approval ledger, so fenced
 	// parsing is disabled for it; a text-only fallback turn keeps it.
@@ -413,13 +436,14 @@ function TurnConversation({ turn }: { turn: TurnState }) {
 	void historyStackDepth;
 	const availability = hasApplied ? undoAvailability() : "already_undone";
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: scroll to the latest on any turn change
-	useEffect(() => {
-		messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-	}, [turn]);
+	const messagesRef = useScrollPinnedToBottom(turn);
 
 	return (
-		<div className="flex flex-1 flex-col gap-2 overflow-y-auto">
+		<div
+			ref={messagesRef}
+			data-testid="chat-messages"
+			className="flex flex-1 flex-col gap-2 overflow-y-auto"
+		>
 			{bubbles.map((message, i) => (
 				<MessageBubble
 					// biome-ignore lint/suspicious/noArrayIndexKey: turn messages are append-only
@@ -476,8 +500,6 @@ function TurnConversation({ turn }: { turn: TurnState }) {
 					<Undo2 className="h-2.5 w-2.5" /> Undo this turn
 				</button>
 			)}
-
-			<div ref={messagesEndRef} />
 		</div>
 	);
 }


### PR DESCRIPTION
Closes #293.

## The bug

You reported that as the AI answer got longer, the whole app scrolled up out of reach. It did,
and there was no way to scroll it back.

The auto-scroll called `scrollIntoView` on a sentinel at the bottom of the message list. That
method does not scroll one container — it walks *every* scrollable ancestor of the anchor and
scrolls each one. One of those ancestors is the layout's middle row, which is `overflow: hidden`
specifically so the user cannot scroll it. A script can, and did. The chat input rode up towards
the top of the window and stayed there.

Setting `scrollTo` on the message list itself moves that one element and nothing above it.

## Getting there was not straight

Worth recording, because the first two reproduction attempts **failed** and both looked like
evidence the diagnosis was wrong:

| Attempt | Setup | Result |
|---|---|---|
| 1 | 720px viewport, 60-paragraph plain transcript | Contained. Document `scrollTop` 0, nothing overflowed |
| 2 | Same, 400px viewport | Contained. Still 0 |
| 3 | **1000x520, tool-loop path** — approved `add_element`, then a long text turn | **Reproduced** |

The missing precondition was the path, not the length. The tool-loop conversation is a different
component from the plain transcript, and its content overflows the panel where an equally tall
transcript does not. Without that overflow there is nothing for an ancestor scroll to act on, and
the bug cannot appear at all. The short viewport in the test is load-bearing for the same reason.

## What was cut

I also added `min-h-0` and `h-full` to the chat column's flex chain — the textbook remedy for this
shape. Taking them out again left the test passing, so they were measurably inert and are not in
this PR.

They were inert because the responsible node is higher up the tree: the panel wrapper still
reports `scrollHeight` 2621 against `clientHeight` 456 after this fix. That residual is #295, and
it matters — `HTMLElement.focus()` also scrolls ancestors, and the panel is full of focusable
controls, so the same symptom is still reachable through a different door.

## Verification

- `bash scripts/ci-local.sh --e2e` — 113 e2e passed, all checks green.
- New `e2e/chat-scroll-containment.spec.ts`. Reverting the hook to `scrollIntoView` fails its
  ancestor assertion, with the stray offset landing on the `overflow: hidden` middle row.
- Unit coverage asserts the scroll happens and lands on the message list. Deleting the call fails
  it; aiming it at the parent fails it. jsdom has no layout engine, so it cannot prove containment
  — the e2e is and remains the only guard for that, and the PR does not pretend otherwise.
- `e2e/ai-tool-loop.spec.ts` was rewired through a new shared SSE module. The reviewer confirmed
  by mutation that removing the approval gate still fails all four of its tests, so the #62
  security discriminator survived the refactor intact.

## Review

Two rounds, two independent lanes each, against a frozen tree.

Round 1 returned **needs-work** from both lanes on the same must-fix, which I had missed entirely:
the commit shipped the unit suite red, because jsdom implements no `Element.prototype.scrollTo`
and the test stubbed `scrollIntoView`. I had run Biome, `tsc` and Playwright but not Vitest.

Round 2 found something better. The round-1 fix was shallower than it looked — those 5 tests only
failed on a *name* jsdom doesn't implement, not on any assertion about scrolling. All 12 passed
with the scroll call deleted outright. That gap is now closed with the two mutations above.

The reviewer also could not reproduce two "before" magnitudes in the commit message (it measured
226/187 where I had recorded 390/48, from a reconstruction carrying its own confounds). The
message now leads with what the committed test actually measures and marks the ad-hoc figures as
such.

Both lanes were told explicitly which of my claims I most wanted refuted, which is where the
useful findings came from.

**Process note:** during round 1 I edited the working tree while the slop lane was still reading
it, which is exactly the isolation failure `AGENTS.md` warns about. It detected the drift and said
so. Both round-1 findings had been established against the clean tree, so no result was corrupted,
but it should not have happened and round 2 was run against a frozen tree.

## Not verified here

Whether this fully resolves what you saw. I reproduced *a* mechanism that produces exactly your
symptom and fixed it. Your screenshot also showed the canvas and palette ending about halfway down
the window with white below, which I could not explain and could not reproduce. If that part
persists after this, it is a separate defect and I'd want another look at it.