### PR TITLE
docs(quality): record the relabeled control and the self-sourced lesson

### DIFF
--- a/docs/quality/agentic-slop.md
+++ b/docs/quality/agentic-slop.md
@@ -25,6 +25,8 @@ slop when they protect a real invariant. A review that manufactures findings is 
 - Defensive branches cover impossible states while realistic failure paths are unhandled.
 - APIs, CLI flags, status codes, environment behavior, or platform guarantees are guessed.
 - Logic is duplicated instead of using an established contract or helper.
+- A control's label and render condition are updated together while its handler keeps doing what
+  the old condition implied.
 - Dead scaffolding, placeholder values, fake adapters, or TODO behavior remains on a success
   path.
 - `any`, double casts, `as never`, non-null assertions, or unvalidated records bypass the type
@@ -47,6 +49,8 @@ slop when they protect a real invariant. A review that manufactures findings is 
 
 - Documentation restates code instead of linking to the canonical source.
 - Rationale or precision is invented after the fact.
+- A rule or comment is justified only by a mistake that never existed outside the change making
+  it, so nothing supporting it survives the branch.
 - A runbook claims a deployment, security, or signing control that is not configured.
 - One hosting, release, or project surface changes while DNS, workflows, privacy text, or
   repository policy remains stale.
@@ -124,3 +128,49 @@ makes a suite pass for a lane that then clears the change.
 require every lane that has a shell to open its report with the tree state it observed and to
 confirm — not assume — that it restored what it changed. A lane with no shell cannot read that
 state and is given its commit instead. See #264 and `.claude/skills/pr-preflight/SKILL.md`.
+
+### 2026-07-27 — A control was relabeled to match its new gate while its handler kept the old one
+
+**Tell:** the clear-text key notice's render condition widened from the selected provider to any
+provider holding residue, and its label was rewritten from a destructive phrasing to a re-read
+phrasing. The gate and the label agreed with each other. The handler still called `deleteKey`,
+which commits a permanent revocation marker — so an `unverified` reading rendered a red `Trash2`
+control labeled `Check again` that destroyed a key the user had asked it only to look at. Later
+in the same change, a control whose copy spoke only about the clear-text slot destroyed an
+encrypted key saved in a second tab. Two review lanes found that one independently in round two:
+it survives the author, and it survives every test that asserts the label.
+
+The general shape: **relabeling is the cheapest edit in a review cycle.** When a reviewer says
+the wording is wrong the fix is a string, and nothing about editing a string prompts anyone to
+re-derive whether the dispatch beneath it still follows from the new condition.
+
+**Fix:** when a control's label or render condition changes, re-derive its handler from the new
+condition, and pin the *dispatch* in a test rather than the label. See PR #266 (`fddaab3`) and the
+2026-07-27 deviation rows in `docs/plans/233-persistent-clear-text-key-warning.md`.
+
+### 2026-07-27 — A comment was justified by a mistake that only existed in its own draft
+
+**Tell:** comments drafted during #233 explained why an approach had been rejected, where the
+rejected approach had only ever existed in an earlier draft of the same diff. They read as
+hard-won and cited nothing a reader could reach. Nobody outside the branch could have made the
+mistake being warned about, and the warning would outlive every reader able to interpret it.
+
+This is not the neighboring pattern of inventing rationale. There the reasoning is fabricated;
+here it is sound and simply undurable — the evidence was discarded with the draft, so the rule it
+supports cannot be re-derived, re-tested, or retired when it stops applying. From the artifact
+alone the two look identical, because a justification with no trace in the record reads the same
+either way, and the artifact-level remedy is the same for both. The distinction is for the author,
+who is this document's primary reader during self-review and the one person who knows which they
+are doing.
+
+**Boundary, so this cannot be used to strip legitimate comments:** a self-review correction is
+good evidence for a comment describing *the code as shipped*. The launch-probe comment in
+`src/components/layout/app-layout.tsx` is the shape that holds up — it says why the probe exists
+and points at a dated measurement in that plan's replan log, so its support outlived the branch.
+The pattern is specifically about rules whose only support is a discarded alternative.
+
+**Fix:** ground a rule in something that outlived the branch — a committed plan row, an issue, or
+a test that fails without it — or state the fact about the shipped code and drop the story. This
+entry is held to that standard too: #233's own instances were caught in its review rounds and
+never merged, so no line of the diff records them. The contemporaneous filing is #267, made the
+same day the fix landed and describing them — a record of the observation, not of the hazard.


