### PR TITLE
docs(runbook): stop the release-lookup check reading a 405 as a stale hit

### DIFF
--- a/docs/runbooks/deploying-the-website.md
+++ b/docs/runbooks/deploying-the-website.md
@@ -76,24 +76,34 @@ Wrangler serves the production build with the same SPA fallback behavior used at
   and `curl -sI https://threatforge.dev | grep -i set-cookie`. Both must return no match.
 - Load the site in a real browser and confirm the console is clean. A CSP violation here means
   the edge is injecting a script the policy blocks — safe, but visible to every visitor.
-- Check the release lookup, which serves the downloads widget:
-  `curl -sS -D- -o /dev/null https://threatforge.dev/api/latest-release`.
-  - `200` with `cache-control: public, max-age=300` — a fresh answer the Worker just built.
+- Check the release lookup, which serves the downloads widget. Keep the status line in the
+  output — every reading below is a status **and** a header, and on this route the header alone
+  will mislead you:
+  `curl -sS -D- -o /dev/null https://threatforge.dev/api/latest-release | grep -iE '^HTTP|cache-control|cf-cache-status|^age'`.
+  - `200` with `cache-control: public, max-age=300` — a fresh answer the Worker just built, and
+    one the zone rewrite below did not touch on the way out.
   - `200` with `cache-control: no-store` — GitHub is refusing us and this colo is serving its
     last known good copy. The page is intact; the version may be up to a day behind.
   - `502` — this colo has never stored a good answer, or its copy aged out. This is the only
     case the downloads page's "Could not load releases" copy should still be reachable through.
+  - `405` with `cache-control: no-store` — **you sent `HEAD`, not `GET`, and measured nothing.**
+    `curl -I` and `curl -X HEAD` both land here, because the handler rejects every method but
+    `GET` (`#263`). Note what it returns: the same `no-store` the stale-fallback `200` above
+    carries. Drop the status line and this reads as a healthy-but-stale route, so the reflex
+    command for reading headers hands back a documented, plausible, wrong answer. It cost a
+    `wrangler tail` session during the `#286` deploy check. Re-run with `-D- -o /dev/null`.
   - `200` with `cf-cache-status: HIT`, a non-zero `age`, and `cache-control: public,
     max-age=14400` — `Cache-Control` has been rewritten to the 4-hour Browser Cache TTL.
-    **This is the normal steady state**, measured on 2026-07-27, not a fault. The `HIT` is the
-    Worker's own `caches.default`, not a cache in front of it: ten requests with ten distinct
-    query strings all returned `HIT`, and `wrangler tail` showed the Worker running for nine of
-    them (the tenth was still in flight). So every request does reach the handler. The `max-age`
-    a client sees is still set by zone configuration rather than by the Worker, so **do not read
-    a stale-vs-fresh conclusion out of the `max-age` number** — that is `#285`.
-    `no-store` is passed through unrewritten — observed on a live `502`, and inferred for the
-    stale `200` on the documented rule that the override is a numeric comparison `no-store` does
-    not participate in.
+    **This is the normal steady state**, measured on 2026-07-27 and again on 2026-07-28 against
+    Worker version `c057de1d`, not a fault. The `HIT` is the Worker's own `caches.default`, not
+    a cache in front of it: ten requests with ten distinct query strings all returned `HIT`, and
+    `wrangler tail` showed the Worker running for nine of them (the tenth was still in flight).
+    So every request does reach the handler. The `max-age` a client sees is still set by zone
+    configuration rather than by the Worker, so **do not read a stale-vs-fresh conclusion out of
+    the `max-age` number** — that is `#285`.
+    `no-store` is passed through unrewritten — observed on a live `502` and on a live `405`, and
+    inferred for the stale `200` on the documented rule that the override is a numeric
+    comparison `no-store` does not participate in.
   - Because the zone rewrites `Cache-Control` on cached hits, `curl` **cannot** detect the one
     failure this route's two-entry cache design is exposed to: a zone cache key that strips the
     query string would collapse the 5-minute freshness entry and the 24-hour fallback entry onto


### PR DESCRIPTION
Closes #304.

