### PR TITLE
fix(worker): apply the release contract where the traffic is, and pin it to paths we control

### DIFF
--- a/docs/plans/286-release-schema-trust.md
+++ b/docs/plans/286-release-schema-trust.md
@@ -1,0 +1,247 @@
+# Issue 286 — Apply the release contract where the traffic is, and pin it to this repository
+
+## Objective
+
+Two halves of one trust question in `worker/latest-release.ts` and
+`src/lib/github-release-schema.ts`.
+
+First, the schema runs on the path that almost never executes and not on the path that serves
+almost every request. `readLastKnownGood` re-parses the stored fallback and refuses it if it
+fails, with a comment explaining that the Cache API is shared, zone-scoped, evictable storage
+rather than this module's private memory. The freshness hit a few lines earlier returns
+`cache.match`'s response straight to the client with no schema run at all. The file's own stated
+reasoning is not applied where the traffic is.
+
+Second, the schema pins release URLs to the `github.com` **host** and not to this
+**repository**. A `browser_download_url` of
+`https://github.com/someone-else/anything/releases/download/v1/evil.dmg` validates today and
+would be rendered as a download button a visitor clicks to run a binary.
+
+Neither is a live hole. Nothing untrusted can write `caches.default` for this zone, and GitHub's
+own API is what populates the payload. Both are defence in depth on the one route that hands a
+user an executable.
+
+## Issue contract
+
+- **Issue:** `#286`
+- **Parent initiative:** `N/A` (originating issue: `#284`, whose security lane found both)
+- **Type:** `Bug`
+- **Effort:** `Medium`
+- **Priority:** `Low`
+- **Autonomy:** `AUTO`
+- **Milestone:** `M3 • Release 1`
+- **Dependencies:** none. No secret, binding, namespace, or account action is required
+- **Non-goals:**
+  - negative caching of refusals — that is `#287`, filed separately because it is one mechanism
+    with its own recovery trade
+  - the fallback path, which already validates and needs no change
+  - the downloads page failure copy
+  - authenticating the upstream call
+
+## Current behavior and evidence
+
+`worker/latest-release.ts:290-293`:
+
+```ts
+const cached = await cache.match(cacheKey);
+if (cached) {
+    return cached;
+}
+```
+
+The response object is handed to the client unread. By contrast `readLastKnownGood`
+(`:226-247`) reads the body, `JSON.parse`s it, runs `parseGithubRelease`, and logs
+`fallback-unreadable` and returns `null` on either failure.
+
+`src/lib/github-release-schema.ts:3-10`:
+
+```ts
+const url = new URL(value);
+return url.protocol === "https:" && url.hostname === "github.com";
+```
+
+`https://github.com/attacker/repo/releases/download/v1/evil.dmg` satisfies this. So does
+`https://github.com:8443/...`, because the check reads `hostname` and ignores the port, and so
+does `https://user:password@github.com/...`.
+
+## Approach
+
+### 1. Validate the freshness hit
+
+Read a clone of the stored response, `JSON.parse` it, and run `parseGithubRelease`. On success
+return the **stored response unchanged**. On failure log a fixed reason token and fall through
+to the upstream fetch exactly as a miss would.
+
+Returning the stored response rather than a re-serialization is deliberate and is the narrower
+change. The stored entry carries its own `Cache-Control: public, max-age=300` and whatever `Age`
+the runtime attached, which together are what tell the visitor's browser how much of the 300
+seconds is left. Re-serializing would emit a fresh `max-age=300` measured from the hit, silently
+extending client-side freshness — a regression introduced by a hardening change, which is the
+worst kind. The bytes returned are the bytes validated, because the clone and the original are
+the same body.
+
+The one property re-serialization would add and this does not is stripping unknown keys from a
+poisoned-but-schema-valid entry. That is already covered downstream: `src/lib/github-releases.ts`
+re-validates this Worker's response with the same schema before use, so extra keys never reach
+`downloads-page.tsx`. Adding a second strip here would buy nothing and cost the freshness
+semantics above.
+
+Reason token: `freshness-unreadable`, mirroring the existing `fallback-unreadable`. The
+`UnavailableReason` docstring widens from "why a lookup could not produce a validated release" to
+cover a stored value that could not be used, because a rejected freshness hit is not fatal — the
+request continues upstream.
+
+Cost: one `JSON.parse` of a few kilobytes per request. This is the hot path, so that is worth
+naming rather than waving at: the body is the narrowed release, on the order of a kilobyte for a
+release with seven assets, and the alternative is a request that reaches GitHub. It is not per
+upstream fetch, it is per request, and it is still far below the cost of the response itself.
+
+### 2. Pin release URLs to this repository
+
+Replace the host check with an origin-and-path check:
+
+- `url.origin === "https://github.com"` — this subsumes both the protocol and the port, where
+  `hostname` ignored the port
+- no `username` or `password` — a genuine API payload never carries credentials, and a URL that
+  does is a phishing shape
+- `url.pathname` begins with a maintainer-controlled release path
+
+*Corrected after the round-1 security review — see the change log.* The first draft pinned to
+`/exit-zero-labs/threat-forge/`, on the assumption that our own repository path is our own
+content. It is not. GitHub stores every pull request head as `refs/pull/N/head` **in the base
+repository**, so a commit anyone pushes to a fork becomes addressable under our path:
+`github.com/exit-zero-labs/threat-forge/raw/<fork-pr-sha>/evil.dmg` serves that contributor's
+bytes and needs no privilege at all. Measured against a live external-fork pull request —
+`github.com/cli/cli/raw/65fb1e0…/README.md` returns 200 for a commit whose head repository is
+`offbyone/cli`.
+
+So the prefixes are the paths that require write access, and the two fields get different ones:
+
+| Field | Prefix | Why that boundary |
+|-------|--------|-------------------|
+| `browser_download_url` | `/exit-zero-labs/threat-forge/releases/download/` | uploading a release asset needs write access |
+| `html_url` | `/exit-zero-labs/threat-forge/releases/` | only a maintainer can create a release page, and this covers `tag/` without pinning to release-page naming |
+
+The trailing slash is load-bearing on both: without it `/releases/downloadable/…` and
+`/releases-of-someone-else/…` satisfy a prefix check. `url.pathname` is the normalized path, so
+`https://github.com/exit-zero-labs/threat-forge/../x` is normalized to `/x` by `new URL` before
+the check sees it.
+
+The comparison lowercases the pathname. GitHub resolves owner and repository names
+case-insensitively — `https://github.com/Exit-Zero-Labs/Threat-Forge/releases/tag/v0.3.0` returns
+200 directly, measured — so `/Exit-Zero-Labs/Threat-Forge/…` is the same repository and not a
+different one, and the namespace is single, so no attacker can hold the variant. `toLowerCase`
+rather than `toLocaleLowerCase`, which is locale-dependent.
+
+This applies to `html_url` as well as `browser_download_url`. **This is one step past AC3**,
+which names only the asset URL. It is taken deliberately: the shape of the check is the same,
+`html_url` is rendered as a link on the downloads page, and the issue's own argument for filing
+both halves together — "fixing one without the other leaves the interesting half open" — applies
+with equal force inside the schema. Called out here and in the PR rather than slipped in.
+
+## Acceptance criteria mapping
+
+| AC | Where it is met |
+|----|-----------------|
+| 1 | `handleLatestRelease` validates the freshness hit and falls through on failure |
+| 2 | Worker test seeds a poisoned freshness entry and asserts it is not served |
+| 3 | `releaseUrlUnder` path prefixes |
+| 4 | Schema test with `https://github.com/someone-else/anything/releases/download/v1/evil.dmg` |
+| 5 | `FULL_GITHUB_RESPONSE` / `NARROWED_RELEASE` and the frontend fixtures are unchanged |
+
+## Test plan
+
+Every test must fail without its change; each is mutation-proved before it is trusted.
+
+1. **Poisoned freshness entry is not served** — seed `RELEASE_URL` with a schema-invalid body,
+   mock a good upstream, assert the response is the upstream release and not the poison, and
+   that `fetch` was called. Fails today because the poison is returned verbatim.
+2. **A valid freshness entry is still served verbatim without an upstream fetch** — the existing
+   test at `latest-release.test.ts:253`, whose fixture body `{ tag_name: "cached" }` is not a
+   valid release and must become one. Its `X-From-Cache` assertion is kept, which is what proves
+   the stored response is returned rather than a rebuilt one.
+3. **A poisoned freshness hit is logged with its own token** — distinguishes it from
+   `fallback-unreadable` in Workers Logs.
+4. **Wrong-repository asset URL is rejected** — realistic `someone-else/anything` download URL.
+5. **`threat-forge-evil` is rejected** — the repository-name boundary.
+6. **Case variant is accepted** — proves the lowercasing is deliberate and not an accident.
+7. **Credentialed and non-443-port github.com URLs are rejected.**
+8. **Genuine payload round-trips unchanged** — the existing fixtures, untouched.
+9. **A fork pull-request commit path is rejected** — `…/raw/<sha>/evil.dmg`. Fails against the
+   repository-root prefix the first draft used, which is what makes it the regression guard for
+   the security finding.
+10. **A `/blob/<sha>/` path is rejected as `html_url`.**
+11. **A release *page* is rejected as an asset URL** — the two prefixes are genuinely different.
+12. **`/releases/downloadable/…` is rejected** — proves the trailing slash, and fails against a
+    prefix written without one.
+
+## Deliberate residual risk
+
+1. **A poisoned entry that satisfies the schema is still served.** The schema is a shape check,
+   not an authenticity check; an attacker who can write this zone's cache with a well-formed
+   release pointing at our own release assets can make the page advertise a real asset of ours
+   under a wrong version or name. With the corrected prefixes the bytes behind that link are
+   still ours, which is what the first draft wrongly assumed of the repository root. Closing it
+   properly means signing the payload, which is `#49`'s territory and not this route's.
+2. **URLs are pinned to the release path, not to the current tag.** A payload naming
+   `/exit-zero-labs/threat-forge/releases/download/v0.0.1/…` would validate for a current
+   release. Everything under that prefix required write access to put there, so this downgrades
+   to serving an older real binary; pinning to the tag would couple the schema to release naming
+   for no further gain.
+3. **The extra `JSON.parse` runs on the hot path.** Measured against the alternative of not
+   validating; see the cost note above.
+4. **One bad asset invalidates the whole release.** `assets` is a `z.array` of the asset schema,
+   so a single out-of-prefix `browser_download_url` rejects the entire payload and the page
+   degrades to the static GitHub link rather than rendering the remaining assets. That is the
+   right way round: an out-of-prefix asset URL is a strong signal that the payload contract broke
+   or the entry was poisoned, and dropping the bad asset silently would render a partial download
+   grid while hiding the event. The `schema-rejected` runbook entry is what surfaces it.
+5. **`html_url` is pinned to `/releases/` rather than `/releases/tag/`,** which every real value
+   matches. Both review lanes raised the tighter option; it was declined because every subpath
+   under `/releases/` already requires write access to put content there, so the tighter prefix
+   buys no security and would fail the whole lookup closed if GitHub ever changed the
+   release-page shape.
+
+## Change log
+
+### 2026-07-28 — correction from the round-1 security review
+
+The security lane refuted the plan's central assumption. The first draft pinned release URLs to
+`/exit-zero-labs/threat-forge/` and residual risk 1 claimed a poisoned-but-valid payload "can only
+make the page advertise a real asset of ours". Both were wrong: fork pull-request heads live in
+the base repository as `refs/pull/N/head`, so `/raw/<sha>/` and `/blob/<sha>/` under our own path
+serve bytes any outside contributor controls, with no privilege required. Verified independently
+against `cli/cli` PR #13982, whose head repository is `offbyone/cli`: `github.com/cli/cli/raw/
+65fb1e0…/README.md` returns 200.
+
+The prefixes were tightened to the paths that require write access, split per field, and four
+tests were added — the fork-commit rejection being the regression guard. Residual risks 1 and 2
+were rewritten to say what is now true rather than what was assumed.
+
+The same review confirmed, with evidence, that the URL predicate has no accepted-but-wrong-host
+string (homoglyph and IDN inputs serialize to punycode origins and fail; traversal collapses
+inside the prefix and 404s server-side), that returning the cached response unchanged is not a
+leak vector, and that `src/lib/github-releases.ts` does strip unknown keys client-side as the
+plan claimed.
+
+The slop lane found no must-fix. Two `consider`s were applied: the `UnavailableReason` docstring,
+reworded once already, was made accurate for all seven tokens rather than for the new one, and the
+duplicated Cache-API rationale in `storedReleaseIsValid` was replaced with a reference to
+`readLastKnownGood`.
+
+### 2026-07-28 — round-2 lanes
+
+A round-2 security lane and a fresh PR-review lane both returned no must-fix and no should-fix
+against the corrected commit. The security lane measured the new prefixes rather than reasoning
+about them: `release.yml` triggers only on a `v*` tag push, `/releases/latest` excludes drafts,
+`/releases/tag/` resolves only real tags — a fork ref returns 404 — and `expanded_assets` reflects
+names set at upload, so every `/releases/` subpath is write-gated. It re-ran the bypass hunt
+against the split prefixes and found nothing accepted that a browser resolves elsewhere; the one
+near-miss, percent-encoded separators that stay literal through `new URL`, was measured against
+GitHub and returns 404 inside our own path rather than escaping it.
+
+Four `consider`s were applied: the homoglyph sentence was narrower than the truth and was
+reworded, the reason for stopping the page prefix at `/releases/` was recorded in the schema and
+in residual risk 5, the all-or-nothing asset behaviour became residual risk 4, and the credentials
+predicate gained two tests so each of its clauses is independently discriminated — the realistic
+`user:password@` shape is refused by either clause alone, so it proved neither.

--- a/docs/runbooks/deploying-the-website.md
+++ b/docs/runbooks/deploying-the-website.md
@@ -116,20 +116,27 @@ Wrangler serves the production build with the same SPA fallback behavior used at
     `upstream-status`.
   - `invalid-json` — GitHub's body was not JSON.
   - `schema-rejected` — valid JSON that failed `parseGithubRelease`. **Investigate this one.** It
-    means GitHub's payload contract broke, or a release shipped an asset link pointing somewhere
-    other than `github.com`, and the widget is alive only because of a stale copy that expires in
-    24 hours.
+    means GitHub's payload contract broke, or a release shipped a `html_url` or asset link
+    pointing outside this repository's release paths, and the widget is alive only because of a
+    stale copy that expires in 24 hours.
   - `fallback-unreadable` — the stale path ran and this colo's stored copy was itself unusable.
     Always follows one of the five above, and means the visitor got a `502`.
+  - `freshness-unreadable` — this colo's 5-minute copy was there but no longer satisfied the
+    schema, so it was discarded and the request went upstream as if it had missed. This one is
+    not a refusal by GitHub and does not by itself mean the visitor saw anything wrong. It should
+    not happen at all: nothing outside this Worker can write the zone's cache. A steady stream of
+    it means either a deploy tightened the schema while colos still hold entries written under
+    the old one — expected for one freshness window after such a deploy, and self-clearing — or
+    something else is writing this key space, which is worth stopping everything for.
 
-  A logged refusal does **not** by itself tell you what the visitor saw: the first five lines are
-  written identically whether the fallback then carried the page as a `200` or nothing was stored
-  and a `502` went out. `--format pretty` will not disambiguate them — it prints an *outcome*
-  (`Ok`, `Exception Thrown`, …), and a sanitized `502` is a perfectly `Ok` invocation. Use
-  `npx wrangler tail --format json` and read `event.response.status`, or open Workers Logs, which
-  `wrangler.jsonc` already enables with `persist: true`. The fallback entry is not externally
-  addressable — the handler normalizes every request onto the bare path — so logs are the only
-  view of it.
+  A logged refusal does **not** by itself tell you what the visitor saw: the five upstream tokens
+  are written identically whether the fallback then carried the page as a `200` or nothing was
+  stored and a `502` went out. `--format pretty` will not disambiguate them — it prints an
+  *outcome* (`Ok`, `Exception Thrown`, …), and a sanitized `502` is a perfectly `Ok` invocation.
+  Use `npx wrangler tail --format json` and read `event.response.status`, or open Workers Logs,
+  which `wrangler.jsonc` already enables with `persist: true`. The fallback entry is not
+  externally addressable — the handler normalizes every request onto the bare path — so logs are
+  the only view of it.
 - Run these against a real deploy, not a preview. Cloudflare guarantees functional cache
   operations for Workers on custom domains and states that dashboard-editor and Playground
   previews have none, so a local or preview session is not evidence about production.

--- a/src/lib/github-release-schema.test.ts
+++ b/src/lib/github-release-schema.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "vitest";
+import { parseGithubRelease } from "./github-release-schema";
+
+/**
+ * A payload shaped like GitHub's, with the URLs left to each test. Kept minimal
+ * on purpose: what is under test here is the URL contract, and every other field
+ * is exercised end to end by `worker/latest-release.test.ts`.
+ */
+function releaseWith(overrides: {
+	htmlUrl?: string;
+	downloadUrl?: string;
+}): Record<string, unknown> {
+	return {
+		tag_name: "v0.3.0",
+		published_at: "2026-07-01T00:00:00Z",
+		html_url:
+			overrides.htmlUrl ?? "https://github.com/exit-zero-labs/threat-forge/releases/tag/v0.3.0",
+		assets: [
+			{
+				name: "Threat.Forge_0.3.0_aarch64.dmg",
+				browser_download_url:
+					overrides.downloadUrl ??
+					"https://github.com/exit-zero-labs/threat-forge/releases/download/v0.3.0/aarch64.dmg",
+				size: 10_000_000,
+			},
+		],
+	};
+}
+
+describe("parseGithubRelease", () => {
+	it("accepts a genuine release payload", () => {
+		const parsed = parseGithubRelease(releaseWith({}));
+
+		expect(parsed?.tag_name).toBe("v0.3.0");
+		expect(parsed?.assets).toHaveLength(1);
+	});
+
+	describe("release URLs are pinned to this repository", () => {
+		// This value becomes a button a visitor clicks to run a binary. `github.com`
+		// alone does not say whose binary it is.
+		const wrongRepo = "https://github.com/someone-else/anything/releases/download/v1/evil.dmg";
+
+		it("rejects an asset URL hosted on github.com but owned by someone else", () => {
+			expect(parseGithubRelease(releaseWith({ downloadUrl: wrongRepo }))).toBeNull();
+		});
+
+		it("rejects a release page URL owned by someone else", () => {
+			expect(parseGithubRelease(releaseWith({ htmlUrl: wrongRepo }))).toBeNull();
+		});
+
+		it("rejects a repository whose name merely starts with ours", () => {
+			expect(
+				parseGithubRelease(
+					releaseWith({
+						downloadUrl:
+							"https://github.com/exit-zero-labs/threat-forge-evil/releases/download/v1/evil.dmg",
+					}),
+				),
+			).toBeNull();
+		});
+
+		it("rejects a path that only reaches ours before normalization", () => {
+			expect(
+				parseGithubRelease(
+					releaseWith({
+						downloadUrl: "https://github.com/exit-zero-labs/threat-forge/../evil/x.dmg",
+					}),
+				),
+			).toBeNull();
+		});
+
+		it("accepts a case variant, which GitHub resolves to the same repository", () => {
+			expect(
+				parseGithubRelease(
+					releaseWith({
+						downloadUrl:
+							"https://github.com/Exit-Zero-Labs/Threat-Forge/releases/download/v1/x.dmg",
+					}),
+				),
+			).not.toBeNull();
+		});
+	});
+
+	describe("our own repository path is not the trust boundary", () => {
+		/**
+		 * GitHub stores every pull request head as `refs/pull/N/head` in the base
+		 * repository, so a commit anyone pushes to a fork becomes addressable under our
+		 * own path. `/raw/<sha>/…` then serves that contributor's bytes. Pinning to the
+		 * repository alone would have accepted these; pinning to the paths that need
+		 * write access does not.
+		 */
+		it("rejects an asset URL served from a fork pull-request commit", () => {
+			expect(
+				parseGithubRelease(
+					releaseWith({
+						downloadUrl:
+							"https://github.com/exit-zero-labs/threat-forge/raw/65fb1e0aa1c3f1e6d1a4c5b2e9f0d7a8b3c4d5e6/evil.dmg",
+					}),
+				),
+			).toBeNull();
+		});
+
+		it("rejects a release page URL pointing at repository content", () => {
+			expect(
+				parseGithubRelease(
+					releaseWith({
+						htmlUrl:
+							"https://github.com/exit-zero-labs/threat-forge/blob/65fb1e0aa1c3f1e6d1a4c5b2e9f0d7a8b3c4d5e6/README.md",
+					}),
+				),
+			).toBeNull();
+		});
+
+		it("rejects an asset URL that is a release page rather than an upload", () => {
+			expect(
+				parseGithubRelease(
+					releaseWith({
+						downloadUrl: "https://github.com/exit-zero-labs/threat-forge/releases/tag/v0.3.0",
+					}),
+				),
+			).toBeNull();
+		});
+
+		it("rejects a sibling path that merely starts with the download prefix", () => {
+			// Without the trailing slash on the prefix this passes.
+			expect(
+				parseGithubRelease(
+					releaseWith({
+						downloadUrl:
+							"https://github.com/exit-zero-labs/threat-forge/releases/downloadable/v1/x.dmg",
+					}),
+				),
+			).toBeNull();
+		});
+	});
+
+	describe("origin", () => {
+		it("rejects a non-443 port, which a hostname check would have allowed", () => {
+			expect(
+				parseGithubRelease(
+					releaseWith({
+						downloadUrl:
+							"https://github.com:8443/exit-zero-labs/threat-forge/releases/download/v1/x.dmg",
+					}),
+				),
+			).toBeNull();
+		});
+
+		it("rejects embedded credentials", () => {
+			expect(
+				parseGithubRelease(
+					releaseWith({
+						downloadUrl:
+							"https://user:password@github.com/exit-zero-labs/threat-forge/releases/download/v1/x.dmg",
+					}),
+				),
+			).toBeNull();
+		});
+
+		it("rejects a password with no username, which only the second clause catches", () => {
+			// The realistic phishing shape above carries both, so removing either clause
+			// alone still rejects it. Each half needs a URL only it can refuse.
+			expect(
+				parseGithubRelease(
+					releaseWith({
+						downloadUrl:
+							"https://:password@github.com/exit-zero-labs/threat-forge/releases/download/v1/x.dmg",
+					}),
+				),
+			).toBeNull();
+		});
+
+		it("rejects a username with no password, which only the first clause catches", () => {
+			expect(
+				parseGithubRelease(
+					releaseWith({
+						downloadUrl:
+							"https://user@github.com/exit-zero-labs/threat-forge/releases/download/v1/x.dmg",
+					}),
+				),
+			).toBeNull();
+		});
+
+		it("rejects a lookalike host", () => {
+			expect(
+				parseGithubRelease(
+					releaseWith({
+						downloadUrl:
+							"https://github.com.evil.test/exit-zero-labs/threat-forge/releases/download/v1/x.dmg",
+					}),
+				),
+			).toBeNull();
+		});
+
+		it("rejects a non-HTTPS scheme", () => {
+			expect(
+				parseGithubRelease(
+					releaseWith({
+						downloadUrl: "http://github.com/exit-zero-labs/threat-forge/releases/download/v1/x.dmg",
+					}),
+				),
+			).toBeNull();
+		});
+
+		it("rejects a value that is not a URL at all", () => {
+			expect(
+				parseGithubRelease(releaseWith({ downloadUrl: "javascript:alert(document.domain)" })),
+			).toBeNull();
+		});
+	});
+});

--- a/src/lib/github-release-schema.ts
+++ b/src/lib/github-release-schema.ts
@@ -1,13 +1,65 @@
 import { z } from "zod";
 
-const githubHttpsUrlSchema = z.string().refine((value) => {
-	try {
-		const url = new URL(value);
-		return url.protocol === "https:" && url.hostname === "github.com";
-	} catch {
-		return false;
-	}
-}, "Expected an HTTPS github.com URL");
+/**
+ * Release paths whose contents only someone with write access can put there.
+ *
+ * `/exit-zero-labs/threat-forge/` is not that boundary, which is the non-obvious part.
+ * GitHub stores every pull request head as `refs/pull/N/head` **in the base repository**,
+ * so a commit pushed to a fork by anyone at all becomes addressable under our own path —
+ * `github.com/exit-zero-labs/threat-forge/raw/<fork-pr-sha>/anything` serves bytes that
+ * contributor controls, and `/blob/` renders them. Measured against a live external-fork
+ * pull request on another repository during the #286 security review. Uploading a release
+ * asset, by contrast, requires write access, and nothing outside this repository's
+ * maintainers can create a release page.
+ *
+ * The trailing slash is load-bearing on both: without it `/releases/downloadable/…` and
+ * `/releases-of-someone-else/…` satisfy a prefix check.
+ *
+ * The page prefix stops at `/releases/` rather than `/releases/tag/`, which every real
+ * `html_url` matches. Every subpath under `/releases/` needs write access to put content
+ * there — `tag/` resolves only real tags, `download/` and `expanded_assets/` come from
+ * asset upload — so `/releases/tag/` would buy no security and would fail the whole
+ * lookup closed if GitHub ever changed the release-page shape.
+ */
+const ASSET_PATH_PREFIX = "/exit-zero-labs/threat-forge/releases/download/";
+const RELEASE_PAGE_PATH_PREFIX = "/exit-zero-labs/threat-forge/releases/";
+
+/**
+ * Accept only URLs under one of this repository's maintainer-controlled release paths.
+ *
+ * The host alone is not enough. These values become links a visitor clicks — one of them
+ * to run a binary — and `https://github.com/someone-else/anything/releases/download/v1/evil.dmg`
+ * is on `github.com`.
+ *
+ * `origin` rather than `hostname` because it carries the scheme and the port together;
+ * a `hostname` check accepts `https://github.com:8443/…`, which is not this origin, and
+ * `origin` is an ASCII serialization, so a look-alike host either becomes its punycode
+ * form — a different origin, rejected — or maps to `github.com` itself, which is not a
+ * look-alike at all. Credentials are refused because a genuine API payload never
+ * carries them and a URL that does is a phishing shape. `pathname` is the normalized
+ * path, so `new URL` has already collapsed any `../` before the prefix is compared.
+ *
+ * The comparison is case-insensitive: GitHub resolves owner and repository names without
+ * regard to case — `https://github.com/Exit-Zero-Labs/Threat-Forge/releases/tag/v0.3.0`
+ * returns 200 directly — so a case variant is this repository rather than a different
+ * one, and the namespace is single and case-insensitive, so no attacker can hold the
+ * variant. `toLowerCase` rather than `toLocaleLowerCase`, which is locale-dependent.
+ */
+function releaseUrlUnder(prefix: string) {
+	return z.string().refine((value) => {
+		try {
+			const url = new URL(value);
+			return (
+				url.origin === "https://github.com" &&
+				url.username === "" &&
+				url.password === "" &&
+				url.pathname.toLowerCase().startsWith(prefix)
+			);
+		} catch {
+			return false;
+		}
+	}, `Expected an HTTPS URL under github.com${prefix}`);
+}
 
 /**
  * Shared contract for the GitHub "latest release" JSON, reduced to the fields the
@@ -24,14 +76,14 @@ const githubHttpsUrlSchema = z.string().refine((value) => {
  */
 export const githubReleaseAssetSchema = z.object({
 	name: z.string(),
-	browser_download_url: githubHttpsUrlSchema,
+	browser_download_url: releaseUrlUnder(ASSET_PATH_PREFIX),
 	size: z.number().int().nonnegative(),
 });
 
 export const githubReleaseSchema = z.object({
 	tag_name: z.string().min(1),
 	published_at: z.string().nullable(),
-	html_url: githubHttpsUrlSchema,
+	html_url: releaseUrlUnder(RELEASE_PAGE_PATH_PREFIX),
 	assets: z.array(githubReleaseAssetSchema),
 });
 

