### PR TITLE
fix(privacy): describe the updater the shipped build actually has

### DIFF
--- a/docs/runbooks/configuring-release-signing.md
+++ b/docs/runbooks/configuring-release-signing.md
@@ -32,6 +32,11 @@ Signing is complete only when all of the following are true:
 - Verification output, checksums, updater manifests, and release workflow provenance are retained
   with the draft release.
 - No long-lived Azure client secret is required by GitHub Actions.
+- The privacy page and the Settings updates section no longer say automatic updates are switched
+  off. Both currently state that they are, and `privacy-page.test.tsx` only catches the half of
+  that drift visible in `tauri.conf.json` — it cannot see a published `latest.json`, so shipping
+  one while the copy still says the check fails would leave both surfaces lying with a green
+  suite. See #259.
 - Provider credential rotation, failed notarization, compromised-key response, and release
   rollback procedures have been exercised or reviewed by an owner.
 

--- a/src/components/panels/settings-dialog.test.tsx
+++ b/src/components/panels/settings-dialog.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { useSettingsStore } from "@/stores/settings-store";
+import { useUpdateStore } from "@/stores/update-store";
 import { DEFAULT_USER_SETTINGS } from "@/types/settings";
 import { SettingsDialog } from "./settings-dialog";
 
@@ -96,5 +97,41 @@ describe("SettingsDialog", () => {
 		expect(tabLabels).toContain("AI");
 		expect(tabLabels).not.toContain("Editor");
 		expect(tabLabels).not.toContain("Shortcuts");
+	});
+
+	describe("Updates section after a failed check", () => {
+		beforeEach(() => {
+			useUpdateStore.setState({
+				isChecking: false,
+				isInstalling: false,
+				updateAvailable: null,
+				lastCheckTime: Date.now(),
+				skippedVersion: null,
+				dismissed: false,
+				installError: null,
+				checkError: "Could not fetch a valid release JSON",
+			});
+		});
+
+		function openUpdates(): void {
+			render(<SettingsDialog />);
+			fireEvent.click(screen.getByRole("button", { name: /Updates/ }));
+		}
+
+		it("does not also claim the version is current", () => {
+			openUpdates();
+
+			// A check that errored found nothing because it never completed. Saying both at once
+			// is how the privacy page came to describe an updater that works (#259).
+			expect(screen.getByText(/Last attempt failed/)).toBeInTheDocument();
+			expect(screen.queryByText(/running the latest version/)).not.toBeInTheDocument();
+		});
+
+		it("does not promise signature verification that no release carries", () => {
+			openUpdates();
+
+			expect(screen.queryByText(/verified with a cryptographic signature/)).not.toBeInTheDocument();
+			expect(screen.getByText(/releases are not signed yet/)).toBeInTheDocument();
+		});
 	});
 });