## What was wrong

`docs/runbooks/deploying-the-website.md` teaches operators to read the health of
`/api/latest-release` out of its `Cache-Control`. The reflex command for reading headers,
`curl -I`, sends `HEAD` — and this route answers `HEAD` with `405` (#263). That `405` carries
`cache-control: no-store`, which is byte-identical to the header the runbook documents as
*"GitHub is refusing us and this colo is serving its last known good copy."*

So the operator does not get an obvious error. They get a documented, plausible, wrong reading
of the route that serves every download on the site. It cost a full misdiagnosis during the #286
deploy check — a `wrangler tail` session, five timed probes, and a read of `_headers` and
`wrangler.jsonc` chasing a stale-fallback state that did not exist.

## What changed

Documentation only. No Worker code, no application code, no behavior.

- The documented command now keeps the status line: the `grep` includes `^HTTP`.
- A `405` row is added that names the trap explicitly, says which commands land on it, points
  at #263 as the underlying defect, and says what to re-run.
- The stale-`200` `no-store` row is now distinguishable from the `405` by the row that follows it.
- The `max-age=300` row says why that value reaches you at all.

Two existing claims are strengthened rather than replaced, which is the part worth reviewing:

- The `max-age=14400` steady-state note is re-confirmed against today's live output on Worker
  version `c057de1d`, alongside its original 2026-07-27 measurement.
- *"`no-store` is passed through unrewritten"* was `observed on a live 502, and inferred for the
  stale 200`. The `405` is a second live observation, so the sentence now cites two.

Nothing was removed: the `HIT`-is-`caches.default` reasoning, the "do not read stale-vs-fresh out
of `max-age`" warning, the collapsed-cache-key caveat, and the reason-token enumeration are all
intact.

## Verification

Every command in the changed step, run verbatim against production on 2026-07-28. Real output:

```console
$ curl -sS -D- -o /dev/null https://threatforge.dev/api/latest-release | grep -iE '^HTTP|cache-control|cf-cache-status|^age'
HTTP/2 200
cf-cache-status: HIT
age: 109
cache-control: public, max-age=14400

$ curl -sSI https://threatforge.dev/api/latest-release | grep -iE '^HTTP|cache-control'
HTTP/2 405
cache-control: no-store

$ curl -sS --max-time 10 -X HEAD -D- -o /dev/null https://threatforge.dev/api/latest-release | grep -iE '^HTTP|cache-control'
HTTP/2 405
cache-control: no-store
```

Both documented forms of the trap (`-I` and `-X HEAD`) reach the `405`, as the new row claims.

The `max-age=300` case was also observed live earlier in the same session, on a request the zone
rewrite did not touch:

```console
HTTP/2 200
cache-control: public, max-age=300
```

`wrangler tail` on the same route showed `outcome: ok`, `logs: []`, ~22 ms wall on requests with
distinct query strings — the handler is healthy and the refusal path is not being taken, which is
what made the `curl -I` reading wrong rather than merely alarming.

`npx biome check docs/runbooks/deploying-the-website.md` reports the path is ignored by
configuration; Biome does not process markdown under `docs/`. There is no docs-specific check in
`scripts/ci-local.sh` or in any workflow, so CI's normal gate is the whole of it here.

## Review notes

Preflight lanes were not dispatched. This is `Effort: Low`, documentation-only, with no
executable surface — the anti-slop self-review was run against the diff and produced two fixes,
both applied before commit:

- *"which means this request missed the zone cache"* overclaimed a mechanism. No
  `cf-cache-status` was present on that response, so `MISS` was an inference, not an
  observation. Replaced with what was actually seen: the zone rewrite did not touch it.
- A novelistic trailing clause (*"before anyone noticed the 405"*) was cut.

## Follow-up for the owner

#263 is the real repair — `HEAD` should return the `GET`'s headers, and then this trap stops
existing. It sits in `M3 • Release 1` and agents may not pull scope forward, so it needs an owner
call. Evidence and a promotion recommendation are recorded on that issue. This runbook change is
worth keeping either way: the durable advice is *never read a route's health out of one header
without the status line*, which outlives the bug.