--- a/worker/latest-release.test.ts
+++ b/worker/latest-release.test.ts
@@ -41,8 +41,8 @@ function storedMaxAgeSeconds(response: Response): number | null {
  *
  * One deliberate divergence: an entry stored without `Cache-Control` never
  * expires here, where Cloudflare would apply its 120-minute default Edge TTL for
- * a 200. No production path stores one — only the hand-seeded cache-hit fixture
- * below does — so the divergence is unreachable from the code under test.
+ * a 200. No production path stores one — only the hand-seeded cache-hit fixtures
+ * below do — so the divergence is unreachable from the code under test.
  */
 function createCache() {
 	const store = new Map<string, Response>();
@@ -253,7 +253,7 @@ describe("handleLatestRelease", () => {
 	it("serves the cached response without a second upstream fetch on a cache hit", async () => {
 		cache.store.set(
 			RELEASE_URL,
-			new Response(JSON.stringify({ tag_name: "cached" }), {
+			new Response(JSON.stringify(NARROWED_RELEASE), {
 				status: 200,
 				headers: { "X-From-Cache": "yes" },
 			}),
@@ -264,7 +264,59 @@ describe("handleLatestRelease", () => {
 		const response = await handleLatestRelease(new Request(RELEASE_URL), ctx);
 
 		expect(fetchSpy).not.toHaveBeenCalled();
+		// The stored response itself, not one rebuilt from the parsed body — which is
+		// what keeps the entry's own freshness headers intact.
 		expect(response.headers.get("X-From-Cache")).toBe("yes");
+		expect(await response.json()).toEqual(NARROWED_RELEASE);
+	});
+
+	it("goes upstream instead of serving a freshness entry that no longer validates", async () => {
+		// `caches.default` is shared, zone-scoped, evictable storage addressed by URL.
+		// The fallback path has always re-parsed what it reads; this is the path almost
+		// every request takes, and it used to hand the stored bytes straight out.
+		cache.store.set(
+			RELEASE_URL,
+			new Response(
+				JSON.stringify({
+					...NARROWED_RELEASE,
+					assets: [
+						{
+							name: "Threat.Forge_0.2.0_aarch64.dmg",
+							browser_download_url:
+								"https://github.com/someone-else/anything/releases/download/v1/evil.dmg",
+							size: 10_000_000,
+						},
+					],
+				}),
+				{ status: 200, headers: { "Cache-Control": `public, max-age=${FRESHNESS_TTL_SECONDS}` } },
+			),
+		);
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValueOnce(new Response(JSON.stringify(FULL_GITHUB_RESPONSE), { status: 200 }));
+		const ctx = createCtx();
+
+		const response = await handleLatestRelease(new Request(RELEASE_URL), ctx);
+		await ctx.settle();
+
+		expect(fetchSpy).toHaveBeenCalledOnce();
+		expect(await response.json()).toEqual(NARROWED_RELEASE);
+	});
+
+	it("names a rejected freshness entry apart from a rejected fallback", async () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		cache.store.set(RELEASE_URL, new Response("not json at all", { status: 200 }));
+		vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+			new Response(JSON.stringify(FULL_GITHUB_RESPONSE), { status: 200 }),
+		);
+		const ctx = createCtx();
+
+		await handleLatestRelease(new Request(RELEASE_URL), ctx);
+		await ctx.settle();
+
+		// `fallback-unreadable` here would tell an operator the 24-hour copy broke while
+		// the request was in fact served normally from upstream.
+		expect(warnSpy).toHaveBeenCalledWith(expect.any(String), { reason: "freshness-unreadable" });
 	});
 
 	it("normalizes query strings to one cache key", async () => {

--- a/worker/latest-release.ts
+++ b/worker/latest-release.ts
@@ -94,13 +94,14 @@ function errorResponse(status: number): Response {
 	);
 }
 
-/** Why a lookup could not produce a validated release. Fixed tokens, never free text. */
+/** Why a candidate source could not produce a validated release. Fixed tokens, never free text. */
 type UnavailableReason =
 	| "fetch-failed"
 	| "upstream-timeout"
 	| "upstream-status"
 	| "invalid-json"
 	| "schema-rejected"
+	| "freshness-unreadable"
 	| "fallback-unreadable";
 
 /**
@@ -213,6 +214,24 @@ async function fetchUpstreamRelease(): Promise<GithubRelease | null> {
 }
 
 /**
+ * Does a stored response still hold something this contract accepts?
+ *
+ * Re-parsed for the same reason `readLastKnownGood` re-parses what it reads, and with
+ * more force: this is the path nearly every request takes. Validating only the rare path
+ * left the schema running where the traffic is not.
+ *
+ * The body is read from a clone so the original stays unconsumed and the caller can
+ * return it intact.
+ */
+async function storedReleaseIsValid(stored: Response): Promise<boolean> {
+	try {
+		return parseGithubRelease(await stored.clone().json()) !== null;
+	} catch {
+		return false;
+	}
+}
+
+/**
  * Read back the last known good release, or `null` if this colo has none it can
  * still use.
  *
@@ -272,6 +291,9 @@ function releaseCacheKey(query?: string): Request {
  * entry as a miss, so a fallback stored with the freshness copy's own
  * `Cache-Control` would expire at the same instant and could never once be read.
  *
+ * Both stored copies are re-validated when they are read. A hit that no longer
+ * satisfies the contract is treated as a miss and the request goes upstream.
+ *
  * When GitHub will not answer, the fallback copy is served as a 200 marked
  * `no-store` and is never written back, so recovery is immediate. A 502 means this
  * colo has never stored a good answer, or the one it had has aged out.
@@ -289,7 +311,16 @@ export async function handleLatestRelease(
 	const fallbackKey = releaseCacheKey(FALLBACK_CACHE_QUERY);
 	const cached = await cache.match(cacheKey);
 	if (cached) {
-		return cached;
+		if (await storedReleaseIsValid(cached)) {
+			// Returned unchanged rather than re-serialized. The entry carries the
+			// `max-age` it was stored with and whatever `Age` the runtime attached, and
+			// those together are what tell the browser how much of the 300 seconds is
+			// left; rebuilding the response would emit a fresh `max-age` measured from
+			// this hit and quietly extend client-side freshness. The validated bytes and
+			// the returned bytes are the same — the check reads a clone.
+			return cached;
+		}
+		logUnavailable("freshness-unreadable");
 	}
 
 	const release = await fetchUpstreamRelease();


### PR DESCRIPTION
Closes #286.

Two halves of one trust question on the route that hands a visitor an executable.

## Half one — the schema ran where the traffic isn't

`readLastKnownGood` re-parses the stored fallback and refuses it if it fails, with a comment explaining that the Cache API is shared, zone-scoped, evictable storage rather than this module's private memory. The freshness hit a few lines earlier returned `cache.match`'s response straight to the client with no schema run at all. The file's own reasoning was not applied where the traffic is.

A freshness hit is now re-validated. A failure logs `freshness-unreadable` and is treated as a miss, so the request goes upstream exactly as it would have.

A valid hit is returned **unchanged** rather than re-serialized. The stored entry carries the `max-age` it was written with and whatever `Age` the runtime attached, and those are what tell the browser how much of the 300 seconds is left; rebuilding the response would emit a fresh `max-age` measured from the hit and quietly extend client-side freshness — a regression introduced by a hardening change. The one thing re-serializing would add is stripping unknown keys, and `src/lib/github-releases.ts` already re-validates this Worker's response with the same schema, so nothing extra reaches the page. Both review lanes verified that downstream claim against the file.

## Half two — "our repository" is not the trust boundary

The schema pinned release URLs to the `github.com` host, so `https://github.com/someone-else/anything/releases/download/v1/evil.dmg` validated and would have rendered as a download button.

The obvious fix — pin to `/exit-zero-labs/threat-forge/` — is wrong, and that is the part worth reading twice. **GitHub stores every pull request head as `refs/pull/N/head` in the base repository**, so a commit anyone pushes to a fork becomes addressable under our own path. Measured on a live external-fork PR:

```
$ curl -sSL -o /dev/null -w '%{http_code} %{url_effective}\n' \
    https://github.com/cli/cli/raw/65fb1e00b872328d96f97591bf4ddb36b2603489/README.md
200 https://raw.githubusercontent.com/cli/cli/65fb1e00.../README.md
```

That SHA's head repository is `offbyone/cli`. `/raw/<sha>/evil.dmg` under our path is bytes an unprivileged outside contributor controls.

So the prefixes are the paths that require write access, one per field:

| Field | Prefix | Why |
|---|---|---|
| `browser_download_url` | `/exit-zero-labs/threat-forge/releases/download/` | uploading a release asset needs write |
| `html_url` | `/exit-zero-labs/threat-forge/releases/` | only a maintainer can create a release |

Plus `origin` rather than `hostname` — it carries the scheme and the port, where a `hostname` check accepted `https://github.com:8443/…` — and no embedded credentials. The trailing slash is load-bearing on both prefixes and a test proves it. `pathname` is normalized, so `new URL` collapses `../` before the comparison. The comparison lowercases, because `https://github.com/Exit-Zero-Labs/Threat-Forge/releases/tag/v0.3.0` returns 200 directly and the namespace is single, so no attacker can hold the variant.

Applying the pin to `html_url` too is one step past the issue's AC3, taken deliberately and disclosed here and in the plan: leaving it on a host check would be the incoherent half of the same fix.

## Verification

- `npm run ci:local` green.
- **Eleven mutations, each killing exactly the intended test** — worker validation removed; asset prefix widened to the repo root; page prefix widened to the repo root; trailing slash dropped; `origin`→`hostname`; username clause removed; password clause removed; lowercasing removed; path check removed entirely.
- The live v0.3.0 payload was fetched and parsed against the final schema: all nine assets and the release page URL validate unchanged.
- The fork-PR mechanism was reproduced independently before acting on it.

## Review lanes

Three independent read-only lanes across two rounds, each against a frozen clean tree.

- **Round 1** — the security lane falsified the plan's central assumption and its residual risk 1 ("can only make the page advertise a real asset of ours"). That is the `/raw/` finding above; the prefixes were tightened, four tests added, and residual risks 1 and 2 rewritten to say what is now true. The slop lane returned `minor`, both `consider`s applied.
- **Round 2** — a fresh security lane and a fresh PR reviewer both returned **no must-fix and no should-fix**. The security lane measured rather than reasoned: `release.yml` triggers only on a `v*` tag push, `/releases/latest` excludes drafts, `/releases/tag/<fork-ref>` returns 404, and no workflow grants `contents: write` from a fork. Its bypass hunt across percent-encoding, IDN homoglyphs, credentials, ports, backslash and tab injection found nothing accepted that a browser resolves elsewhere — the one near-miss, encoded separators surviving `new URL`, was measured against GitHub and 404s inside our own path.
- Four round-2 `consider`s applied: the homoglyph sentence was narrower than the truth and was reworded; the reason for stopping the page prefix at `/releases/` is now recorded; the all-or-nothing asset behaviour became a documented residual risk; and the credentials predicate gained two tests, because the realistic `user:password@` shape is refused by either clause alone and therefore proved neither.

`docs/plans/286-release-schema-trust.md` carries both rounds as dated change-log entries rather than a rewritten history.

Neither half was a live hole — nothing untrusted can write this zone's cache and GitHub populates the payload. Both are defence in depth on the one route that hands a user a binary.