--- a/src/components/panels/settings-dialog.tsx
+++ b/src/components/panels/settings-dialog.tsx
@@ -279,6 +279,7 @@ function UpdatesSection() {
 	const isChecking = useUpdateStore((s) => s.isChecking);
 	const updateAvailable = useUpdateStore((s) => s.updateAvailable);
 	const lastCheckTime = useUpdateStore((s) => s.lastCheckTime);
+	const checkError = useUpdateStore((s) => s.checkError);
 	const checkForUpdate = useUpdateStore((s) => s.checkForUpdate);
 
 	const lastChecked = lastCheckTime ? new Date(lastCheckTime).toLocaleString() : "Never";
@@ -297,7 +298,9 @@ function UpdatesSection() {
 			<div className="flex items-center justify-between gap-4">
 				<div className="min-w-0">
 					<p className="text-sm font-medium text-foreground">Check for updates</p>
-					<p className="text-xs text-muted-foreground">Last checked: {lastChecked}</p>
+					<p className="text-xs text-muted-foreground">
+						{checkError ? `Last attempt failed: ${checkError}` : `Last checked: ${lastChecked}`}
+					</p>
 				</div>
 				<button
 					type="button"
@@ -325,14 +328,15 @@ function UpdatesSection() {
 				</div>
 			)}
 
-			{!updateAvailable && lastCheckTime && !isChecking && (
-				<p className="text-xs text-muted-foreground">You're running the latest version.</p>
+			{!updateAvailable && lastCheckTime && !isChecking && !checkError && (
+				<p className="text-xs text-muted-foreground">You&apos;re running the latest version.</p>
 			)}
 
 			<div className="border-t border-border pt-4">
 				<p className="text-xs text-muted-foreground">
-					ThreatForge checks for updates automatically every 24 hours. Updates are downloaded from
-					GitHub Releases and verified with a cryptographic signature.
+					Threat Forge looks for a new version when you open it, at most once a day. Installing one
+					needs a signed release, and releases are not signed yet, so the check has nothing valid to
+					find. New versions are a download from threatforge.dev until that changes.
 				</p>
 			</div>
 		</div>

--- a/src/pages/privacy-page.test.tsx
+++ b/src/pages/privacy-page.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import tauriConfigSource from "../../src-tauri/tauri.conf.json?raw";
+import { PrivacyPage } from "./privacy-page";
+
+/**
+ * The privacy page states what the desktop app sends over the network, and that is only true
+ * for one particular updater configuration. The two live in files nobody would think to change
+ * together, so each assertion reads the real `tauri.conf.json` and only demands something of
+ * the copy when the configuration makes the claim checkable (#259).
+ */
+
+const tauriConfigSchema = z.object({
+	plugins: z.object({
+		updater: z.object({
+			endpoints: z.array(z.string()).nonempty(),
+			pubkey: z.string(),
+		}),
+	}),
+});
+
+const updater = tauriConfigSchema.parse(JSON.parse(tauriConfigSource)).plugins.updater;
+
+function privacyText(): string {
+	render(
+		<MemoryRouter>
+			<PrivacyPage />
+		</MemoryRouter>,
+	);
+	// Anchor on painted content so an empty render cannot pass as clean copy.
+	expect(screen.getByRole("heading", { name: "Privacy Policy" })).toBeInTheDocument();
+	return document.body.textContent ?? "";
+}
+
+describe("Privacy page auto-updater section", () => {
+	it("does not claim the check sends data the endpoint has no way to carry", () => {
+		const carriesVersion = updater.endpoints.some((e) => e.includes("{{current_version}}"));
+		// tauri-plugin-updater substitutes exactly four placeholders (updater.rs:437-440).
+		// `{{bundle_type}}` names the installer format, which reveals the platform too.
+		const carriesTarget = updater.endpoints.some(
+			(e) => e.includes("{{target}}") || e.includes("{{arch}}") || e.includes("{{bundle_type}}"),
+		);
+		expect(
+			carriesVersion,
+			"endpoint gained a version placeholder — the privacy copy must now say the version is sent",
+		).toBe(false);
+		expect(
+			carriesTarget,
+			"endpoint gained a target placeholder — the privacy copy must now say the platform is sent",
+		).toBe(false);
+
+		const text = privacyText();
+		expect(text).toContain("carries no version number and nothing about your machine");
+	});
+
+	it("says what GitHub does see, rather than claiming nothing identifying is sent", () => {
+		const text = privacyText();
+		expect(text).toContain("GitHub does see your IP address");
+		expect(text).not.toContain("no personally identifiable information is transmitted");
+	});
+
+	it("describes updates as unavailable for as long as releases are unsigned", () => {
+		expect(
+			updater.pubkey,
+			"a signing pubkey was configured — the privacy copy still says updates are not switched on",
+		).toBe("");
+
+		const text = privacyText();
+		expect(text).toContain("Automatic updates are not switched on yet");
+	});
+});

--- a/src/pages/privacy-page.tsx
+++ b/src/pages/privacy-page.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { PageShell } from "./shared/page-shell";
 
-const LAST_UPDATED = "July 26, 2026";
+const LAST_UPDATED = "July 27, 2026";
 
 export function PrivacyPage() {
 	return (
@@ -60,9 +60,17 @@ export function PrivacyPage() {
 
 					<Section title="Auto-Updater">
 						<p>
-							The desktop application checks GitHub Releases for new versions. This request includes
-							only the current app version and operating system — no personally identifiable
-							information is transmitted.
+							The desktop app asks GitHub whether a newer release exists when you open it, at most
+							once a day, and whenever you press Check for updates. Left running, it does not ask
+							again. The address it requests is fixed, so the request carries no version number and
+							nothing about your machine. GitHub does see your IP address and that the request came
+							from a Tauri updater, the same as it would for any other download from them.
+						</p>
+						<p>
+							Automatic updates are not switched on yet. Installing one requires a signed release,
+							and Threat Forge is not signing its binaries yet, so the check has nothing valid to
+							find and reports that it failed. Until that changes, moving to a new version means
+							downloading it from threatforge.dev yourself.
 						</p>
 					</Section>
 

--- a/src/stores/update-store.test.ts
+++ b/src/stores/update-store.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useUpdateStore } from "./update-store";
+
+/**
+ * The update check fails on every shipped build: releases are unsigned, so there is no
+ * `latest.json` to fetch. That is expected. Presenting it as a check that ran and found nothing
+ * is not (#259).
+ */
+
+const invokeMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: invokeMock }));
+vi.mock("@/lib/platform", () => ({ isTauri: () => true }));
+
+function resetStore(): void {
+	useUpdateStore.setState({
+		isChecking: false,
+		isInstalling: false,
+		updateAvailable: null,
+		lastCheckTime: null,
+		skippedVersion: null,
+		dismissed: false,
+		installError: null,
+		checkError: null,
+	});
+}
+
+describe("update store check failures", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		resetStore();
+	});
+
+	it("records the reason a check failed instead of reporting a completed check", async () => {
+		invokeMock.mockRejectedValue(new Error("Could not fetch a valid release JSON"));
+
+		await useUpdateStore.getState().checkForUpdate();
+
+		const state = useUpdateStore.getState();
+		expect(state.checkError).toBe("Could not fetch a valid release JSON");
+		expect(state.updateAvailable).toBeNull();
+	});
+
+	it("still stamps the time on a failure, because that is what throttles the retry", async () => {
+		invokeMock.mockRejectedValue(new Error("network unreachable"));
+
+		await useUpdateStore.getState().checkForUpdate();
+
+		expect(useUpdateStore.getState().lastCheckTime).toBeGreaterThan(0);
+	});
+
+	it("persists the failure alongside the timestamp that describes it", () => {
+		// `checkOnLaunch` skips a re-check for 24h after any stamped attempt, so if the error
+		// were dropped on rehydrate the next launch would show a clean "Last checked".
+		const persisted = useUpdateStore.persist.getOptions().partialize?.({
+			...useUpdateStore.getState(),
+			lastCheckTime: 1,
+			checkError: "Could not fetch a valid release JSON",
+		});
+		expect(persisted).toMatchObject({
+			lastCheckTime: 1,
+			checkError: "Could not fetch a valid release JSON",
+		});
+	});
+
+	it("clears a previous failure once a check succeeds", async () => {
+		invokeMock.mockRejectedValue(new Error("network unreachable"));
+		await useUpdateStore.getState().checkForUpdate();
+		expect(useUpdateStore.getState().checkError).not.toBeNull();
+
+		invokeMock.mockResolvedValue(null);
+		await useUpdateStore.getState().checkForUpdate();
+
+		expect(useUpdateStore.getState().checkError).toBeNull();
+	});
+});

