### PR TITLE
fix(a11y): give marketing routes an axe gate and a legible accent

### DIFF
--- a/docs/quality/e2e-visual-accessibility-rubric.md
+++ b/docs/quality/e2e-visual-accessibility-rubric.md
@@ -11,6 +11,7 @@ not claim any of them replace human visual review.
 | Rubric item | Category | Mechanism |
 |---|---|---|
 | Contrast | Automated | `assertNoSeriousAccessibilityViolations` (axe `color-contrast` rule, once the known pre-existing exceptions — see "Known accessibility exceptions" below — are retired for a given surface) |
+| Marketing route coverage | Automated | `e2e/accessibility-marketing.spec.ts` scans all six public routes — `/`, `/downloads`, `/about`, `/privacy`, `/terms`, `/support` — at 1280×900 and 320×720, and again in dark theme. Navigation, the paint wait, and the scan are one inseparable helper, because axe reports an unpainted page as clean and so a scan that races the route's lazy chunk is a confident false pass; a dedicated test serves the pre-paint app shell and demonstrates that zero-violations result rather than asserting it (#292) |
 | Empty states | Automated | Existing `empty-states`-family specs plus `e2e/accessibility-audit.spec.ts`'s empty-canvas case |
 | Errors | Automated | `e2e/accessibility-audit.spec.ts`'s ephemeral-storage case (`seedEphemeralWorkspace`) exercises the visible "This session won't be saved" degraded/error state; malformed-file alerts are native transient dialogs and cannot be axe-scanned after dismissal |
 | Responsive behavior | Partially automated | At 900×700, `e2e/accessibility-audit.spec.ts` requires each key interactive surface to be visible and fully inside the viewport (`toBeInViewport({ ratio: 1 })`) with no body-level horizontal overflow; it does not prove the layout still *looks* good |

