### PR TITLE
fix(ui): keep the right panel's content inside its box

### DIFF
--- a/e2e/chat-scroll-containment.spec.ts
+++ b/e2e/chat-scroll-containment.spec.ts
@@ -101,4 +101,54 @@ test.describe("Chat scroll containment", () => {
 		const inputBoxAfter = await input.boundingBox();
 		expect(inputBoxAfter?.y).toBeCloseTo(inputBoxBefore?.y ?? -1, 0);
 	});
+
+	/**
+	 * #293's fix stopped one script from exploiting the panel's overflow. This pins the overflow
+	 * itself, because `scrollIntoView` was never the only caller that walks scrollable ancestors.
+	 *
+	 * The escaping node is the `sr-only` live region in `tool-call-card.tsx`: `position: absolute`
+	 * with no offsets, so it sat at its static position deep in the message flow while being laid
+	 * out against the layout's right `<aside>`, the nearest positioned ancestor — and therefore
+	 * outside this scroller's clipping. Removing `relative` from `chat-messages` restores it.
+	 *
+	 * The forced scroll at the end pins the property rather than one caller: the row cannot be
+	 * scrolled at all, which holds for `scrollIntoView`, `focus()`, and any future script alike.
+	 */
+	test("the right panel's content never exceeds its box", async ({ page }) => {
+		await routeAnthropic(page, [addElementResponse(), longTextResponse()]);
+		await openAiPanelWithModel(page);
+
+		await send(page, "add a cache");
+		await page.getByRole("button", { name: "Approve" }).click();
+		await expect(page.getByTestId("right-panel")).toContainText("Here is what changed.");
+
+		const box = await page.evaluate(() => {
+			const scroller = document.querySelector<HTMLElement>("[data-testid='chat-messages']");
+			const aside = scroller?.closest("aside");
+			const row = aside?.parentElement ?? null;
+			// The middle row is `overflow: hidden`: a script may scroll it and the user may not.
+			if (row) row.scrollTop = 9999;
+			return {
+				messageScroll: scroller ? scroller.scrollHeight : 0,
+				messageBox: scroller ? scroller.clientHeight : 0,
+				asideScroll: aside ? aside.scrollHeight : -1,
+				asideBox: aside ? aside.clientHeight : -2,
+				rowScroll: row ? row.scrollHeight : -1,
+				rowBox: row ? row.clientHeight : -2,
+				rowTopAfterForcedScroll: row ? row.scrollTop : -1,
+			};
+		});
+
+		// The turn must overflow the message list, or the containment below proves nothing.
+		expect(
+			box.messageScroll,
+			"the answer must overflow the message list for this test to discriminate",
+		).toBeGreaterThan(box.messageBox * 2);
+
+		// The message list absorbs all of it. Nothing escapes into the panel or the layout row,
+		// so there is no range for an ancestor scroll to act on.
+		expect(box.asideScroll).toBe(box.asideBox);
+		expect(box.rowScroll).toBe(box.rowBox);
+		expect(box.rowTopAfterForcedScroll).toBe(0);
+	});
 });

--- a/src/components/panels/ai-chat-tab.tsx
+++ b/src/components/panels/ai-chat-tab.tsx
@@ -386,11 +386,13 @@ function MessageList({ messages, isStreaming }: { messages: ChatMessage[]; isStr
 		);
 	}
 