### PR DESCRIPTION
Closes #267.

Transcribes the two recognition patterns that came out of #233 and were deliberately left out of #264's diff. Docs-only: two bullets and two dated log entries in `docs/quality/agentic-slop.md`.

## Pattern 1 — the relabeled control

A control's render condition widens and its label is rewritten to match, while the handler keeps doing what the old condition implied. Label and gate agree; only the dispatch disagrees, and nothing on screen shows it.

In #233 an `unverified` reading rendered a red `Trash2` labeled `Check again` wired to `deleteKey`, which commits a permanent revocation marker — `browser-key-vault.ts:723`, reached only through `deleteKey`, and the file notes at :704 there is no way to clear one. Later in the same change, a control whose copy spoke only about the clear-text slot destroyed an encrypted key saved in a second tab; two lanes found that independently in round two.

Guard: when a label or render condition changes, re-derive the handler from the new condition and pin the *dispatch* in a test, not the label.

## Pattern 2 — the self-sourced lesson

A rule whose only support is a mistake that never existed outside the change making it.

Distinguished in the entry from the adjacent "rationale invented after the fact", which #267 named as a must-not-restate: there the reasoning is fabricated, here it is sound but undurable. Both read identically from the artifact, so the entry says plainly that *that* distinction is one only the author can apply during self-review — while the bullet is worded around the survivability check, which any reviewer can run.

The boundary is stated so this cannot be used to strip legitimate comments, anchored to a shipped counter-example: the launch-probe comment in `app-layout.tsx:57-60`, whose support is a dated row in that plan's replan log and so outlived the branch.

## AC2 needs your call

The issue's AC2 asks each entry to cite the #233 evidence "specifically enough that a reader can find it in the diff."

- **Pattern 1 meets it.** The reviewer confirmed the plan file was *added* in `fddaab3` (#266), so deviation rows 795 and 799 are genuinely in that diff. `fddaab3` is an ancestor of `main`.
- **Pattern 2 cannot meet it, by construction.** Its instances were caught in #233's own review rounds and never merged. #266 is a squash merge with the branch deleted, the plan records no comment-removal deviation, and the PR's only review comments are two CodeQL notices. Both lanes searched independently and confirmed the impossibility.

Rather than manufacture a line reference — which would itself be the pattern being filed — the entry states the absence and cites #267 as the contemporaneous filing, made the same day the fix landed (#266 merged 12:31 UTC, #267 filed 12:44 UTC). Both lanes judged this legitimate rather than circular: #267 is testimony authored before this commit and independent of this diff, and the entry is explicit that it records the observation, not the hazard.

**Flagging rather than claiming AC2 met.** If you'd rather pattern 2 lived as a bullet only, with no dated log entry, that's a one-block deletion — though AC1 currently asks for both.

## Review

Two independent read-only lanes, two rounds each, frozen commits, tree state recorded on open and close.

Round 1 (`a0ef485`) — both `minor`, zero must-fix. The slop lane landed the finding that mattered: my pattern-2 entry was, by its own criterion, self-sourced, surviving only on a rhetorical inversion ("that absence is the reason the pattern needs writing down"). The reviewer independently found dialect drift against `:77` "neighboring", and both flagged the fabricated-vs-undurable split as operationally thin.

All applied: cut the inversion and anchored to #267; cut "which is what a genuinely invisible defect looks like"; rewrote the thin distinction to state outright that both look identical from the artifact; unified spelling; and dropped a self-congratulatory paragraph from the commit message that narrated a mistake existing only in my own draft — the slop lane called that self-promotion, and it was right.

Round 2 (`d7a3a1f`) — both **clean**, zero must-fix, zero should-fix. Two framing `consider`s applied anyway: "the remedy is the same" → "the artifact-level remedy is the same" (the old phrasing undersold the bullet's reviewer-operable check), and "the durable record" → "the contemporaneous filing … a record of the observation, not of the hazard."

Every factual assertion was verified against the repo by both lanes in both rounds, not read for plausibility. One I caught myself: the first draft cited `ec26b8c`, which lives only on the deleted feature branch — replaced with #266 (`fddaab3`), confirmed an ancestor of `main`.

`.e0l/` untouched; if either pattern deserves to be company-wide that is an upstream amendment.

## Verification

`npm run ci:local` green. No test references this file; CI runs the full gate.