--- a/src/stores/update-store.ts
+++ b/src/stores/update-store.ts
@@ -23,6 +23,8 @@ interface UpdateState {
 	dismissed: boolean;
 	/** Error message from a failed install attempt */
 	installError: string | null;
+	/** Error message from the last update check, cleared once one succeeds */
+	checkError: string | null;
 
 	// Actions
 	checkForUpdate: () => Promise<void>;
@@ -44,6 +46,7 @@ export const useUpdateStore = create<UpdateState>()(
 			skippedVersion: null,
 			dismissed: false,
 			installError: null,
+			checkError: null,
 
 			checkForUpdate: async () => {
 				if (!isTauri() || get().isChecking) return;
@@ -56,12 +59,15 @@ export const useUpdateStore = create<UpdateState>()(
 						updateAvailable: info,
 						lastCheckTime: Date.now(),
 						dismissed: false,
+						checkError: null,
 					});
 				} catch (err) {
-					// Update check may fail if updater is not configured or network is down.
-					// Still record the check time to avoid retrying too frequently.
-					console.warn("Update check failed:", err);
-					set({ lastCheckTime: Date.now() });
+					// A failed check is recorded as one, not passed off as a check that found
+					// nothing. The app cannot install an update until releases are signed, so this
+					// is the expected path today and the user is entitled to know it (#259).
+					// The timestamp is still written, because it throttles the retry.
+					const message = err instanceof Error ? err.message : String(err);
+					set({ lastCheckTime: Date.now(), checkError: message });
 				} finally {
 					set({ isChecking: false });
 				}
@@ -89,9 +95,14 @@ export const useUpdateStore = create<UpdateState>()(
 		}),
 		{
 			name: "threatforge-updates",
+			// `checkError` travels with the timestamp it describes. Persisting one without the
+			// other is what made the old bug survive a restart: `lastCheckTime` came back, the
+			// error did not, and the next launch skipped its re-check because the stamp looked
+			// recent — so Settings showed a clean "Last checked" for a check that had failed.
 			partialize: (state) => ({
 				lastCheckTime: state.lastCheckTime,
 				skippedVersion: state.skippedVersion,
+				checkError: state.checkError,
 			}),
 		},
 	),