+	// `relative` mirrors `TurnConversation` for parity. This list renders bubbles only, so
+	// nothing absolutely positioned escapes it today (#295).
 	return (
 		<div
 			ref={messagesRef}
 			data-testid="chat-messages"
-			className="flex flex-1 flex-col gap-2 overflow-y-auto"
+			className="relative flex flex-1 flex-col gap-2 overflow-y-auto"
 		>
 			{messages.map((msg, i) => (
 				<MessageBubble
@@ -438,11 +440,19 @@ function TurnConversation({ turn }: { turn: TurnState }) {
 
 	const messagesRef = useScrollPinnedToBottom(turn);
 
+	// `relative` below is load-bearing (#295). This scroller renders `ToolCallBatch`, whose
+	// `sr-only` live region is `position: absolute` with no offsets: it renders at its static
+	// position — far down a long turn — while being laid out against its nearest positioned
+	// ancestor. That ancestor used to be the layout's right `<aside>`, and an absolutely
+	// positioned element whose containing block sits outside a scroller is not clipped by
+	// that scroller, so this one node escaped and stretched the aside's scroll range past
+	// anything the user could scroll back. Anchoring the containing block here clips it with
+	// the rest of the turn. `e2e/chat-scroll-containment.spec.ts` pins the property.
 	return (
 		<div
 			ref={messagesRef}
 			data-testid="chat-messages"
-			className="flex flex-1 flex-col gap-2 overflow-y-auto"
+			className="relative flex flex-1 flex-col gap-2 overflow-y-auto"
 		>
 			{bubbles.map((message, i) => (
 				<MessageBubble


### PR DESCRIPTION
Closes #295.

## What was wrong

A long tool-loop turn left the layout's right `<aside>` with a scroll range several times its own height, dragging the `overflow: hidden` middle row with it — a range the user has no way to scroll back. #293 stopped one script from exploiting it; the overflow itself remained.

## The cause is not flex sizing

#295 suspected a missing `min-h-0`. That hypothesis is disproved: adding `min-h-0` to `ai-chat-tab.tsx` during #293 measurably changed nothing. Measuring the whole ancestor chain during an approved `add_element` plus a long text turn, `chat-messages`, its parent, `AiChatTab`, the tab content and `#right-panel` are all bounded. The aside is where the number jumps.

The single escapee is a 1px `sr-only` live region in `tool-call-card.tsx:213`. `sr-only` sets `position: absolute` with no offsets, so it renders at its *static* position — far down the message flow — while being laid out against its nearest **positioned** ancestor, which was the aside. An absolutely positioned element whose containing block sits outside a scroller is not clipped by that scroller. The message list absorbed its own content correctly; this one node escaped.

## The fix

`relative` on the `chat-messages` scroller makes the message flow the containing block, so such content is clipped with everything else. Measured after: aside `scrollHeight` 4045 → 456, zero escaping descendants, message list still scrolls its own content normally.

`TurnConversation`'s `relative` is the load-bearing one — it is the scroller that renders `ToolCallBatch`. `MessageList` gets the same class for parity and its comment says only that. Verified empirically: removing `MessageList`'s class alone leaves the suite green; removing `TurnConversation`'s turns it red.

## AC4 is proposed for striking, not checked

The fourth criterion asked for a test that focusing a panel control leaves the row at 0. That test would not discriminate. Measured on the *unfixed* build, focusing every control in the panel left the row at 0 every time, because each control lives inside a scroller that clips, so revealing it never needs an ancestor to move. The one node far out of view is not focusable, and a review lane could not construct a counterexample either.

The suite pins the stronger property instead: the row cannot be scrolled *at all*, forced with `row.scrollTop = 9999`. That covers `scrollIntoView`, `focus()`, and any future caller. Raised as a comment on #295 rather than decided here — it needs owner sign-off that the criterion is retired rather than met.

## Pixel figures are kept out of the code

The issue measured the aside at 2621; the same repro measured 4045 here. The numbers track content and viewport, so they do not belong in a durable comment. `e2e/chat-scroll-containment.spec.ts` is the evidence.

## Verification

- `bash scripts/ci-local.sh --e2e` — green, 133 E2E passed
- Mutation-proved: removing `relative` from `TurnConversation` turns the new test red
- Accessibility unchanged — the live region is still in the accessibility tree and `aria-live` fires independent of clipping; `sr-only` already hid it visually

## Review lanes

Two independent read-only lanes (pr-reviewer, slop-auditor), both against a frozen clean tree, two rounds.

- **Round 1** found no must-fix in the behaviour but three artifact defects: the mechanism comment was attached to `MessageList`, which never renders the escaping region; a cross-reference pointed at itself; and the comment asserted the `focus()` vector my own measurement had disproved.
- **Round 2** independently found that those three fixes had been *reported* applied but were **not in the tree** — the amend rewrote the commit message and the test while the source comments stayed inverted, so the commit message described a file that did not exist. Both lanes converged on this without prompting. Fixed for real in `36e0786`, verified by reading the committed blob rather than the working tree.

Nothing a reviewer could not verify: the AC4 substitution is the one open judgment call, and it is on the issue.