--- a/e2e/accessibility-marketing.spec.ts
+++ b/e2e/accessibility-marketing.spec.ts
@@ -1,0 +1,98 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "./fixtures";
+import { assertNoSeriousAccessibilityViolations, scanAccessibility } from "./support/accessibility";
+
+/**
+ * Tier-2 accessibility gate for the marketing routes (issue #292).
+ *
+ * `accessibility-audit.spec.ts` covers `/app` states only, so every public page shipped
+ * unscanned and every one of them was failing contrast.
+ */
+
+/** Every route `App.tsx` serves outside `/app`. `/terms` is included; #292's list omitted it. */
+const MARKETING_ROUTES = ["/", "/downloads", "/about", "/privacy", "/terms", "/support"] as const;
+
+/** The landing page reflows hardest at 320px, which is where #292 was originally measured. */
+const VIEWPORTS = [
+	{ name: "desktop", width: 1280, height: 900 },
+	{ name: "narrow", width: 320, height: 720 },
+] as const;
+
+/**
+ * Navigate, wait for paint, and scan — as one step that cannot be taken apart.
+ *
+ * Waiting is the whole defense. An unpainted page reports zero violations, which is
+ * indistinguishable from a healthy one, so a scan that races the route's lazy chunk is a
+ * confident false pass. #292's first probe reported exactly that.
+ *
+ * The wait therefore lives *inside* the scan rather than beside it. An earlier version of this
+ * file exposed the two separately, and review showed that deleting the wait from the call sites,
+ * while leaving the wait function and its own test intact, let a real contrast regression pass
+ * 13 of 13. There is deliberately no unguarded scan here for a future edit to strand after a
+ * `goto`.
+ *
+ * The footer anchor matters as much as the heading: the heading paints with the route shell, but
+ * three of the original violations were in the footer, below the fold.
+ */
+async function scanMarketingRoute(page: Page, route: string): Promise<void> {
+	await page.goto(route);
+	await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+	await expect(page.getByRole("contentinfo")).toBeAttached();
+
+	await assertNoSeriousAccessibilityViolations(page);
+}
+
+test.describe("Marketing route accessibility", () => {
+	for (const viewport of VIEWPORTS) {
+		for (const route of MARKETING_ROUTES) {
+			test(`${route} has no serious violations at ${viewport.name}`, async ({ page }) => {
+				await page.setViewportSize({ width: viewport.width, height: viewport.height });
+
+				await scanMarketingRoute(page, route);
+			});
+		}
+	}
+
+	for (const route of MARKETING_ROUTES) {
+		test(`${route} has no serious violations in dark theme`, async ({ browser }) => {
+			// These pages share `documentElement` with the app, so a reader whose system is dark
+			// sees them dark. The dark palette is expected to pass — the brand green is 10:1 on
+			// the dark surface, which is what it was designed for — but "expected to pass" is the
+			// state this suite exists to stop trusting. The class assertion matters: without it a
+			// context that failed to flip would quietly scan light theme a third time.
+			const context = await browser.newContext({ colorScheme: "dark" });
+			const page = await context.newPage();
+			try {
+				await page.goto(route);
+				await expect(page.locator("html")).toHaveClass(/dark/);
+
+				await scanMarketingRoute(page, route);
+			} finally {
+				await context.close();
+			}
+		});
+	}
+
+	test("a route that never paints cannot pass the gate", async ({ page }) => {
+		// Prove the guard fires, and prove what it guards against is real: axe scores the app
+		// shell before React paints as perfectly clean. This is the served `index.html` — correct
+		// `lang` and `<title>`, empty root — which is precisely the state a scan races when it
+		// starts before the route's lazy chunk arrives.
+		await page.route("**/*", async (route) => {
+			if (route.request().resourceType() === "document") {
+				await route.fulfill({
+					contentType: "text/html",
+					body: '<!doctype html><html lang="en"><head><title>Threat Forge</title></head><body><div id="root"></div></body></html>',
+				});
+				return;
+			}
+			await route.abort();
+		});
+		await page.goto("/");
+
+		const unpainted = await scanAccessibility(page);
+		expect(unpainted.violations).toHaveLength(0);
+
+		await expect(scanMarketingRoute(page, "/")).rejects.toThrow();
+	});
+});