### PR DESCRIPTION
Closes #259.

## What was actually wrong

The privacy page said the desktop update check "includes only the current app version and operating system — no personally identifiable information is transmitted." Both halves were wrong, in opposite directions. The endpoint is a fixed URL with no placeholders, so the request carries *neither* the version nor the platform; and what it does carry unavoidably — the caller's IP, to GitHub — was the one thing "no PII" glossed over.

**The issue's premise was partly wrong and I corrected it rather than implementing it.** #259 assumed an empty `pubkey` meant the updater never reaches the network. Reading `tauri-plugin-updater` 2.10.1 (the version `Cargo.lock` pins), `UpdaterBuilder::build` validates only the endpoint list and the architecture; `pubkey` is not read until `verify_signature` on the download path. The request goes out on every eligible launch and only then fails. Confirmed live: the endpoint 302s to the current release and 404s.

**I found a worse defect than the filed one.** A failed check was caught, logged to the console, and *still* stamped `lastCheckTime` — so Settings displayed "Last checked: just now" for a check that never completed. That is a success-shaped fallback on a user-visible surface. Settings now reports the failure.

## Beyond the issue's criteria

Review lanes caught two contradictions I introduced or left standing **in the same file I was editing**: Settings still rendered "You're running the latest version" on the failure path — the identical conflation I was fixing one panel over — and a footer still promised updates "verified with a cryptographic signature" that no release carries. Both fixed, each pinned by a test proven to fail against the old markup.

## Evidence

Every assertion here was mutation-proved, in both directions where that's meaningful:

- Reverting the privacy copy fails all three of `privacy-page.test.tsx`'s assertions.
- Adding a `{{current_version}}`, `{{target}}`, `{{arch}}`, or `{{bundle_type}}` placeholder to the endpoint fails it from the other side; so does adding a `pubkey`. That is all four placeholders the crate substitutes (`updater.rs:437-440`) — round 2 caught that my first version covered only three, which meant a `{{bundle_type}}` placeholder could have falsified the copy silently.
- Dropping `checkError` from `partialize` fails the persistence test and only that one. This one matters: persisting the timestamp without its error resurrects the exact bug one restart later, because that stamp also suppresses the re-check for 24 hours.
- Restoring either old Settings string fails its test.

`bash scripts/ci-local.sh --e2e` green (the real gate — `npm run ci:local` skips Playwright).

## Known residual, stated rather than hidden

The copy-to-config tripwire is one-directional. It gates on `pubkey`, so it cannot see a published `latest.json`. If one shipped while `pubkey` stayed empty, `check()` would start succeeding, the copy would become false, and the suite would stay green. The normal enablement path is caught (the runbook produces both in the same step, and a populated `pubkey` trips the test), but the gap is real, so I added it to the signing runbook's completion definition instead of pretending the test covers it.

Also filed #297 from the review: both updater commands `map_err(|e| e.to_string())`, and the plugin's `Io` variant can stringify a local filesystem path into a UI label. Latent today because the install path is unreachable; it goes live when signing lands.

Signing itself remains #49 and #44/#50/#51, deferred by the owner. This is the copy and the honesty of the failure path, which shouldn't wait on it.

## Review

Two independent read-only lanes (pr-reviewer, slop-auditor), two rounds, each against a frozen tree at a named commit with mutations confined to `/tmp`. Round 1 returned changes-requested/needs-work on findings I had missed; round 2 returned **minor with zero must-fix**, and its three `consider` items are all applied above.

## For owner validation

The privacy page is legal-adjacent, so the judgment I'd most like checked is whether every sentence reads as true *and* not misleading by omission — particularly "GitHub does see your IP address and that the request came from a Tauri updater," which is the disclosure the old copy omitted entirely.