--- a/src/pages/downloads-page.tsx
+++ b/src/pages/downloads-page.tsx
@@ -34,7 +34,7 @@ export function DownloadsPage() {
 									href={release.releaseUrl}
 									target="_blank"
 									rel="noopener noreferrer"
-									className="font-mono text-tf-signal hover:underline"
+									className="font-mono text-tf-signal-ink underline"
 								>
 									{release.version}
 								</a>
@@ -52,7 +52,7 @@ export function DownloadsPage() {
 									href={GITHUB_RELEASES_URL}
 									target="_blank"
 									rel="noopener noreferrer"
-									className="text-tf-signal hover:underline"
+									className="text-tf-signal-ink underline"
 								>
 									Download from GitHub
 								</a>
@@ -76,7 +76,7 @@ export function DownloadsPage() {
 					<div className="mt-16 text-center">
 						<p className="text-sm text-muted-foreground">
 							Or{" "}
-							<Link to="/app" className="text-tf-signal hover:underline">
+							<Link to="/app" className="text-tf-signal-ink underline">
 								try the web version
 							</Link>{" "}
 							— no download required.
@@ -153,7 +153,7 @@ function PlatformCard({
 				{icon}
 				<h3 className="font-semibold">{title}</h3>
 				{highlighted && (
-					<span className="ml-auto rounded-full bg-tf-signal/10 px-2.5 py-0.5 text-[10px] font-medium text-tf-signal">
+					<span className="ml-auto rounded-full bg-tf-signal/10 px-2.5 py-0.5 text-[10px] font-medium text-tf-signal-ink">
 						Recommended
 					</span>
 				)}

--- a/src/pages/landing-page.tsx
+++ b/src/pages/landing-page.tsx
@@ -84,7 +84,7 @@ function HeroSection() {
 				</div>
 				<h1 className="text-3xl font-bold tracking-tight text-balance text-foreground sm:text-4xl lg:text-5xl">
 					Threat modeling for people who <br className="hidden sm:inline" />
-					<span className="text-tf-signal">hate threat modeling tools</span>
+					<span className="text-tf-signal-ink">hate threat modeling tools</span>
 				</h1>
 				<p className="mx-auto mt-6 max-w-2xl text-lg text-muted-foreground">
 					You know the drill. Install something Windows-only, drag boxes around for an afternoon,
@@ -126,7 +126,7 @@ function FeaturesSection() {
 				<div className="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
 					{FEATURES.map((feature) => (
 						<div key={feature.title} className="rounded-lg border border-border/50 bg-card p-6">
-							<feature.icon className="h-8 w-8 text-tf-signal" />
+							<feature.icon className="h-8 w-8 text-tf-signal-ink" />
 							<h3 className="mt-4 text-sm font-semibold text-foreground">{feature.title}</h3>
 							<p className="mt-2 text-sm leading-relaxed text-muted-foreground">
 								{feature.description}

--- a/src/pages/privacy-page.tsx
+++ b/src/pages/privacy-page.tsx
@@ -90,7 +90,7 @@ export function PrivacyPage() {
 					<Section title="Contact">
 						<p>
 							For privacy concerns, contact us at{" "}
-							<a href="mailto:privacy@exitzerolabs.com" className="text-tf-signal hover:underline">
+							<a href="mailto:privacy@exitzerolabs.com" className="text-tf-signal-ink underline">
 								privacy@exitzerolabs.com
 							</a>
 							.

--- a/src/pages/shared/page-footer.tsx
+++ b/src/pages/shared/page-footer.tsx
@@ -27,7 +27,7 @@ export function PageFooter({ onOpenSettings }: PageFooterProps) {
 							</a>
 							.
 						</p>
-						<p className="mt-1 text-xs text-muted-foreground/60">v{__APP_VERSION__ ?? "dev"}</p>
+						<p className="mt-1 text-xs text-muted-foreground">v{__APP_VERSION__ ?? "dev"}</p>
 					</div>
 
 					{/* Product */}
@@ -126,14 +126,14 @@ export function PageFooter({ onOpenSettings }: PageFooterProps) {
 					</div>
 				</div>
 
-				<div className="mt-10 flex items-center justify-center gap-4 border-t border-border/50 pt-6 text-xs text-muted-foreground/60">
+				<div className="mt-10 flex items-center justify-center gap-4 border-t border-border/50 pt-6 text-xs text-muted-foreground">
 					<span>
 						&copy; {new Date().getFullYear()}{" "}
 						<a
 							href="https://www.exitzerolabs.com"
 							target="_blank"
 							rel="noopener noreferrer"
-							className="transition-colors hover:text-muted-foreground"
+							className="transition-colors hover:text-foreground"
 						>
 							Exit Zero Labs LLC
 						</a>

--- a/src/pages/support-page.tsx
+++ b/src/pages/support-page.tsx
@@ -64,7 +64,7 @@ export function SupportPage() {
 									href={`${GITHUB_URL}/issues`}
 									target="_blank"
 									rel="noopener noreferrer"
-									className="mt-3 inline-block text-sm text-tf-signal hover:underline"
+									className="mt-3 inline-block text-sm text-tf-signal-ink hover:underline"
 								>
 									Open an issue on GitHub
 								</a>
@@ -76,7 +76,7 @@ export function SupportPage() {
 								</p>
 								<a
 									href="mailto:admin@exitzerolabs.com"
-									className="mt-3 inline-block text-sm text-tf-signal hover:underline"
+									className="mt-3 inline-block text-sm text-tf-signal-ink hover:underline"
 								>
 									admin@exitzerolabs.com
 								</a>
@@ -207,7 +207,7 @@ function FirstRunSection() {
 					href={`${GITHUB_URL}/releases`}
 					target="_blank"
 					rel="noopener noreferrer"
-					className="text-tf-signal hover:underline"
+					className="text-tf-signal-ink underline"
 				>
 					View releases on GitHub
 				</a>
@@ -225,7 +225,7 @@ function renderAnswer(answer: string): ReactNode {
 					href={`${GITHUB_URL}/blob/main/SECURITY.md`}
 					target="_blank"
 					rel="noopener noreferrer"
-					className="text-tf-signal hover:underline"
+					className="text-tf-signal-ink underline"
 				>
 					Security Policy
 				</a>{" "}
@@ -241,7 +241,7 @@ function renderAnswer(answer: string): ReactNode {
 					href={GITHUB_URL}
 					target="_blank"
 					rel="noopener noreferrer"
-					className="text-tf-signal hover:underline"
+					className="text-tf-signal-ink underline"
 				>
 					GitHub repository
 				</a>{" "}

--- a/src/pages/terms-page.tsx
+++ b/src/pages/terms-page.tsx
@@ -20,7 +20,7 @@ export function TermsPage() {
 								href="https://opensource.org/licenses/Apache-2.0"
 								target="_blank"
 								rel="noopener noreferrer"
-								className="text-tf-signal hover:underline"
+								className="text-tf-signal-ink underline"
 							>
 								Apache License 2.0
 							</a>

--- a/src/styles.css
+++ b/src/styles.css
@@ -53,6 +53,19 @@
 	--color-tf-canvas: #fafaf8;
 	--color-tf-mist: #94a3b8;
 
+	/*
+	 * Signal drawn *on* the page background, rather than being the surface itself.
+	 *
+	 * The brand green is tuned for dark surfaces, where it reaches 10.2:1; on white it is 1.87:1
+	 * and fails WCAG 1.4.3 outright (#292). Where the green is the surface — button fills, badge
+	 * backgrounds, borders, rings — it keeps `--color-tf-signal`, because contrast there is a
+	 * question about whatever sits on top of it. Where the green is the mark being read against
+	 * the page, it uses this token, which `html.light` darkens: links, the landing headline
+	 * accent, and the marketing feature icons, which are read against the same background as the
+	 * text and would otherwise be the one washed-out element on a legible page.
+	 */
+	--color-tf-signal-ink: #00d97e;
+
 	/* Sidebar — for shadcn sidebar component */
 	--color-sidebar: oklch(0.145 0 0);
 	--color-sidebar-foreground: oklch(0.985 0 0);
@@ -109,6 +122,9 @@ html.light {
 	--color-sidebar-accent-foreground: oklch(0.205 0 0);
 	--color-sidebar-border: oklch(0.922 0 0);
 	--color-sidebar-ring: oklch(0.708 0 0);
+
+	/* 5.91:1 on white. The brand green at this lightness, not a different hue. */
+	--color-tf-signal-ink: #00734a;
 }
 
 /*


### PR DESCRIPTION
Closes #292.

## The issue understated it

#292 reported four failing contrast targets on the landing page. Measuring all six public routes at two viewports found **every one of the twelve combinations failing** — plus `/terms`, which the issue's route list omitted, and which I covered because a gate that skips a page because an issue forgot to name it is the gap this issue exists to close.

Two root causes, and the second one only appeared after fixing the first.

## The brand green is not a text color

`#00d97e` is tuned for dark surfaces, where it reaches 10.2:1. On white it is **1.87:1** — not marginal, roughly a quarter of what body text needs. It was the `h1` accent and every inline link on four routes.

Rather than restyle the brand, this splits the token along **where the green sits**. Where it *is* the surface — button fills, the badge background, borders, rings — `--color-tf-signal` is untouched, because contrast there is a question about whatever sits on top of it. Where it is the mark being read *against* the page, a new `--color-tf-signal-ink` applies, which `html.light` darkens to `#00734a` — the same hue at lower lightness, 5.91:1. Dark theme keeps the vivid green, which was already correct.

The footer was the second cause: `text-muted-foreground/60` computed to `#999999` at 2.84:1. The 40% fade bought nothing the muted token wasn't already providing. **It was failing in dark theme too, which nobody had noticed because nothing scanned it.**

## Fixing contrast unmasked a second rule

A darker link no longer separates from body text by color alone, so axe began reporting `link-in-text-block` at 1.26:1 against a 3:1 minimum. The answer is not a lighter link — that reintroduces the original defect — it's a non-color distinguisher, so in-prose links are underlined at rest. The standalone `inline-block` CTAs aren't in a text block and keep their hover underline.

This is worth flagging as a general lesson: **fixing one axe rule can unmask another that the failure was hiding.** Re-probe all rules after a contrast fix, not just the one you were chasing.

## The test design is the interesting part

#292 warns that its own first probe reported a confident clean pass by racing the route's lazy chunk, because **axe reports an unpainted page as zero violations — indistinguishable from a healthy one.**

My first version defended that badly, and the review lane proved it: the wait was a separate function with its own test, so deleting the *call* from the route tests — leaving the function and its test intact — let a real contrast regression pass **13/13**. Guarding the function body is not guarding its use.

So navigation, the wait, and the scan are now one inseparable helper. There is no unguarded scan left to strand after a `goto`. The same double mutation now leaves 18 of 19 green and turns the guard test red. The guard serves the real pre-paint app shell — correct `lang` and `<title>`, empty root — and *demonstrates* axe scoring it clean rather than asserting the risk in a comment.

## Evidence

Every fix proven load-bearing by reverting it, measured against the shipped 19-test suite at `--workers=1`:

| Mutation | Result |
|---|---|
| Light-theme `--color-tf-signal-ink` → `#00d97e` | 10 of 19 fail |
| Footer `/60` opacity restored | 18 of 19 fail (including all six dark-theme scans) |
| Paint wait deleted **and** token regression reintroduced | guard test fails; suite red |

`bash scripts/ci-local.sh --e2e` green — 132 E2E, 19 new.

## Owner taste call, non-blocking

The darkened green is the one genuinely taste-bound decision. I asked and you were away, so I shipped **B `#00734a`** (most brand-faithful, 5.91:1). Swapping is one line in `html.light`. Measured alternatives:

| | Hex | On white |
|---|---|---|
| **B (shipped)** | `#00734A` | 5.91:1 |
| A emerald-700 | `#047857` | 5.48:1 |
| D lightest passing | `#00875A` | 4.55:1 |
| F deep forest | `#006644` | 7.04:1 (AAA) |
| C teal-forward | `#0F766E` | 5.47:1 |

## Review

Two independent read-only lanes, two rounds each, against a frozen tree with mutations confined to `/tmp`.

Round 1 found the paint-wait hole above (should-fix) and that dark theme was entirely unscanned. Round 2's slop lane caught something I'd rather it hadn't needed to: when round 1 flagged that I'd colored an SVG icon with the text token, **I rewrote the comment to justify the code instead of fixing the contradiction** — and the justification I invented ("icons sit inline with the copy they label") is checkably false; they're block elements stacked above the heading. The comment now states the actual distinction. Round 2's review lane separately caught that my commit message's mutation counts had gone stale against a suite that had grown; they're re-measured above.

Both lanes ended `minor` with no must-fix.

## For owner validation

Two judgment calls worth your eye: whether always-underlined prose links read acceptably on `/support` and `/privacy` (it's a visible change to those pages), and whether the darker accent still feels like ThreatForge on the landing hero.

Out of scope, filed rather than folded in: #299 (in-app status icons are 1.87:1 in light themes — WCAG 1.4.11, which axe does not check, so no gate sees it).